### PR TITLE
fix: use copy-anything for deepClone to be compatible with nodeJS before v17

### DIFF
--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
@@ -10,6 +10,7 @@ import {
   TypeMismatchError,
 } from '@openfeature/js-sdk';
 import axios from 'axios';
+import _ from 'lodash';
 import {transformContext} from './context-transformer';
 import {ProxyNotReady} from './errors/proxyNotReady';
 import {ProxyTimeout} from './errors/proxyTimeout';
@@ -117,11 +118,11 @@ export class GoFeatureFlagProvider implements Provider {
    */
   async callGoffDataCollection() {
     if (this.dataCollectorBuffer?.length === 0) {
-      return
+      return;
     }
 
-    const dataToSend = structuredClone(this.dataCollectorBuffer);
-    this.dataCollectorBuffer = []
+    const dataToSend = _.cloneDeep<FeatureEvent<any>[] | undefined>(this.dataCollectorBuffer) || [];
+    this.dataCollectorBuffer = [];
 
     const request: DataCollectorRequest<boolean> = {events: dataToSend, meta: this.dataCollectorMetadata,}
     const endpointURL = new URL(this.endpoint);
@@ -138,7 +139,7 @@ export class GoFeatureFlagProvider implements Provider {
     } catch (e) {
       this.logger?.error(`impossible to send the data to the collector: ${e}`)
       // if we have an issue calling the collector we put the data back in the buffer
-      this.dataCollectorBuffer = [...this.dataCollectorBuffer, ...dataToSend]
+      this.dataCollectorBuffer = [...this.dataCollectorBuffer, ...dataToSend];
     }
   }
 

--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
@@ -10,7 +10,7 @@ import {
   TypeMismatchError,
 } from '@openfeature/js-sdk';
 import axios from 'axios';
-import _ from 'lodash';
+import {copy} from 'copy-anything';
 import {transformContext} from './context-transformer';
 import {ProxyNotReady} from './errors/proxyNotReady';
 import {ProxyTimeout} from './errors/proxyTimeout';
@@ -121,7 +121,7 @@ export class GoFeatureFlagProvider implements Provider {
       return;
     }
 
-    const dataToSend = _.cloneDeep<FeatureEvent<any>[] | undefined>(this.dataCollectorBuffer) || [];
+    const dataToSend = copy(this.dataCollectorBuffer) || [];
     this.dataCollectorBuffer = [];
 
     const request: DataCollectorRequest<boolean> = {events: dataToSend, meta: this.dataCollectorMetadata,}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@swc/helpers": "~0.5.0",
         "axios": "1.4.0",
         "configcat-js": "^8.0.0",
+        "copy-anything": "^3.0.5",
         "launchdarkly-js-client-sdk": "^3.1.3",
         "lodash.isequal": "^4.5.0",
         "lru-cache": "^10.0.0",
@@ -5739,6 +5740,20 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
     },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.30.2",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.30.2.tgz",
@@ -7893,6 +7908,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.15.tgz",
+      "integrity": "sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/is-wsl": {
@@ -16662,6 +16688,14 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
     },
+    "copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "requires": {
+        "is-what": "^4.1.8"
+      }
+    },
     "core-js-compat": {
       "version": "3.30.2",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.30.2.tgz",
@@ -18220,6 +18254,11 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
+    },
+    "is-what": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.15.tgz",
+      "integrity": "sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA=="
     },
     "is-wsl": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@swc/helpers": "~0.5.0",
     "axios": "1.4.0",
     "configcat-js": "^8.0.0",
+    "copy-anything": "^3.0.5",
     "launchdarkly-js-client-sdk": "^3.1.3",
     "lodash.isequal": "^4.5.0",
     "lru-cache": "^10.0.0",


### PR DESCRIPTION
## This PR
- use `copy-anything` for deepClone to be compatible with nodeJS before v17

Fixes #428 

