### PR TITLE
feat!: add metrics hook

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "libs/hooks/open-telemetry": "6.0.2",
+  "libs/hooks/open-telemetry": "0.1.0",
   "libs/providers/go-feature-flag": "0.5.12",
   "libs/providers/flagd": "0.7.7",
   "libs/providers/flagd-web": "0.3.4",

--- a/libs/hooks/open-telemetry/README.md
+++ b/libs/hooks/open-telemetry/README.md
@@ -2,12 +2,14 @@
 
 # OpenTelemetry Hook
 
-The OpenTelemetry hook for OpenFeature provides a [spec compliant][otel-spec] way to automatically add a feature flag evaluation to a span as a span event. Since feature flags are dynamic and affect runtime behavior, it’s important to collect relevant feature flag telemetry signals. This can be used to determine the impact a feature has on a request, enabling enhanced observability use cases, such as A/B testing or progressive feature releases.
+The OpenTelemetry hooks for OpenFeature provide a [spec compliant][otel-spec] way to automatically add feature flag evaluation information to traces and metrics.
+Since feature flags are dynamic and affect runtime behavior, it’s important to collect relevant feature flag telemetry signals.
+These can be used to determine the impact a feature has on application behavior, enabling enhanced observability use cases, such as A/B testing or progressive feature releases.
 
 ## Installation
 
 ```
-$ npm install @openfeature/open-telemetry-hook
+$ npm install @openfeature/open-telemetry-hooks
 ```
 
 ### Peer dependencies
@@ -18,33 +20,52 @@ Confirm that the following peer dependencies are installed.
 $ npm install @openfeature/js-sdk @opentelemetry/api
 ```
 
+## Hooks
+
+### TracingHook
+
+This hook adds a [span event](https://opentelemetry.io/docs/concepts/signals/traces/#span-events) for each feature flag evaluation.
+
+### MetricsHook
+
+This hook performs metric collection by tapping into various hook stages. Below are the metrics are extracted by this hook:
+
+- `feature_flag.evaluation_requests_total`
+- `feature_flag.evaluation_success_total`
+- `feature_flag.evaluation_error_total`
+- `feature_flag.evaluation_active_count`
+
 ## Usage
 
-OpenFeature provides various ways to register hooks. The location that a hook is registered affects when the hook is run. It's recommended to register the `OpenTelemetryHook` globally in most situations but it's possible to only enable the hook on specific clients. You should **never** register the `OpenTelemetryHook` globally and on a client.
+OpenFeature provides various ways to register hooks. The location that a hook is registered affects when the hook is run.
+It's recommended to register both the `TracingHook` and `MetricsHook` globally in most situations, but it's possible to only enable the hook on specific clients.
+You should **never** register these hooks both globally and on a client.
 
 More information on hooks can be found in the [OpenFeature documentation][hook-concept].
 
 ### Register Globally
 
-The `OpenTelemetryHook` can be set on the OpenFeature singleton. This will ensure that every flag evaluation will always create a span event, if am active span is available.
+The `TracingHook` and `MetricsHook` can both be set on the OpenFeature singleton.
+This will ensure that every flag evaluation will always generate the applicable telemetry signals.
 
 ```typescript
 import { OpenFeature } from '@openfeature/js-sdk';
-import { OpenTelemetryHook } from '@openfeature/open-telemetry-hook';
+import { TracingHook } from '@openfeature/open-telemetry-hooks';
 
-OpenFeature.addHooks(new OpenTelemetryHook());
+OpenFeature.addHooks(new TracingHook());
 ```
 
 ### Register Per Client
 
-The `OpenTelemetryHook` can be set on an individual client. This should only be done if it wasn't set globally and other clients shouldn't use this hook. Setting the hook on the client will ensure that every flag evaluation performed by this client will always create a span event, if am active span is available.
+ The `TracingHook` and `MetricsHook` can both be set on an individual client. This should only be done if it wasn't set globally and other clients shouldn't use this hook.
+ Setting the hook on the client will ensure that every flag evaluation performed by this client will always generate the applicable telemetry signals.
 
 ```typescript
 import { OpenFeature } from '@openfeature/js-sdk';
-import { OpenTelemetryHook } from '@openfeature/open-telemetry-hook';
+import { MetricsHook } from '@openfeature/open-telemetry-hooks';
 
 const client = OpenFeature.getClient('my-app');
-client.addHooks(new OpenTelemetryHook());
+client.addHooks(new MetricsHook());
 ```
 
 ## Development

--- a/libs/hooks/open-telemetry/package.json
+++ b/libs/hooks/open-telemetry/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@openfeature/open-telemetry-hook",
-  "version": "6.0.2",
+  "name": "@openfeature/open-telemetry-hooks",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/open-feature/js-sdk-contrib.git",
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@openfeature/js-sdk": "^1.0.0",
-    "@opentelemetry/api": "^1.2.0"
+    "@opentelemetry/api": ">=1.3.0"
   },
   "license": "Apache-2.0"
 }

--- a/libs/hooks/open-telemetry/src/index.ts
+++ b/libs/hooks/open-telemetry/src/index.ts
@@ -1,1 +1,2 @@
-export * from './lib/open-telemetry-hook';
+export * from './lib/traces';
+export * from './lib/metrics';

--- a/libs/hooks/open-telemetry/src/lib/constants.ts
+++ b/libs/hooks/open-telemetry/src/lib/constants.ts
@@ -1,0 +1,5 @@
+export const FEATURE_FLAG = 'feature_flag';
+export const ACTIVE_COUNT_NAME = `${FEATURE_FLAG}.evaluation_active_count`;
+export const REQUESTS_TOTAL_NAME = `${FEATURE_FLAG}.evaluation_requests_total`;
+export const SUCCESS_TOTAL_NAME = `${FEATURE_FLAG}.evaluation_success_total`;
+export const ERROR_TOTAL_NAME = `${FEATURE_FLAG}.evaluation_error_total`;

--- a/libs/hooks/open-telemetry/src/lib/metrics/index.ts
+++ b/libs/hooks/open-telemetry/src/lib/metrics/index.ts
@@ -1,0 +1,1 @@
+export * from './metrics-hook';

--- a/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.spec.ts
+++ b/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.spec.ts
@@ -1,0 +1,216 @@
+import { BeforeHookContext, EvaluationDetails, HookContext, StandardResolutionReasons } from '@openfeature/js-sdk';
+import opentelemetry from '@opentelemetry/api';
+import {
+  DataPoint,
+  MeterProvider,
+  MetricReader,
+  ScopeMetrics,
+} from '@opentelemetry/sdk-metrics';
+import { ACTIVE_COUNT_NAME, ERROR_TOTAL_NAME, REQUESTS_TOTAL_NAME, SUCCESS_TOTAL_NAME } from '../constants';
+import { MetricsHook } from './metrics-hook';
+
+// no-op "in-memory" reader
+class InMemoryMetricReader extends MetricReader {
+  protected onShutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+  protected onForceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe(MetricsHook.name, () => {
+  let reader: MetricReader;
+
+  beforeAll(() => {
+    reader = new InMemoryMetricReader();
+    const provider = new MeterProvider();
+
+    provider.addMetricReader(reader);
+
+    // Set this MeterProvider to be global to the app being instrumented.
+    const successful = opentelemetry.metrics.setGlobalMeterProvider(provider);
+    expect(successful).toBeTruthy();
+  });
+
+  describe(MetricsHook.prototype.before, () => {
+    it('should increment evaluation_active_count and evaluation_requests_total and set attrs', async () => {
+      const FLAG_KEY = 'before-test-key';
+      const PROVIDER_NAME = 'before-provider-name';
+      const hook = new MetricsHook();
+      const mockHookContext: BeforeHookContext = {
+        flagKey: FLAG_KEY,
+        providerMetadata: {
+          name: PROVIDER_NAME,
+        },
+      } as BeforeHookContext;
+
+      hook.before(mockHookContext);
+      const result = await reader.collect();
+      expect(
+        hasDataPointMatching(
+          result.resourceMetrics.scopeMetrics,
+          ACTIVE_COUNT_NAME,
+          0,
+          (point) =>
+            point.value === 1 && point.attributes.key === FLAG_KEY && point.attributes.provider === PROVIDER_NAME
+        )
+      ).toBeTruthy();
+      expect(
+        hasDataPointMatching(
+          result.resourceMetrics.scopeMetrics,
+          REQUESTS_TOTAL_NAME,
+          0,
+          (point) =>
+            point.value === 1 && point.attributes.key === FLAG_KEY && point.attributes.provider === PROVIDER_NAME
+        )
+      ).toBeTruthy();
+    });
+  });
+
+  describe(MetricsHook.prototype.after, () => {
+    describe('variant set', () => {
+      it('should increment evaluation_success_total and set attrs with variant = variant', async () => {
+        const FLAG_KEY = 'after-test-key';
+        const PROVIDER_NAME = 'after-provider-name';
+        const VARIANT = 'one';
+        const VALUE = 1;
+        const hook = new MetricsHook();
+        const mockHookContext: HookContext = {
+          flagKey: FLAG_KEY,
+          providerMetadata: {
+            name: PROVIDER_NAME,
+          },
+        } as HookContext;
+        const evaluationDetails: EvaluationDetails<number> = {
+          variant: VARIANT,
+          value: VALUE,
+          reason: StandardResolutionReasons.STATIC,
+        } as EvaluationDetails<number>;
+
+        hook.after(mockHookContext, evaluationDetails);
+        const result = await reader.collect();
+        expect(
+          hasDataPointMatching(
+            result.resourceMetrics.scopeMetrics,
+            SUCCESS_TOTAL_NAME,
+            0,
+            (point) =>
+              point.value === 1 &&
+              point.attributes.key === FLAG_KEY &&
+              point.attributes.provider === PROVIDER_NAME &&
+              point.attributes.variant === VARIANT &&
+              point.attributes.reason === StandardResolutionReasons.STATIC
+          )
+        ).toBeTruthy();
+      });
+
+      it('should increment evaluation_success_total and set attrs with variant = value', async () => {
+        const FLAG_KEY = 'after-test-key';
+        const PROVIDER_NAME = 'after-provider-name';
+        const VALUE = 1;
+        const hook = new MetricsHook();
+        const mockHookContext: HookContext = {
+          flagKey: FLAG_KEY,
+          providerMetadata: {
+            name: PROVIDER_NAME,
+          },
+        } as HookContext;
+        const evaluationDetails: EvaluationDetails<number> = {
+          value: VALUE,
+          reason: StandardResolutionReasons.STATIC,
+        } as EvaluationDetails<number>;
+
+        hook.after(mockHookContext, evaluationDetails);
+        const result = await reader.collect();
+        expect(
+          hasDataPointMatching(
+            result.resourceMetrics.scopeMetrics,
+            SUCCESS_TOTAL_NAME,
+            1,
+            (point) =>
+              point.value === 1 &&
+              point.attributes.key === FLAG_KEY &&
+              point.attributes.provider === PROVIDER_NAME &&
+              point.attributes.variant === VALUE.toString() &&
+              point.attributes.reason === StandardResolutionReasons.STATIC
+          )
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe(MetricsHook.prototype.finally, () => {
+    it('should decrement evaluation_success_total and set attrs', async () => {
+      const FLAG_KEY = 'finally-test-key';
+      const PROVIDER_NAME = 'finally-provider-name';
+      const hook = new MetricsHook();
+      const mockHookContext: HookContext = {
+        flagKey: FLAG_KEY,
+        providerMetadata: {
+          name: PROVIDER_NAME,
+        },
+      } as HookContext;
+
+      hook.finally(mockHookContext);
+      const result = await reader.collect();
+      expect(
+        hasDataPointMatching(
+          result.resourceMetrics.scopeMetrics,
+          ACTIVE_COUNT_NAME,
+          1,
+          (point) =>
+            point.value === -1 && point.attributes.key === FLAG_KEY && point.attributes.provider === PROVIDER_NAME
+        )
+      ).toBeTruthy();
+    });
+  });
+
+  describe(MetricsHook.prototype.error, () => {
+    it('should decrement evaluation_success_total and set attrs', async () => {
+      const FLAG_KEY = 'error-test-key';
+      const PROVIDER_NAME = 'error-provider-name';
+      const ERROR_MESSAGE = 'error message';
+      const error = new Error(ERROR_MESSAGE);
+      const hook = new MetricsHook();
+      const mockHookContext: HookContext = {
+        flagKey: FLAG_KEY,
+        providerMetadata: {
+          name: PROVIDER_NAME,
+        },
+      } as HookContext;
+
+      hook.error(mockHookContext, error);
+      const result = await reader.collect();
+      expect(
+        hasDataPointMatching(
+          result.resourceMetrics.scopeMetrics,
+          ERROR_TOTAL_NAME,
+          0,
+          (point) =>
+            point.value === 1 && point.attributes.key === FLAG_KEY && point.attributes.provider === PROVIDER_NAME
+        )
+      ).toBeTruthy();
+    });
+  });
+});
+
+const hasDataPointMatching = (
+  scopeMetrics: ScopeMetrics[],
+  metricName: string,
+  dataPointIndex: number,
+  dataPointMatcher: (dataPoint: DataPoint<number>) => boolean
+) => {
+  const found = scopeMetrics.find((sm) =>
+    sm.metrics.find((m) => {
+      const point = m.dataPoints[dataPointIndex] as DataPoint<number>;
+      if (point) {
+        return m.descriptor.name === metricName && dataPointMatcher(point);
+      }
+    })
+  );
+  if (!found) {
+    throw Error('Unable to find matching datapoint');
+  }
+  return found;
+};

--- a/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.ts
+++ b/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.ts
@@ -1,0 +1,83 @@
+import {
+  BeforeHookContext,
+  StandardResolutionReasons,
+  type EvaluationDetails,
+  type FlagValue,
+  type Hook,
+  type HookContext,
+} from '@openfeature/js-sdk';
+import { Counter, UpDownCounter, ValueType, metrics } from '@opentelemetry/api';
+import { ACTIVE_COUNT_NAME, ERROR_TOTAL_NAME, REQUESTS_TOTAL_NAME, SUCCESS_TOTAL_NAME } from '../constants';
+
+type EvaluationAttributes = Pick<EvaluationDetails<FlagValue>, 'variant' | 'reason'> & {
+  key: string;
+  provider: string;
+};
+type ErrorEvaluationAttributes = EvaluationAttributes & { exception: string };
+
+const METER_NAME = 'js.openfeature.dev';
+
+const ACTIVE_DESCRIPTION = 'active flag evaluations counter';
+const REQUESTS_DESCRIPTION = 'feature flag evaluation request counter';
+const SUCCESS_DESCRIPTION = 'feature flag evaluation success counter';
+const ERROR_DESCRIPTION = 'feature flag evaluation error counter';
+
+export class MetricsHook implements Hook {
+  private readonly evaluationActiveUpDownCounter: UpDownCounter<EvaluationAttributes>;
+  private readonly evaluationRequestCounter: Counter<EvaluationAttributes>;
+  private readonly evaluationSuccessCounter: Counter<EvaluationAttributes>;
+  private readonly evaluationErrorCounter: Counter<ErrorEvaluationAttributes>;
+
+  constructor() {
+    const meter = metrics.getMeter(METER_NAME);
+    this.evaluationActiveUpDownCounter = meter.createUpDownCounter(ACTIVE_COUNT_NAME, {
+      description: ACTIVE_DESCRIPTION,
+      valueType: ValueType.INT,
+    });
+    this.evaluationRequestCounter = meter.createCounter(REQUESTS_TOTAL_NAME, {
+      description: REQUESTS_DESCRIPTION,
+      valueType: ValueType.INT,
+    });
+    this.evaluationSuccessCounter = meter.createCounter(SUCCESS_TOTAL_NAME, {
+      description: SUCCESS_DESCRIPTION,
+      valueType: ValueType.INT,
+    });
+    this.evaluationErrorCounter = meter.createCounter(ERROR_TOTAL_NAME, {
+      description: ERROR_DESCRIPTION,
+      valueType: ValueType.INT,
+    });
+  }
+
+  before(hookContext: BeforeHookContext) {
+    const attributes = {
+      key: hookContext.flagKey,
+      provider: hookContext.providerMetadata.name,
+    };
+    this.evaluationActiveUpDownCounter.add(1, attributes);
+    this.evaluationRequestCounter.add(1, attributes);
+  }
+
+  after(hookContext: Readonly<HookContext<FlagValue>>, evaluationDetails: EvaluationDetails<FlagValue>) {
+    this.evaluationSuccessCounter.add(1, {
+      key: hookContext.flagKey,
+      provider: hookContext.providerMetadata.name,
+      variant: evaluationDetails.variant ?? evaluationDetails.value?.toString(),
+      reason: evaluationDetails.reason ?? StandardResolutionReasons.UNKNOWN,
+    });
+  }
+
+  error(hookContext: Readonly<HookContext<FlagValue>>, error: unknown) {
+    this.evaluationErrorCounter.add(1, {
+      key: hookContext.flagKey,
+      provider: hookContext.providerMetadata.name,
+      exception: (error as Error)?.message || 'Unknown error',
+    });
+  }
+
+  finally(hookContext: Readonly<HookContext<FlagValue>>) {
+    this.evaluationActiveUpDownCounter.add(-1, {
+      key: hookContext.flagKey,
+      provider: hookContext.providerMetadata.name,
+    });
+  }
+}

--- a/libs/hooks/open-telemetry/src/lib/traces/index.ts
+++ b/libs/hooks/open-telemetry/src/lib/traces/index.ts
@@ -1,0 +1,1 @@
+export * from './tracing-hook';

--- a/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.spec.ts
+++ b/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.spec.ts
@@ -3,7 +3,7 @@ import { EvaluationDetails, HookContext } from '@openfeature/js-sdk';
 const addEvent = jest.fn();
 const recordException = jest.fn();
 
-const getActiveSpan = jest.fn<any, any>(() => ({ addEvent, recordException }));
+const getActiveSpan = jest.fn<unknown, unknown[]>(() => ({ addEvent, recordException }));
 
 jest.mock('@opentelemetry/api', () => ({
   trace: {
@@ -12,7 +12,7 @@ jest.mock('@opentelemetry/api', () => ({
 }));
 
 // Import must be after the mocks
-import { OpenTelemetryHook } from './open-telemetry-hook';
+import { TracingHook } from './tracing-hook';
 
 describe('OpenTelemetry Hooks', () => {
   const hookContext: HookContext = {
@@ -32,10 +32,10 @@ describe('OpenTelemetry Hooks', () => {
     logger: console,
   };
 
-  let otelHook: OpenTelemetryHook;
+  let otelHook: TracingHook;
 
   beforeEach(() => {
-    otelHook = new OpenTelemetryHook();
+    otelHook = new TracingHook();
   });
 
   afterEach(() => {

--- a/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.ts
+++ b/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.ts
@@ -1,17 +1,14 @@
 import { Hook, HookContext, EvaluationDetails, FlagValue } from '@openfeature/js-sdk';
 import { trace } from '@opentelemetry/api';
+import { FEATURE_FLAG } from '../constants';
 
-const eventName = 'feature_flag';
 const spanEventProperties = Object.freeze({
-  FLAG_KEY: 'feature_flag.key',
-  PROVIDER_NAME: 'feature_flag.provider_name',
-  VARIANT: 'feature_flag.variant',
+  FLAG_KEY: `${FEATURE_FLAG}.key`,
+  PROVIDER_NAME: `${FEATURE_FLAG}.provider_name`,
+  VARIANT: `${FEATURE_FLAG}.variant`,
 });
 
-/**
- * @deprecated OpenTelemetryHook (and this package) will be deprecated. Please use TracingHook from `@openfeature/open-telemetry-hooks`
- */
-export class OpenTelemetryHook implements Hook {
+export class TracingHook implements Hook {
   after(hookContext: HookContext, evaluationDetails: EvaluationDetails<FlagValue>) {
     const currentTrace = trace.getActiveSpan();
     if (currentTrace) {
@@ -25,7 +22,7 @@ export class OpenTelemetryHook implements Hook {
         }
       }
 
-      currentTrace.addEvent(eventName, {
+      currentTrace.addEvent(FEATURE_FLAG, {
         [spanEventProperties.FLAG_KEY]: hookContext.flagKey,
         [spanEventProperties.PROVIDER_NAME]: hookContext.providerMetadata.name,
         [spanEventProperties.VARIANT]: variant,

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@nx/web": "16.2.2",
         "@nx/workspace": "16.2.2",
         "@openfeature/js-sdk": "^1.3.1",
+        "@opentelemetry/sdk-metrics": "^1.15.0",
         "@swc-node/register": "~1.6.0",
         "@swc/cli": "~0.1.62",
         "@swc/core": "~1.3.51",
@@ -3110,6 +3111,69 @@
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.0.tgz",
+      "integrity": "sha512-GGTS6BytfaN8OgbCUOnxg/a9WVsVUj0484zXHZuBzvIXx7V4Tmkb0IHnnhS7Q0cBLNLgjNuvrCpQaP8fIvO4bg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.15.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.0.tgz",
+      "integrity": "sha512-Sb8A6ZXHXDlgHv32UNRE3y8McWE3vkb5dsSttYArYa5ZpwjiF5ge0vnnKUUnG7bY0AgF9VBIOORZE8gsrnD2WA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.15.0",
+        "@opentelemetry/semantic-conventions": "1.15.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.15.0.tgz",
+      "integrity": "sha512-fFUnAcPvlXO39nlIduGuaeCuiZyFtSLCn9gW/0djFRO5DFst4m4gcT6+llXvNWuUvtGB49s56NP10B9IZRN0Rw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.15.0",
+        "@opentelemetry/resources": "1.15.0",
+        "lodash.merge": "^4.6.2",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.0.tgz",
+      "integrity": "sha512-f3wwFrFyCpGrFBrFs7lCUJSCSCGyeKG52c+EKeobs3Dd29M75yO6GYkt6PkYPfDawxSlV5p+4yJPPk8tPObzTQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -14737,6 +14801,48 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA=="
+    },
+    "@opentelemetry/core": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.0.tgz",
+      "integrity": "sha512-GGTS6BytfaN8OgbCUOnxg/a9WVsVUj0484zXHZuBzvIXx7V4Tmkb0IHnnhS7Q0cBLNLgjNuvrCpQaP8fIvO4bg==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/semantic-conventions": "1.15.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@opentelemetry/resources": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.0.tgz",
+      "integrity": "sha512-Sb8A6ZXHXDlgHv32UNRE3y8McWE3vkb5dsSttYArYa5ZpwjiF5ge0vnnKUUnG7bY0AgF9VBIOORZE8gsrnD2WA==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/core": "1.15.0",
+        "@opentelemetry/semantic-conventions": "1.15.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@opentelemetry/sdk-metrics": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.15.0.tgz",
+      "integrity": "sha512-fFUnAcPvlXO39nlIduGuaeCuiZyFtSLCn9gW/0djFRO5DFst4m4gcT6+llXvNWuUvtGB49s56NP10B9IZRN0Rw==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/core": "1.15.0",
+        "@opentelemetry/resources": "1.15.0",
+        "lodash.merge": "^4.6.2",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.0.tgz",
+      "integrity": "sha512-f3wwFrFyCpGrFBrFs7lCUJSCSCGyeKG52c+EKeobs3Dd29M75yO6GYkt6PkYPfDawxSlV5p+4yJPPk8tPObzTQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
     },
     "@parcel/watcher": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@nx/web": "16.2.2",
     "@nx/workspace": "16.2.2",
     "@openfeature/js-sdk": "^1.3.1",
+    "@opentelemetry/sdk-metrics": "^1.15.0",
     "@swc-node/register": "~1.6.0",
     "@swc/cli": "~0.1.62",
     "@swc/core": "~1.3.51",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,7 @@
       "prerelease": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "versioning": "default",
-      "extra-files": ["src/lib/open-telemetry-hook.ts"]
+      "versioning": "default"
     },
     "libs/providers/go-feature-flag": {
       "release-type": "node",


### PR DESCRIPTION
* add metrics hook
* rename open-telemetry hook to tracing hook


----

We should also merge [this](https://github.com/open-feature/js-sdk-contrib/pull/449) first, to provide a deprecation warning for the old package/hook.

Fixes: https://github.com/open-feature/js-sdk-contrib/issues/447