### PR TITLE
fix: fix ESM and web polyfills issue

### DIFF
--- a/libs/hooks/open-telemetry/package.json
+++ b/libs/hooks/open-telemetry/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@openfeature/open-telemetry-hook",
   "version": "5.1.1",
-  "type": "commonjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/open-feature/js-sdk-contrib.git",

--- a/libs/hooks/open-telemetry/project.json
+++ b/libs/hooks/open-telemetry/project.json
@@ -4,7 +4,7 @@
   "projectType": "library",
   "targets": {
     "package": {
-      "executor": "@nrwl/web:rollup",
+      "executor": "@nrwl/rollup:rollup",
       "outputs": [
         "{options.outputPath}"
       ],
@@ -13,7 +13,9 @@
         "outputPath": "dist/libs/hooks/open-telemetry",
         "entryFile": "libs/hooks/open-telemetry/src/index.ts",
         "tsConfig": "libs/hooks/open-telemetry/tsconfig.lib.json",
-        "compiler": "babel",
+        "compiler": "tsc",
+        "skipTypeField": true,
+        "generateExportsField": true,
         "umdName": "OpenTelemetry",
         "external": [
           "typescript"

--- a/libs/providers/flagd-web/package.json
+++ b/libs/providers/flagd-web/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@openfeature/flagd-web-provider",
   "version": "0.1.2",
-  "type": "commonjs",
   "scripts": {
     "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi",
     "current-version": "echo $npm_package_version"

--- a/libs/providers/flagd/package.json
+++ b/libs/providers/flagd/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@openfeature/flagd-provider",
   "version": "0.7.2",
-  "type": "commonjs",
   "scripts": {
     "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi",
     "current-version": "echo $npm_package_version"

--- a/libs/providers/flagd/project.json
+++ b/libs/providers/flagd/project.json
@@ -57,14 +57,16 @@
       ]
     },
     "package": {
-      "executor": "@nrwl/web:rollup",
+      "executor": "@nrwl/rollup:rollup",
       "outputs": ["{options.outputPath}"],
       "options": {
         "project": "libs/providers/flagd/package.json",
         "outputPath": "dist/libs/providers/flagd",
         "entryFile": "libs/providers/flagd/src/index.ts",
         "tsConfig": "libs/providers/flagd/tsconfig.lib.json",
-        "compiler": "babel",
+        "compiler": "tsc",
+        "skipTypeField": true,
+        "generateExportsField": true,
         "buildableProjectDepsInPackageJsonType": "dependencies",
         "umdName": "flagd",
         "external": ["typescript"],

--- a/libs/providers/go-feature-flag/package.json
+++ b/libs/providers/go-feature-flag/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@openfeature/go-feature-flag-provider",
   "version": "0.5.2",
-  "type": "commonjs",
   "scripts": {
     "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi",
     "current-version": "echo $npm_package_version"

--- a/libs/providers/go-feature-flag/project.json
+++ b/libs/providers/go-feature-flag/project.json
@@ -38,7 +38,7 @@
       }
     },
     "package": {
-      "executor": "@nrwl/web:rollup",
+      "executor": "@nrwl/rollup:rollup",
       "outputs": [
         "{options.outputPath}"
       ],
@@ -47,7 +47,9 @@
         "outputPath": "dist/libs/providers/go-feature-flag",
         "entryFile": "libs/providers/go-feature-flag/src/index.ts",
         "tsConfig": "libs/providers/go-feature-flag/tsconfig.lib.json",
-        "compiler": "babel",
+        "compiler": "tsc",
+        "skipTypeField": true,
+        "generateExportsField": true,
         "buildableProjectDepsInPackageJsonType": "dependencies",
         "umdName": "go-feature-flag",
         "external": [

--- a/tools/generators/open-feature/index.ts
+++ b/tools/generators/open-feature/index.ts
@@ -120,15 +120,17 @@ function normalizeOptions(tree: Tree, schema: SchemaOptions) {
 function updateProject(tree: Tree, projectRoot: string, umdName: string) {
   updateJson(tree, joinPathFragments(projectRoot, 'project.json'), (json) => {
     json.targets['package'] = {
-      executor: '@nrwl/web:rollup',
+      executor: '@nrwl/rollup:rollup',
       outputs: ['{options.outputPath}'],
       options: {
         project: `${projectRoot}/package.json`,
         outputPath: `dist/${projectRoot}`,
         entryFile: `${projectRoot}/src/index.ts`,
         tsConfig: `${projectRoot}/tsconfig.lib.json`,
-        buildableProjectDepsInPackageJsonType: "dependencies",
-        compiler: 'babel',
+        buildableProjectDepsInPackageJsonType: 'dependencies',
+        compiler: 'tsc',
+        skipTypeField: true,
+        generateExportsField: true,
         umdName,
         external: ['typescript'],
         format: ['cjs', 'esm'],


### PR DESCRIPTION
Fixes: https://github.com/open-feature/js-sdk-contrib/issues/198

This _seems_ to be the result of a breaking change in the nx `@nrwl/web:rollup` executor, which previously added an exports statement. I have moved to `@nrwl/rollup:rollup` with the `tsc` compiler, which generates the exports correctly and also fixes some [inappropriate polyfills](https://github.com/nrwl/nx/issues/10304) the `@nrwl/web:rollup` executor was adding.