### PR TITLE
feat: Return CACHED reason when using cache

### DIFF
--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.spec.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.spec.ts
@@ -701,7 +701,8 @@ describe('GoFeatureFlagProvider', () => {
       const cli = OpenFeature.getClient();
       const got1 = await cli.getBooleanDetails(flagName, false, {targetingKey});
       const got2 = await cli.getBooleanDetails(flagName, false, {targetingKey});
-      expect(got1).toEqual(got2);
+      expect(got1.reason).toEqual(StandardResolutionReasons.TARGETING_MATCH);
+      expect(got2.reason).toEqual(StandardResolutionReasons.CACHED);
       expect(axiosMock.history['post'].length).toBe(1);
     });
 

--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
@@ -280,7 +280,8 @@ export class GoFeatureFlagProvider implements Provider {
           variation: cacheValue.variant || 'SdkDefault',
           userKey: user.key,
         }
-        this.dataCollectorBuffer?.push(dataCollectorEvent)
+        this.dataCollectorBuffer?.push(dataCollectorEvent);
+        cacheValue.reason = StandardResolutionReasons.CACHED;
         return cacheValue;
       }
     }


### PR DESCRIPTION
## This PR
- Return `CACHED` as a reason when using the cache in the provider.