### PR TITLE
feat: add Composite provider

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "libs/hooks/open-telemetry": "2.0.0",
   "libs/providers/go-feature-flag": "0.2.0",
-  "libs/providers/flagd": "0.4.0"
+  "libs/providers/flagd": "0.4.0",
+  "libs/providers/federated": "0.1.0"
 }

--- a/libs/providers/federated/.babelrc
+++ b/libs/providers/federated/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    [
+      "@nrwl/web/babel",
+      {
+        "useBuiltIns": "usage"
+      }
+    ]
+  ]
+}

--- a/libs/providers/federated/.eslintrc.json
+++ b/libs/providers/federated/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/providers/federated/README.md
+++ b/libs/providers/federated/README.md
@@ -1,0 +1,17 @@
+# NodeJS Federated Provider for OpenFeature
+
+![Experimental](https://img.shields.io/badge/experimental-breaking%20changes%20allowed-yellow)
+
+## Installation
+
+```
+$ npm install @openfeature/federated-provider
+```
+
+## Building
+
+Run `nx package providers-federated` to build the library.
+
+## Running unit tests
+
+Run `nx test providers-federated` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/providers/federated/babel.config.json
+++ b/libs/providers/federated/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": ["minify"]
+}

--- a/libs/providers/federated/jest.config.ts
+++ b/libs/providers/federated/jest.config.ts
@@ -1,0 +1,15 @@
+/* eslint-disable */
+export default {
+  displayName: 'providers-federated',
+  preset: '../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  transform: {
+    '^.+\\.[tj]s$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/providers/federated',
+};

--- a/libs/providers/federated/package.json
+++ b/libs/providers/federated/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@openfeature/federated-provider",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "scripts": {
+    "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi",
+    "current-version": "echo $npm_package_version"
+  }
+}

--- a/libs/providers/federated/project.json
+++ b/libs/providers/federated/project.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/providers/federated/src",
+  "projectType": "library",
+  "targets": {
+    "publish": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "npm run publish-if-not-exists",
+        "cwd": "dist/libs/providers/federated"
+      },
+      "dependsOn": [
+        {
+          "projects": "self",
+          "target": "package"
+        }
+      ]
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/providers/federated/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/providers/federated"],
+      "options": {
+        "jestConfig": "libs/providers/federated/jest.config.ts",
+        "passWithNoTests": true
+      }
+    },
+    "package": {
+      "executor": "@nrwl/web:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "project": "libs/providers/federated/package.json",
+        "outputPath": "dist/libs/providers/federated",
+        "entryFile": "libs/providers/federated/src/index.ts",
+        "tsConfig": "libs/providers/federated/tsconfig.lib.json",
+        "compiler": "babel",
+        "umdName": "Federated",
+        "external": ["typescript"],
+        "format": ["cjs", "esm"],
+        "assets": [
+          {
+            "glob": "LICENSE",
+            "input": "./",
+            "output": "./"
+          },
+          {
+            "glob": "README.md",
+            "input": "./libs/providers/federated",
+            "output": "./"
+          }
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/providers/federated/src/index.ts
+++ b/libs/providers/federated/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/federated-provider';

--- a/libs/providers/federated/src/lib/federated-provider.spec.ts
+++ b/libs/providers/federated/src/lib/federated-provider.spec.ts
@@ -1,0 +1,292 @@
+import {
+  Provider,
+  ResolutionDetails,
+  ErrorCode,
+  OpenFeature,
+} from '@openfeature/nodejs-sdk';
+import { FederatedProvider } from './federated-provider';
+
+describe('FederatedProvider', () => {
+  describe('All Providers Error', () => {
+    const provider = new FederatedProvider([
+      {
+        resolveBooleanEvaluation: () => {
+          return {
+            errorCode: ErrorCode.FLAG_NOT_FOUND,
+          };
+        },
+        resolveStringEvaluation: () => {
+          return {
+            errorCode: ErrorCode.FLAG_NOT_FOUND,
+          };
+        },
+        resolveNumberEvaluation: () => {
+          return {
+            errorCode: ErrorCode.FLAG_NOT_FOUND,
+          };
+        },
+        resolveObjectEvaluation: () => {
+          return {
+            errorCode: ErrorCode.FLAG_NOT_FOUND,
+          };
+        },
+      } as unknown as Provider,
+    ]);
+
+    it('should throw because the flag can not be found during boolean evaluation', async () => {
+      await expect(
+        provider.resolveBooleanEvaluation('test', false, {})
+      ).rejects.toThrowError();
+    });
+
+    it('should throw because the flag can not be found during string evaluation', async () => {
+      await expect(
+        provider.resolveStringEvaluation('test', 'test', {})
+      ).rejects.toThrowError();
+    });
+
+    it('should throw because the flag can not be found during number evaluation', async () => {
+      await expect(
+        provider.resolveNumberEvaluation('test', 1, {})
+      ).rejects.toThrowError();
+    });
+
+    it('should throw because the flag can not be found during object evaluation', async () => {
+      await expect(
+        provider.resolveObjectEvaluation('test', { name: 'test' }, {})
+      ).rejects.toThrowError();
+    });
+  });
+
+  describe('Use value from first successful provider', () => {
+    const mockProvider1Boolean = jest.fn(
+      (): Promise<ResolutionDetails<boolean>> => {
+        return Promise.resolve({
+          value: false,
+          errorCode: ErrorCode.FLAG_NOT_FOUND,
+        });
+      }
+    );
+    const mockProvider1String = jest.fn(
+      (): Promise<ResolutionDetails<string>> => {
+        return Promise.resolve({
+          value: 'error',
+          errorCode: ErrorCode.FLAG_NOT_FOUND,
+        });
+      }
+    );
+    const mockProvider1Number = jest.fn(
+      (): Promise<ResolutionDetails<number>> => {
+        return Promise.resolve({
+          value: 0,
+          errorCode: ErrorCode.FLAG_NOT_FOUND,
+        });
+      }
+    );
+    const mockProvider1Object = jest.fn(
+      (): Promise<ResolutionDetails<object>> => {
+        return Promise.resolve({
+          value: { name: 'error' },
+          errorCode: ErrorCode.FLAG_NOT_FOUND,
+        });
+      }
+    );
+
+    const provider1 = {
+      resolveBooleanEvaluation: mockProvider1Boolean,
+      resolveStringEvaluation: mockProvider1String,
+      resolveNumberEvaluation: mockProvider1Number,
+      resolveObjectEvaluation: mockProvider1Object,
+    } as unknown as Provider;
+
+    const mockProvider2Boolean = jest.fn(
+      (): Promise<ResolutionDetails<boolean>> => {
+        return Promise.resolve({
+          value: true,
+        });
+      }
+    );
+    const mockProvider2String = jest.fn(
+      (): Promise<ResolutionDetails<string>> => {
+        return Promise.resolve({
+          value: 'openfeature',
+        });
+      }
+    );
+    const mockProvider2Number = jest.fn(
+      (): Promise<ResolutionDetails<number>> => {
+        return Promise.resolve({
+          value: 10,
+        });
+      }
+    );
+    const mockProvider2Object = jest.fn(
+      (): Promise<ResolutionDetails<object>> => {
+        return Promise.resolve({
+          value: { name: 'openfeature' },
+        });
+      }
+    );
+    const provider2 = {
+      resolveBooleanEvaluation: mockProvider2Boolean,
+      resolveStringEvaluation: mockProvider2String,
+      resolveNumberEvaluation: mockProvider2Number,
+      resolveObjectEvaluation: mockProvider2Object,
+    } as unknown as Provider;
+
+    const mockProvider3Boolean = jest.fn(
+      (): Promise<ResolutionDetails<boolean>> => {
+        return Promise.resolve({
+          value: true,
+        });
+      }
+    );
+    const mockProvider3String = jest.fn(
+      (): Promise<ResolutionDetails<string>> => {
+        return Promise.resolve({
+          value: 'openfeature',
+        });
+      }
+    );
+    const mockProvider3Number = jest.fn(
+      (): Promise<ResolutionDetails<number>> => {
+        return Promise.resolve({
+          value: 11,
+        });
+      }
+    );
+    const mockProvider3Object = jest.fn(
+      (): Promise<ResolutionDetails<object>> => {
+        return Promise.resolve({
+          value: { name: 'openfeature' },
+        });
+      }
+    );
+    const provider3 = {
+      resolveBooleanEvaluation: mockProvider3Boolean,
+      resolveStringEvaluation: mockProvider3String,
+      resolveNumberEvaluation: mockProvider3Number,
+      resolveObjectEvaluation: mockProvider3Object,
+    } as unknown as Provider;
+
+    const federatedProvider = new FederatedProvider([
+      provider1,
+      provider2,
+      provider3,
+    ]);
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should resolve a boolean value from the second provider', async () => {
+      await expect(
+        federatedProvider.resolveBooleanEvaluation('test', false, {})
+      ).resolves.toStrictEqual({ value: true });
+
+      expect(mockProvider1Boolean).toHaveBeenCalledTimes(1);
+      expect(mockProvider2Boolean).toHaveBeenCalledTimes(1);
+      expect(mockProvider3Boolean).not.toHaveBeenCalled();
+    });
+
+    it('should resolve a string value from the second provider', async () => {
+      await expect(
+        federatedProvider.resolveStringEvaluation('test', 'fallback', {})
+      ).resolves.toStrictEqual({ value: 'openfeature' });
+
+      expect(mockProvider1String).toHaveBeenCalledTimes(1);
+      expect(mockProvider2String).toHaveBeenCalledTimes(1);
+      expect(mockProvider3String).not.toHaveBeenCalled();
+    });
+
+    it('should resolve a number value from the second provider', async () => {
+      await expect(
+        federatedProvider.resolveNumberEvaluation('test', 2, {})
+      ).resolves.toStrictEqual({ value: 10 });
+
+      expect(mockProvider1Number).toHaveBeenCalledTimes(1);
+      expect(mockProvider2Number).toHaveBeenCalledTimes(1);
+      expect(mockProvider3Number).not.toHaveBeenCalled();
+    });
+
+    it('should resolve a object value from the second provider', async () => {
+      await expect(
+        federatedProvider.resolveObjectEvaluation(
+          'test',
+          { name: 'federated' },
+          {}
+        )
+      ).resolves.toStrictEqual({ value: { name: 'openfeature' } });
+
+      expect(mockProvider1Object).toHaveBeenCalledTimes(1);
+      expect(mockProvider2Object).toHaveBeenCalledTimes(1);
+      expect(mockProvider3Object).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Provider Hooks', () => {
+    const mockHook = jest.fn();
+    OpenFeature.setProvider(
+      new FederatedProvider([
+        {
+          hooks: [
+            {
+              before: mockHook,
+            },
+          ],
+          resolveBooleanEvaluation: () => {
+            return {
+              value: true,
+            };
+          },
+          resolveStringEvaluation: () => {
+            return {
+              value: 'enabled',
+            };
+          },
+          resolveNumberEvaluation: () => {
+            return {
+              value: 10,
+            };
+          },
+          resolveObjectEvaluation: () => {
+            return {
+              value: { name: 'openfeature' },
+            };
+          },
+        } as unknown as Provider,
+      ])
+    );
+    const client = OpenFeature.getClient();
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('provider hook should run when getting boolean value', async () => {
+      await expect(
+        client.getBooleanValue('test', false)
+      ).resolves.toStrictEqual(true);
+      expect(mockHook).toBeCalledTimes(1);
+    });
+
+    it('provider hook should run when getting string value', async () => {
+      await expect(
+        client.getStringValue('test', 'test')
+      ).resolves.toStrictEqual('enabled');
+      expect(mockHook).toBeCalledTimes(1);
+    });
+
+    it('provider hook should run when getting number value', async () => {
+      await expect(client.getNumberValue('test', 1)).resolves.toStrictEqual(10);
+      expect(mockHook).toBeCalledTimes(1);
+    });
+
+    it('provider hook should run when getting object value', async () => {
+      await expect(
+        client.getObjectValue('test', { name: 'test' })
+      ).resolves.toStrictEqual({ name: 'openfeature' });
+      expect(mockHook).toBeCalledTimes(1);
+    });
+  });
+});

--- a/libs/providers/federated/src/lib/federated-provider.ts
+++ b/libs/providers/federated/src/lib/federated-provider.ts
@@ -1,0 +1,90 @@
+import {
+  EvaluationContext,
+  Provider,
+  ResolutionDetails,
+  Hook,
+} from '@openfeature/nodejs-sdk';
+
+export class FederatedProvider implements Provider {
+  metadata = {
+    name: FederatedProvider.name,
+  };
+
+  hooks: Hook[] = [];
+
+  constructor(private readonly providers: Provider[]) {
+    providers.forEach((p) => this.hooks.push(...(p.hooks ?? [])));
+  }
+
+  async resolveBooleanEvaluation(
+    flagKey: string,
+    defaultValue: boolean,
+    context: EvaluationContext
+  ): Promise<ResolutionDetails<boolean>> {
+    for (const provider of this.providers) {
+      const result = await provider.resolveBooleanEvaluation(
+        flagKey,
+        defaultValue,
+        context
+      );
+      if (!result.errorCode) {
+        return result;
+      }
+    }
+    throw new Error('All registered providers failed');
+  }
+
+  async resolveStringEvaluation(
+    flagKey: string,
+    defaultValue: string,
+    context: EvaluationContext
+  ): Promise<ResolutionDetails<string>> {
+    for (const provider of this.providers) {
+      const result = await provider.resolveStringEvaluation(
+        flagKey,
+        defaultValue,
+        context
+      );
+      if (!result.errorCode) {
+        return result;
+      }
+    }
+    throw new Error('All registered providers failed');
+  }
+
+  async resolveNumberEvaluation(
+    flagKey: string,
+    defaultValue: number,
+    context: EvaluationContext
+  ): Promise<ResolutionDetails<number>> {
+    for (const provider of this.providers) {
+      const result = await provider.resolveNumberEvaluation(
+        flagKey,
+        defaultValue,
+        context
+      );
+      if (!result.errorCode) {
+        return result;
+      }
+    }
+    throw new Error('All registered providers failed');
+  }
+
+  async resolveObjectEvaluation<U extends object>(
+    flagKey: string,
+    defaultValue: U,
+    context: EvaluationContext
+  ): Promise<ResolutionDetails<U>> {
+    for (const provider of this.providers) {
+      const result = await provider.resolveObjectEvaluation(
+        flagKey,
+        defaultValue,
+        context
+      );
+      if (!result.errorCode) {
+        return result;
+      }
+    }
+    throw new Error('All registered providers failed');
+  }
+}

--- a/libs/providers/federated/tsconfig.json
+++ b/libs/providers/federated/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ES6",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/providers/federated/tsconfig.lib.json
+++ b/libs/providers/federated/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/libs/providers/federated/tsconfig.spec.json
+++ b/libs/providers/federated/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.6.7",
-        "@openfeature/nodejs-sdk": "0.0.1-alpha.50",
+        "@openfeature/nodejs-sdk": "^0.3.1",
         "@opentelemetry/api": "^1.1.0",
         "@protobuf-ts/grpc-transport": "^2.7.0",
         "axios": "^0.27.2",
@@ -3237,9 +3237,9 @@
       }
     },
     "node_modules/@openfeature/nodejs-sdk": {
-      "version": "0.0.1-alpha.50",
-      "resolved": "https://registry.npmjs.org/@openfeature/nodejs-sdk/-/nodejs-sdk-0.0.1-alpha.50.tgz",
-      "integrity": "sha512-GqUjNKl5umN/WufqlDU+M7JDtc46sylUVeLFEdEUbdXmtAEzq03RYeOEVf3xoVa4pnz45KdjJSVtMesx1M/ARw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@openfeature/nodejs-sdk/-/nodejs-sdk-0.3.1.tgz",
+      "integrity": "sha512-KhiOYC/HVFDj98sOL3qv+hcSliyklT5eCPnrDiHlAIdpJedkMOzEiKj4jA9hNh5b3rj5kVCPuqA931QoOGSH1A==",
       "engines": {
         "node": ">=14"
       }
@@ -16827,9 +16827,9 @@
       }
     },
     "@openfeature/nodejs-sdk": {
-      "version": "0.0.1-alpha.50",
-      "resolved": "https://registry.npmjs.org/@openfeature/nodejs-sdk/-/nodejs-sdk-0.0.1-alpha.50.tgz",
-      "integrity": "sha512-GqUjNKl5umN/WufqlDU+M7JDtc46sylUVeLFEdEUbdXmtAEzq03RYeOEVf3xoVa4pnz45KdjJSVtMesx1M/ARw=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@openfeature/nodejs-sdk/-/nodejs-sdk-0.3.1.tgz",
+      "integrity": "sha512-KhiOYC/HVFDj98sOL3qv+hcSliyklT5eCPnrDiHlAIdpJedkMOzEiKj4jA9hNh5b3rj5kVCPuqA931QoOGSH1A=="
     },
     "@opentelemetry/api": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "private": true,
   "dependencies": {
     "@grpc/grpc-js": "^1.6.7",
-    "@openfeature/nodejs-sdk": "0.0.1-alpha.50",
+    "@openfeature/nodejs-sdk": "^0.3.1",
     "@opentelemetry/api": "^1.1.0",
     "@protobuf-ts/grpc-transport": "^2.7.0",
     "axios": "^0.27.2",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,9 +7,7 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "versioning": "default",
-      "extra-files": [
-        "src/lib/open-telemetry-hook.ts"
-      ]
+      "extra-files": ["src/lib/open-telemetry-hook.ts"]
     },
     "libs/providers/go-feature-flag": {
       "release-type": "node",
@@ -19,6 +17,13 @@
       "versioning": "default"
     },
     "libs/providers/flagd": {
+      "release-type": "node",
+      "prerelease": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "versioning": "default"
+    },
+    "libs/providers/federated": {
       "release-type": "node",
       "prerelease": true,
       "bump-minor-pre-major": true,

--- a/tools/generators/open-feature/files/provider/src/lib/__libFileName__.ts__tmpl__
+++ b/tools/generators/open-feature/files/provider/src/lib/__libFileName__.ts__tmpl__
@@ -1,6 +1,5 @@
 import {
   EvaluationContext,
-  FlagEvaluationOptions,
   Provider,
   ResolutionDetails,
 } from '@openfeature/nodejs-sdk';
@@ -10,13 +9,10 @@ export class <%= libClassName %> implements Provider {
     name: <%= libClassName %>.name
   };
 
-  contextTransformer = () => ({});
-
   resolveBooleanEvaluation(
     flagKey: string,
     defaultValue: boolean,
-    transformedContext: EvaluationContext,
-    options: FlagEvaluationOptions
+    context: EvaluationContext
   ): Promise<ResolutionDetails<boolean>> {
     throw new Error('Method not implemented.');
   }
@@ -24,8 +20,7 @@ export class <%= libClassName %> implements Provider {
   resolveStringEvaluation(
     flagKey: string,
     defaultValue: string,
-    transformedContext: EvaluationContext,
-    options: FlagEvaluationOptions
+    context: EvaluationContext
   ): Promise<ResolutionDetails<string>> {
     throw new Error('Method not implemented.');
   }
@@ -33,8 +28,7 @@ export class <%= libClassName %> implements Provider {
   resolveNumberEvaluation(
     flagKey: string,
     defaultValue: number,
-    transformedContext: EvaluationContext,
-    options: FlagEvaluationOptions
+    context: EvaluationContext
   ): Promise<ResolutionDetails<number>> {
     throw new Error('Method not implemented.');
   }
@@ -42,8 +36,7 @@ export class <%= libClassName %> implements Provider {
   resolveObjectEvaluation<U extends object>(
     flagKey: string,
     defaultValue: U,
-    transformedContext: EvaluationContext,
-    options: FlagEvaluationOptions
+    context: EvaluationContext
   ): Promise<ResolutionDetails<U>> {
     throw new Error('Method not implemented.');
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,17 +10,15 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
-    "lib": [
-      "es2017",
-      "dom"
-    ],
+    "lib": ["es2017", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@openfeature/flagd-provider": [
-        "libs/providers/flagd/src/index.ts"
+      "@openfeature/federated-provider": [
+        "libs/providers/federated/src/index.ts"
       ],
+      "@openfeature/flagd-provider": ["libs/providers/flagd/src/index.ts"],
       "@openfeature/go-feature-flag-provider": [
         "libs/providers/go-feature-flag/src/index.ts"
       ],
@@ -29,8 +27,5 @@
       ]
     }
   },
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+  "exclude": ["node_modules", "tmp"]
 }

--- a/workspace.json
+++ b/workspace.json
@@ -3,6 +3,7 @@
   "version": 2,
   "projects": {
     "hooks-open-telemetry": "libs/hooks/open-telemetry",
+    "providers-federated": "libs/providers/federated",
     "providers-flagd": "libs/providers/flagd",
     "providers-go-feature-flag": "libs/providers/go-feature-flag"
   }


### PR DESCRIPTION
## Overview

The federated provider is based on the "super provider" concept that has been brought up in a number of community meetings. This PR adds an provider that supports an arbitrary number of child providers. Flags are evaluated based on the order providers are registered.

## Limitations

- All child provider hooks are run.