### PR TITLE
fix: go-feature-flag provider this.apiKey is undefined

### DIFF
--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
@@ -41,7 +41,7 @@ export class GoFeatureFlagProvider implements Provider {
 
     // Add API key to the headers
     if (options.apiKey) {
-      axios.defaults.headers.common['Authorization'] = `Bearer ${this.apiKey}`;
+      axios.defaults.headers.common['Authorization'] = `Bearer ${options.apiKey}`;
     }
   }
 


### PR DESCRIPTION
## This PR
I am struggling here and adding more bugs at every commit 🤦 
This one should be the good one 🤞

I was using `this.apiKey` instead of `options.apiKey`.