### PR TITLE
fix!: Remove ConfigCat 7 peer dependencies as it is missing informatio…

### DIFF
--- a/libs/providers/config-cat/package.json
+++ b/libs/providers/config-cat/package.json
@@ -8,6 +8,6 @@
   },
   "peerDependencies": {
     "@openfeature/js-sdk": "^1.3.0",
-    "configcat-js": "^7.0.0 || ^8.0.0"
+    "configcat-js": "^8.0.0"
   }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Removes ConfigCat 7.0.0 from valid peer dependency versions of config cat provider, as the flags changes information is not present in 7.0.0.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

