### PR TITLE
chore: add node version matrix to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Fixes: https://github.com/open-feature/js-sdk-contrib/issues/430