### PR TITLE
chore: correct publish executor

### DIFF
--- a/libs/hooks/open-telemetry/project.json
+++ b/libs/hooks/open-telemetry/project.json
@@ -47,7 +47,7 @@
       }
     },
     "publish": {
-      "executor": "@nx/workspace:run-commands",
+      "executor": "nx:run-commands",
       "options": {
         "command": "npm run publish-if-not-exists",
         "cwd": "dist/libs/hooks/open-telemetry"

--- a/libs/providers/env-var/project.json
+++ b/libs/providers/env-var/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "publish": {
-      "executor": "@nx/workspace:run-commands",
+      "executor": "nx:run-commands",
       "options": {
         "command": "npm run publish-if-not-exists",
         "cwd": "dist/libs/providers/env-var"

--- a/libs/providers/go-feature-flag/project.json
+++ b/libs/providers/go-feature-flag/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "publish": {
-      "executor": "@nx/workspace:run-commands",
+      "executor": "nx:run-commands",
       "options": {
         "command": "npm run publish-if-not-exists",
         "cwd": "dist/libs/providers/go-feature-flag"

--- a/libs/providers/in-memory/project.json
+++ b/libs/providers/in-memory/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "publish": {
-      "executor": "@nx/workspace:run-commands",
+      "executor": "nx:run-commands",
       "options": {
         "command": "npm run publish-if-not-exists",
         "cwd": "dist/libs/providers/in-memory"


### PR DESCRIPTION
Some of the publish commands were using a "workspace executor", instead of an nx one.