### PR TITLE
feat: add in memory provider

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,6 @@
   "libs/hooks/open-telemetry": "6.0.1",
   "libs/providers/go-feature-flag": "0.5.4",
   "libs/providers/flagd": "0.7.5",
-  "libs/providers/env-var": "0.1.1"
+  "libs/providers/env-var": "0.1.1",
+  "libs/providers/in-memory": "0.1.0"
 }

--- a/libs/providers/in-memory/.eslintrc.json
+++ b/libs/providers/in-memory/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/providers/in-memory/README.md
+++ b/libs/providers/in-memory/README.md
@@ -2,7 +2,9 @@
 
 An *extremely* simple OpenFeature provider, intended for simple demos and as a test stub.
 
-Flag values are entirely static - evaluation context is ignored and there's no way to update the flags at runtime. 
+Flagging decisions are static - evaluation context is ignored. The only way to change a flag value is 
+to replace the entire configuration (with `replaceConfiguration`), and this is only intended to be used
+when the provider is acting as a test stub.
 
 Object values are not currently supported (but a PR implementing them would be gratefully received!)
 
@@ -35,6 +37,19 @@ const client = OpenFeature.getClient('my-app');
 // get that hardcoded boolean flag
 const boolValue = await client.getBooleanValue('a-boolean-flag', false);
 ```
+
+### replace the flag configuration
+*a crude facility for when the provider is being used as a test stub*
+
+```
+provider.replaceConfiguration({
+  'a-boolean-flag': false
+})
+```
+
+Note that this entirely replaces the previous configuration - no merging is
+performed and all previous values are lost.
+
 
 ## Development
 

--- a/libs/providers/in-memory/README.md
+++ b/libs/providers/in-memory/README.md
@@ -1,4 +1,10 @@
-# in-memory Provider
+# In-Memory Provider
+
+An *extremely* simple OpenFeature provider, intended for simple demos and as a test stub.
+
+Flag values are entirely static - evaluation context is ignored and there's no way to update the flags at runtime. 
+
+Object values are not currently supported (but a PR implementing them would be gratefully received!)
 
 ## Installation
 
@@ -6,10 +12,32 @@
 $ npm install @openfeature/in-memory-provider
 ```
 
-## Building
+## Usage
+
+### set up the provider with some flag values
+```
+import { InMemoryProvider } from '@openfeature/in-memory-provider'
+import { OpenFeature } from '@openfeature/js-sdk'
+
+const flags = {
+  'a-boolean-flag': true,
+  'a-string-flag': 'the flag value',
+}
+const provider = new InMemoryProvider(flags)
+OpenFeature.setProvider(provider)
+```
+
+### check a flag's value
+```
+// create a client
+const client = OpenFeature.getClient('my-app');
+
+// get that hardcoded boolean flag
+const boolValue = await client.getBooleanValue('a-boolean-flag', false);
+```
+
+## Development
 
 Run `nx package providers-in-memory` to build the library.
-
-## Running unit tests
 
 Run `nx test providers-in-memory` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/providers/in-memory/README.md
+++ b/libs/providers/in-memory/README.md
@@ -1,0 +1,15 @@
+# in-memory Provider
+
+## Installation
+
+```
+$ npm install @openfeature/in-memory-provider
+```
+
+## Building
+
+Run `nx package providers-in-memory` to build the library.
+
+## Running unit tests
+
+Run `nx test providers-in-memory` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/providers/in-memory/babel.config.json
+++ b/libs/providers/in-memory/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": [["minify", { "builtIns": false }]]
+}

--- a/libs/providers/in-memory/jest.config.ts
+++ b/libs/providers/in-memory/jest.config.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+export default {
+  displayName: 'providers-in-memory',
+  preset: '../../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/providers/in-memory',
+};

--- a/libs/providers/in-memory/package.json
+++ b/libs/providers/in-memory/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openfeature/in-memory-provider",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "scripts": {
+    "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi",
+    "current-version": "echo $npm_package_version"
+  },
+  "peerDependencies": {
+    "@openfeature/js-sdk": "^1.0.0"
+  }
+}

--- a/libs/providers/in-memory/project.json
+++ b/libs/providers/in-memory/project.json
@@ -1,0 +1,76 @@
+{
+  "name": "providers-in-memory",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/providers/in-memory/src",
+  "projectType": "library",
+  "targets": {
+    "publish": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "npm run publish-if-not-exists",
+        "cwd": "dist/libs/providers/in-memory"
+      },
+      "dependsOn": [
+        {
+          "projects": "self",
+          "target": "package"
+        }
+      ]
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/providers/in-memory/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/providers/in-memory/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "package": {
+      "executor": "@nrwl/rollup:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "project": "libs/providers/in-memory/package.json",
+        "outputPath": "dist/libs/providers/in-memory",
+        "entryFile": "libs/providers/in-memory/src/index.ts",
+        "tsConfig": "libs/providers/in-memory/tsconfig.lib.json",
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "compiler": "tsc",
+        "generateExportsField": true,
+        "umdName": "in-memory",
+        "external": ["typescript"],
+        "format": ["cjs", "esm"],
+        "assets": [
+          {
+            "glob": "package.json",
+            "input": "./assets",
+            "output": "./src/"
+          },
+          {
+            "glob": "LICENSE",
+            "input": "./",
+            "output": "./"
+          },
+          {
+            "glob": "README.md",
+            "input": "./libs/providers/in-memory",
+            "output": "./"
+          }
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/providers/in-memory/src/index.ts
+++ b/libs/providers/in-memory/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/in-memory-provider';

--- a/libs/providers/in-memory/src/lib/flag-configuration.ts
+++ b/libs/providers/in-memory/src/lib/flag-configuration.ts
@@ -1,0 +1,2 @@
+type FlagValue = boolean | string | number;
+export type FlagConfiguration = Record<string, FlagValue>;

--- a/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
@@ -1,4 +1,9 @@
-import { FlagNotFoundError, ResolutionDetails, StandardResolutionReasons } from '@openfeature/js-sdk';
+import {
+  FlagNotFoundError,
+  ResolutionDetails,
+  StandardResolutionReasons,
+  TypeMismatchError,
+} from '@openfeature/js-sdk';
 import { InMemoryProvider } from './in-memory-provider';
 
 describe(InMemoryProvider, () => {
@@ -21,10 +26,50 @@ describe(InMemoryProvider, () => {
       verifyResolution(resolution, { expectedValue: true });
     });
 
+    it('throws a TypeMismatchError when asked to resolve a non-boolean flag', async () => {
+      const evaluation = provider.resolveStringEvaluation('a-string-flag');
+
+      expect(evaluation).rejects.toThrow(TypeMismatchError);
+    });
+
     it('throws when asked for an unrecognized flag', async () => {
       const evaluation = provider.resolveBooleanEvaluation('unknown-flag');
       expect(evaluation).rejects.toThrow(FlagNotFoundError);
     });
+  });
+
+  describe('string flags', () => {
+    it('resolves to the configured value for a known flag', async () => {
+      const resolution = await provider.resolveStringEvaluation('a-string-flag');
+      verifyResolution(resolution, { expectedValue: 'configured-value' });
+    });
+
+    it('throws when asked for an unrecognized flag', async () => {
+      const evaluation = provider.resolveStringEvaluation('unknown-string-flag');
+      expect(evaluation).rejects.toThrow(FlagNotFoundError);
+    });
+
+    it('throws a TypeMismatchError when asked to resolve a non-string flag', async () => {
+      const evaluation = provider.resolveStringEvaluation('a-boolean-flag');
+
+      expect(evaluation).rejects.toThrow(TypeMismatchError);
+    });
+  });
+
+  it('reflects changes in flag configuration', async () => {
+    const provider = new InMemoryProvider({
+      'some-flag': 'initial-value',
+    });
+
+    const firstResolution = await provider.resolveStringEvaluation('some-flag');
+    verifyResolution(firstResolution, { expectedValue: 'initial-value' });
+
+    provider.replaceConfiguration({
+      'some-flag': 'updated-value',
+    });
+
+    const secondResolution = await provider.resolveStringEvaluation('some-flag');
+    verifyResolution(secondResolution, { expectedValue: 'updated-value' });
   });
 });
 

--- a/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
@@ -98,6 +98,20 @@ describe(InMemoryProvider, () => {
     const secondResolution = await provider.resolveStringEvaluation('some-flag');
     verifyResolution(secondResolution, { expectedValue: 'updated-value' });
   });
+
+  it('does not let you monkey with the configuration passed by reference', async () => {
+    const configuration = {
+      'some-flag': 'initial-value',
+    };
+    const provider = new InMemoryProvider(configuration);
+
+    // I passed configuration by reference, so maybe I can mess
+    // with it behind the providers back!
+    configuration['some-flag'] = 'change';
+
+    const resolution = await provider.resolveStringEvaluation('some-flag');
+    verifyResolution(resolution, { expectedValue: 'initial-value' });
+  });
 });
 
 type VerifyResolutionParams<U> = {

--- a/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
@@ -25,7 +25,7 @@ describe(InMemoryProvider, () => {
     });
 
     it('throws a TypeMismatchError when asked to resolve a non-boolean flag', async () => {
-      const evaluation = provider.resolveStringEvaluation('a-string-flag');
+      const evaluation = provider.resolveBooleanEvaluation('a-string-flag');
 
       expect(evaluation).rejects.toThrow(TypeMismatchError);
     });

--- a/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
@@ -18,10 +18,6 @@ describe(InMemoryProvider, () => {
     provider = new InMemoryProvider(flags);
   });
 
-  it('should be and instance of InMemoryProvider', () => {
-    expect(provider).toBeInstanceOf(InMemoryProvider);
-  });
-
   describe('boolean flags', () => {
     it('resolves to the configured value for a known flag', async () => {
       const resolution = await provider.resolveBooleanEvaluation('a-boolean-flag');

--- a/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
@@ -1,7 +1,38 @@
+import { FlagNotFoundError, ResolutionDetails, StandardResolutionReasons } from '@openfeature/js-sdk';
 import { InMemoryProvider } from './in-memory-provider';
 
-describe('InMemoryProvider', () => {
+describe(InMemoryProvider, () => {
+  let provider: InMemoryProvider;
+  beforeEach(() => {
+    const flags = {
+      'a-string-flag': 'configured-value',
+      'a-boolean-flag': true,
+    };
+    provider = new InMemoryProvider(flags);
+  });
+
   it('should be and instance of InMemoryProvider', () => {
-    expect(new InMemoryProvider()).toBeInstanceOf(InMemoryProvider);
+    expect(provider).toBeInstanceOf(InMemoryProvider);
+  });
+
+  describe('boolean flags', () => {
+    it('resolves to the configured value for a known flag', async () => {
+      const resolution = await provider.resolveBooleanEvaluation('a-boolean-flag');
+      verifyResolution(resolution, { expectedValue: true });
+    });
+
+    it('throws when asked for an unrecognized flag', async () => {
+      const evaluation = provider.resolveBooleanEvaluation('unknown-flag');
+      expect(evaluation).rejects.toThrow(FlagNotFoundError);
+    });
   });
 });
+
+type VerifyResolutionParams<U> = {
+  expectedValue: U;
+};
+function verifyResolution<U>(resolution: ResolutionDetails<U>, { expectedValue }: VerifyResolutionParams<U>) {
+  expect(resolution.value).toBe(expectedValue);
+  expect(resolution.reason).toBe(StandardResolutionReasons.STATIC);
+  expect(resolution.errorCode).toBeUndefined();
+}

--- a/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
@@ -1,0 +1,7 @@
+import { InMemoryProvider } from './in-memory-provider';
+
+describe('InMemoryProvider', () => {
+  it('should be and instance of InMemoryProvider', () => {
+    expect(new InMemoryProvider()).toBeInstanceOf(InMemoryProvider);
+  });
+});

--- a/libs/providers/in-memory/src/lib/in-memory-provider.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.ts
@@ -18,11 +18,11 @@ export class InMemoryProvider implements Provider {
   private _flagConfiguration: FlagConfiguration;
 
   constructor(flagConfiguration: FlagConfiguration = {}) {
-    this._flagConfiguration = flagConfiguration;
+    this._flagConfiguration = { ...flagConfiguration };
   }
 
   replaceConfiguration(flagConfiguration: FlagConfiguration) {
-    this._flagConfiguration = flagConfiguration;
+    this._flagConfiguration = { ...flagConfiguration };
   }
 
   async resolveBooleanEvaluation(flagKey: string): Promise<ResolutionDetails<boolean>> {

--- a/libs/providers/in-memory/src/lib/in-memory-provider.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.ts
@@ -1,0 +1,41 @@
+import { EvaluationContext, Provider, JsonValue, ResolutionDetails } from '@openfeature/js-sdk';
+
+export class InMemoryProvider implements Provider {
+  metadata = {
+    name: InMemoryProvider.name,
+  };
+
+  hooks = [];
+
+  resolveBooleanEvaluation(
+    flagKey: string,
+    defaultValue: boolean,
+    context: EvaluationContext
+  ): Promise<ResolutionDetails<boolean>> {
+    throw new Error('Method not implemented.');
+  }
+
+  resolveStringEvaluation(
+    flagKey: string,
+    defaultValue: string,
+    context: EvaluationContext
+  ): Promise<ResolutionDetails<string>> {
+    throw new Error('Method not implemented.');
+  }
+
+  resolveNumberEvaluation(
+    flagKey: string,
+    defaultValue: number,
+    context: EvaluationContext
+  ): Promise<ResolutionDetails<number>> {
+    throw new Error('Method not implemented.');
+  }
+
+  resolveObjectEvaluation<U extends JsonValue>(
+    flagKey: string,
+    defaultValue: U,
+    context: EvaluationContext
+  ): Promise<ResolutionDetails<U>> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/libs/providers/in-memory/src/lib/in-memory-provider.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.ts
@@ -19,6 +19,10 @@ export class InMemoryProvider implements Provider {
     this._flagConfiguration = flagConfiguration;
   }
 
+  replaceConfiguration(flagConfiguration: FlagConfiguration) {
+    this._flagConfiguration = flagConfiguration;
+  }
+
   async resolveBooleanEvaluation(flagKey: string): Promise<ResolutionDetails<boolean>> {
     if (!(flagKey in this._flagConfiguration)) {
       throw new FlagNotFoundError();
@@ -34,12 +38,19 @@ export class InMemoryProvider implements Provider {
     };
   }
 
-  resolveStringEvaluation(
-    flagKey: string,
-    defaultValue: string,
-    context: EvaluationContext
-  ): Promise<ResolutionDetails<string>> {
-    throw new Error('Method not implemented.');
+  async resolveStringEvaluation(flagKey: string): Promise<ResolutionDetails<string>> {
+    if (!(flagKey in this._flagConfiguration)) {
+      throw new FlagNotFoundError();
+    }
+    const flagValue = this._flagConfiguration[flagKey];
+    if (typeof flagValue !== 'string') {
+      throw new TypeMismatchError();
+    }
+
+    return {
+      value: flagValue,
+      reason: StandardResolutionReasons.STATIC,
+    };
   }
 
   resolveNumberEvaluation(

--- a/libs/providers/in-memory/src/lib/in-memory-provider.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.ts
@@ -7,6 +7,7 @@ import {
   TypeMismatchError,
   StandardResolutionReasons,
   GeneralError,
+  FlagValue,
 } from '@openfeature/js-sdk';
 import { FlagConfiguration } from './flag-configuration';
 
@@ -25,51 +26,50 @@ export class InMemoryProvider implements Provider {
   }
 
   async resolveBooleanEvaluation(flagKey: string): Promise<ResolutionDetails<boolean>> {
-    if (!(flagKey in this._flagConfiguration)) {
-      throw new FlagNotFoundError();
-    }
-    const flagValue = this._flagConfiguration[flagKey];
+    const flagValue = this.lookupFlagValueOrThrow(flagKey);
+
     if (typeof flagValue !== 'boolean') {
       throw new TypeMismatchError();
     }
 
-    return {
-      value: flagValue,
-      reason: StandardResolutionReasons.STATIC,
-    };
+    return staticResolution(flagValue);
   }
 
   async resolveStringEvaluation(flagKey: string): Promise<ResolutionDetails<string>> {
-    if (!(flagKey in this._flagConfiguration)) {
-      throw new FlagNotFoundError();
-    }
-    const flagValue = this._flagConfiguration[flagKey];
+    const flagValue = this.lookupFlagValueOrThrow(flagKey);
+
     if (typeof flagValue !== 'string') {
       throw new TypeMismatchError();
     }
 
-    return {
-      value: flagValue,
-      reason: StandardResolutionReasons.STATIC,
-    };
+    return staticResolution(flagValue);
   }
 
   async resolveNumberEvaluation(flagKey: string): Promise<ResolutionDetails<number>> {
-    if (!(flagKey in this._flagConfiguration)) {
-      throw new FlagNotFoundError();
-    }
-    const flagValue = this._flagConfiguration[flagKey];
+    const flagValue = this.lookupFlagValueOrThrow(flagKey);
+
     if (typeof flagValue !== 'number') {
       throw new TypeMismatchError();
     }
 
-    return {
-      value: flagValue,
-      reason: StandardResolutionReasons.STATIC,
-    };
+    return staticResolution(flagValue);
   }
 
   async resolveObjectEvaluation<U extends JsonValue>(flagKey: string): Promise<ResolutionDetails<U>> {
     throw new GeneralError('support for object flags has not been implemented');
   }
+
+  private lookupFlagValueOrThrow(flagKey: string): FlagValue {
+    if (!(flagKey in this._flagConfiguration)) {
+      throw new FlagNotFoundError();
+    }
+    return this._flagConfiguration[flagKey];
+  }
+}
+
+function staticResolution<U>(value: U): ResolutionDetails<U> {
+  return {
+    value,
+    reason: StandardResolutionReasons.STATIC,
+  };
 }

--- a/libs/providers/in-memory/src/lib/in-memory-provider.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.ts
@@ -6,6 +6,7 @@ import {
   FlagNotFoundError,
   TypeMismatchError,
   StandardResolutionReasons,
+  GeneralError,
 } from '@openfeature/js-sdk';
 import { FlagConfiguration } from './flag-configuration';
 
@@ -53,19 +54,22 @@ export class InMemoryProvider implements Provider {
     };
   }
 
-  resolveNumberEvaluation(
-    flagKey: string,
-    defaultValue: number,
-    context: EvaluationContext
-  ): Promise<ResolutionDetails<number>> {
-    throw new Error('Method not implemented.');
+  async resolveNumberEvaluation(flagKey: string): Promise<ResolutionDetails<number>> {
+    if (!(flagKey in this._flagConfiguration)) {
+      throw new FlagNotFoundError();
+    }
+    const flagValue = this._flagConfiguration[flagKey];
+    if (typeof flagValue !== 'number') {
+      throw new TypeMismatchError();
+    }
+
+    return {
+      value: flagValue,
+      reason: StandardResolutionReasons.STATIC,
+    };
   }
 
-  resolveObjectEvaluation<U extends JsonValue>(
-    flagKey: string,
-    defaultValue: U,
-    context: EvaluationContext
-  ): Promise<ResolutionDetails<U>> {
-    throw new Error('Method not implemented.');
+  async resolveObjectEvaluation<U extends JsonValue>(flagKey: string): Promise<ResolutionDetails<U>> {
+    throw new GeneralError('support for object flags has not been implemented');
   }
 }

--- a/libs/providers/in-memory/src/lib/in-memory-provider.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.ts
@@ -1,18 +1,37 @@
-import { EvaluationContext, Provider, JsonValue, ResolutionDetails } from '@openfeature/js-sdk';
+import {
+  EvaluationContext,
+  Provider,
+  JsonValue,
+  ResolutionDetails,
+  FlagNotFoundError,
+  TypeMismatchError,
+  StandardResolutionReasons,
+} from '@openfeature/js-sdk';
+import { FlagConfiguration } from './flag-configuration';
 
 export class InMemoryProvider implements Provider {
-  metadata = {
-    name: InMemoryProvider.name,
-  };
+  readonly metadata = {
+    name: 'In-Memory Provider',
+  } as const;
+  private _flagConfiguration: FlagConfiguration;
 
-  hooks = [];
+  constructor(flagConfiguration: FlagConfiguration = {}) {
+    this._flagConfiguration = flagConfiguration;
+  }
 
-  resolveBooleanEvaluation(
-    flagKey: string,
-    defaultValue: boolean,
-    context: EvaluationContext
-  ): Promise<ResolutionDetails<boolean>> {
-    throw new Error('Method not implemented.');
+  async resolveBooleanEvaluation(flagKey: string): Promise<ResolutionDetails<boolean>> {
+    if (!(flagKey in this._flagConfiguration)) {
+      throw new FlagNotFoundError();
+    }
+    const flagValue = this._flagConfiguration[flagKey];
+    if (typeof flagValue !== 'boolean') {
+      throw new TypeMismatchError();
+    }
+
+    return {
+      value: flagValue,
+      reason: StandardResolutionReasons.STATIC,
+    };
   }
 
   resolveStringEvaluation(

--- a/libs/providers/in-memory/tsconfig.json
+++ b/libs/providers/in-memory/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ES6",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/providers/in-memory/tsconfig.lib.json
+++ b/libs/providers/in-memory/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/providers/in-memory/tsconfig.spec.json
+++ b/libs/providers/in-memory/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "babel-preset-minify": "0.5.2",
     "eslint": "~8.35.0",
     "eslint-config-prettier": "8.7.0",
-    "jest": "^29.4.1",
-    "jest-environment-jsdom": "^29.4.1",
+    "jest": "^29.3.1",
+    "jest-environment-jsdom": "^29.3.1",
     "jest-fetch-mock": "^3.0.3",
     "nx": "15.8.5",
     "prettier": "2.8.4",
-    "ts-jest": "^29.0.5",
+    "ts-jest": "^29.0.3",
     "ts-node": "10.9.1",
     "typescript": "4.9.5"
   }

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "babel-preset-minify": "0.5.2",
     "eslint": "~8.35.0",
     "eslint-config-prettier": "8.7.0",
-    "jest": "^29.3.1",
-    "jest-environment-jsdom": "^29.3.1",
+    "jest": "^29.4.1",
+    "jest-environment-jsdom": "^29.4.1",
     "jest-fetch-mock": "^3.0.3",
     "nx": "15.8.5",
     "prettier": "2.8.4",
-    "ts-jest": "^29.0.3",
+    "ts-jest": "^29.0.5",
     "ts-node": "10.9.1",
     "typescript": "4.9.5"
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,6 +29,13 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "versioning": "default"
+    },
+    "libs/providers/in-memory": {
+      "release-type": "node",
+      "prerelease": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "versioning": "default"
     }
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,7 +20,8 @@
       "@openfeature/env-var-provider": ["libs/providers/env-var/src/index.ts"],
       "@openfeature/flagd-provider": ["libs/providers/flagd/src/index.ts"],
       "@openfeature/go-feature-flag-provider": ["libs/providers/go-feature-flag/src/index.ts"],
-      "@openfeature/hooks-open-telemetry": ["libs/hooks/open-telemetry/src/index.ts"]
+      "@openfeature/hooks-open-telemetry": ["libs/hooks/open-telemetry/src/index.ts"],
+      "@openfeature/in-memory-provider": ["libs/providers/in-memory/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
adds a super simple in-memory provider, for use in automated tests, and for demos.