### PR TITLE
feat: Support apiKey for GO Feature Flag relay proxy v1.7.0

### DIFF
--- a/libs/providers/go-feature-flag/src/lib/errors/unauthorized.ts
+++ b/libs/providers/go-feature-flag/src/lib/errors/unauthorized.ts
@@ -1,0 +1,13 @@
+import { ErrorCode, OpenFeatureError } from '@openfeature/js-sdk'
+
+// ProxyNotReady is an error send when we try to call the relay proxy and he is not ready
+// to return a valid response.
+export class Unauthorized extends OpenFeatureError {
+  code: ErrorCode
+
+  constructor(message: string) {
+    super(message)
+    Object.setPrototypeOf(this, Unauthorized.prototype)
+    this.code = ErrorCode.GENERAL
+  }
+}

--- a/libs/providers/go-feature-flag/src/lib/errors/unauthorized.ts
+++ b/libs/providers/go-feature-flag/src/lib/errors/unauthorized.ts
@@ -1,7 +1,6 @@
 import { ErrorCode, OpenFeatureError } from '@openfeature/js-sdk'
 
-// ProxyNotReady is an error send when we try to call the relay proxy and he is not ready
-// to return a valid response.
+// Unauthorized is an error send when the provider do an unauthorized call to the relay proxy.
 export class Unauthorized extends OpenFeatureError {
   code: ErrorCode
 

--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.spec.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.spec.ts
@@ -12,6 +12,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { ProxyNotReady } from './errors/proxyNotReady';
 import { ProxyTimeout } from './errors/proxyTimeout';
 import { UnknownError } from './errors/unknownError';
+import {Unauthorized} from './errors/unauthorized';
 import { GoFeatureFlagProvider } from './go-feature-flag-provider';
 import { GoFeatureFlagProxyResponse } from './model';
 
@@ -80,7 +81,7 @@ describe('GoFeatureFlagProvider', () => {
             expect(result.errorCode).toEqual(ErrorCode.PARSE_ERROR)
           })
       });
-  
+
       it('unknown error codes should return GENERAL code', async () => {
         const flagName = 'random-other-other-flag';
         const targetingKey = 'user-key';
@@ -129,6 +130,22 @@ describe('GoFeatureFlagProvider', () => {
           expect(err).toBeInstanceOf(FlagNotFoundError);
           expect(err.message).toEqual(
             `Flag ${flagName} was not found in your configuration`
+          );
+        });
+    });
+    it('should throw an error if invalid api key is propvided', async () => {
+      const flagName = 'unauthorized';
+      const targetingKey = 'user-key';
+      const dns = `${endpoint}v1/feature/${flagName}/eval`;
+
+      axiosMock.onPost(dns).reply(401, {} as GoFeatureFlagProxyResponse<string>);
+
+      await goff
+        .resolveStringEvaluation(flagName, 'sdk-default', { targetingKey })
+        .catch((err) => {
+          expect(err).toBeInstanceOf(Unauthorized);
+          expect(err.message).toEqual(
+            'invalid token used to contact GO Feature Flag relay proxy instance'
           );
         });
     });

--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.spec.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.spec.ts
@@ -12,7 +12,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { ProxyNotReady } from './errors/proxyNotReady';
 import { ProxyTimeout } from './errors/proxyTimeout';
 import { UnknownError } from './errors/unknownError';
-import {Unauthorized} from './errors/unauthorized';
+import { Unauthorized } from './errors/unauthorized';
 import { GoFeatureFlagProvider } from './go-feature-flag-provider';
 import { GoFeatureFlagProxyResponse } from './model';
 

--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
@@ -13,7 +13,7 @@ import { transformContext } from './context-transformer';
 import { ProxyNotReady } from './errors/proxyNotReady';
 import { ProxyTimeout } from './errors/proxyTimeout';
 import { UnknownError } from './errors/unknownError';
-import {Unauthorized} from './errors/unauthorized';
+import { Unauthorized } from './errors/unauthorized';
 import {
   GoFeatureFlagProviderOptions,
   GoFeatureFlagProxyRequest,

--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
@@ -178,7 +178,7 @@ export class GoFeatureFlagProvider implements Provider {
         timeout: this.timeout,
       };
 
-      if (this.apiKey && this.apiKey !== ''){
+      if (this.apiKey) {
         reqConfig.headers?.put('Authorization', `Bearer ${this.apiKey}`);
       }
 

--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
@@ -8,7 +8,7 @@ import {
   StandardResolutionReasons,
   TypeMismatchError,
 } from '@openfeature/js-sdk';
-import axios, {AxiosRequestConfig} from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import { transformContext } from './context-transformer';
 import { ProxyNotReady } from './errors/proxyNotReady';
 import { ProxyTimeout } from './errors/proxyTimeout';

--- a/libs/providers/go-feature-flag/src/lib/model.ts
+++ b/libs/providers/go-feature-flag/src/lib/model.ts
@@ -47,6 +47,12 @@ export interface GoFeatureFlagProxyResponse<T> {
 export interface GoFeatureFlagProviderOptions {
   endpoint: string;
   timeout?: number; // in millisecond
+
+  // apiKey (optional) If the relay proxy is configured to authenticate the requests, you should provide
+  // an API Key to the provider. Please ask the administrator of the relay proxy to provide an API Key.
+  // (This feature is available only if you are using GO Feature Flag relay proxy v1.7.0 or above)
+  // Default: null
+  apiKey?: string;
 }
 
 // GOFeatureFlagResolutionReasons allows to extends resolution reasons


### PR DESCRIPTION
## This PR
Since version `v1.7.0` GO Feature Flag relay proxy support an authorization key.
This PR makes it possible to send this API Key to the proxy.


### Related Issues
Fixes https://github.com/thomaspoignant/go-feature-flag/issues/666
