### PR TITLE
fix: module issues with types

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -1,0 +1,3 @@
+{
+  "module": "commonjs"
+}

--- a/libs/hooks/open-telemetry/project.json
+++ b/libs/hooks/open-telemetry/project.json
@@ -14,7 +14,6 @@
         "entryFile": "libs/hooks/open-telemetry/src/index.ts",
         "tsConfig": "libs/hooks/open-telemetry/tsconfig.lib.json",
         "compiler": "tsc",
-        "skipTypeField": true,
         "generateExportsField": true,
         "umdName": "OpenTelemetry",
         "external": [
@@ -25,6 +24,11 @@
           "esm"
         ],
         "assets": [
+          {
+            "glob": "package.json",
+            "input": "./assets",
+            "output": "./src/"
+          },
           {
             "glob": "LICENSE",
             "input": "./",

--- a/libs/providers/flagd-web/project.json
+++ b/libs/providers/flagd-web/project.json
@@ -71,6 +71,11 @@
         "format": ["cjs", "esm"], 
         "assets": [
           {
+            "glob": "package.json",
+            "input": "./assets",
+            "output": "./src/"
+          },
+          {
             "glob": "LICENSE",
             "input": "./",
             "output": "./"

--- a/libs/providers/flagd/project.json
+++ b/libs/providers/flagd/project.json
@@ -65,13 +65,17 @@
         "entryFile": "libs/providers/flagd/src/index.ts",
         "tsConfig": "libs/providers/flagd/tsconfig.lib.json",
         "compiler": "tsc",
-        "skipTypeField": true,
         "generateExportsField": true,
         "buildableProjectDepsInPackageJsonType": "dependencies",
         "umdName": "flagd",
         "external": ["typescript"],
         "format": ["cjs", "esm"],
         "assets": [
+          {
+            "glob": "package.json",
+            "input": "./assets",
+            "output": "./src/"
+          },
           {
             "glob": "LICENSE",
             "input": "./",

--- a/libs/providers/go-feature-flag/project.json
+++ b/libs/providers/go-feature-flag/project.json
@@ -48,7 +48,6 @@
         "entryFile": "libs/providers/go-feature-flag/src/index.ts",
         "tsConfig": "libs/providers/go-feature-flag/tsconfig.lib.json",
         "compiler": "tsc",
-        "skipTypeField": true,
         "generateExportsField": true,
         "buildableProjectDepsInPackageJsonType": "dependencies",
         "umdName": "go-feature-flag",
@@ -60,6 +59,11 @@
           "esm"
         ],
         "assets": [
+          {
+            "glob": "package.json",
+            "input": "./assets",
+            "output": "./src/"
+          },
           {
             "glob": "LICENSE",
             "input": "./",

--- a/tools/generators/open-feature/index.ts
+++ b/tools/generators/open-feature/index.ts
@@ -135,7 +135,7 @@ function updateProject(tree: Tree, projectRoot: string, umdName: string) {
         format: ['cjs', 'esm'],
         assets: [
           // Move a "commonjs" package.json to the types root (js is bundled).
-          // This prevents is from having to add file extensions to all our imports in ESM contexts, which ESM requires.
+          // This prevents us from having to add file extensions to all our imports in ESM contexts, which ESM requires.
           {
             glob: "package.json",
             input: "./assets",

--- a/tools/generators/open-feature/index.ts
+++ b/tools/generators/open-feature/index.ts
@@ -129,12 +129,16 @@ function updateProject(tree: Tree, projectRoot: string, umdName: string) {
         tsConfig: `${projectRoot}/tsconfig.lib.json`,
         buildableProjectDepsInPackageJsonType: 'dependencies',
         compiler: 'tsc',
-        skipTypeField: true,
         generateExportsField: true,
         umdName,
         external: ['typescript'],
         format: ['cjs', 'esm'],
         assets: [
+          {
+            glob: "package.json",
+            input: "./assets",
+            output: "./src/"
+          },
           {
             glob: 'LICENSE',
             input: './',

--- a/tools/generators/open-feature/index.ts
+++ b/tools/generators/open-feature/index.ts
@@ -134,6 +134,8 @@ function updateProject(tree: Tree, projectRoot: string, umdName: string) {
         external: ['typescript'],
         format: ['cjs', 'esm'],
         assets: [
+          // Move a "commonjs" package.json to the types root (js is bundled).
+          // This prevents is from having to add file extensions to all our imports in ESM contexts, which ESM requires.
           {
             glob: "package.json",
             input: "./assets",


### PR DESCRIPTION
Fixes an issue with imports in ES module projects. Specifically, in some TS configurations, compilation would fail because TS esm support requires file extensions on all imports. Though our code is bundled, our declaration files are not, and they are also subject to this requirement. To avoid having to add `.js` extensions in our rendered type files, this adds a package.json with `type: commonjs` only in the type file roots, making them behave as commonjs modules, (which don't require file extensions in imports).

I attempted first to bundle all our types into a single d.ts (to avoid imports entirely), but was unable to find a decent solution to that.

Fixes: https://github.com/open-feature/js-sdk-contrib/issues/198

I've tested this fix with the example repo in the linked issue, as well as another es-module project, and a commonjs project. Everything works as expected.