### PR TITLE
fix: deprecate otel hook

### DIFF
--- a/libs/hooks/open-telemetry/README.md
+++ b/libs/hooks/open-telemetry/README.md
@@ -1,4 +1,4 @@
-:warning: This package will be deprecated. Please use TracingHook from `@openfeature/open-telemetry-hooks`.
+:warning: This package will be deprecated. Please use the telemetry hooks package from `@openfeature/open-telemetry-hooks`.
 
 # OpenTelemetry Hook
 

--- a/libs/hooks/open-telemetry/README.md
+++ b/libs/hooks/open-telemetry/README.md
@@ -1,3 +1,5 @@
+:warning: This package will be deprecated. Please use TracingHook from `@openfeature/open-telemetry-hooks`.
+
 # OpenTelemetry Hook
 
 The OpenTelemetry hook for OpenFeature provides a [spec compliant][otel-spec] way to automatically add a feature flag evaluation to a span as a span event. Since feature flags are dynamic and affect runtime behavior, it’s important to collect relevant feature flag telemetry signals. This can be used to determine the impact a feature has on a request, enabling enhanced observability use cases, such as A/B testing or progressive feature releases.

--- a/libs/hooks/open-telemetry/src/lib/open-telemetry-hook.ts
+++ b/libs/hooks/open-telemetry/src/lib/open-telemetry-hook.ts
@@ -8,6 +8,9 @@ const spanEventProperties = Object.freeze({
   VARIANT: 'feature_flag.variant',
 });
 
+/**
+ * @deprecated OpenTelemetryHook (and this package) will be deprecated. Please use TracingHook from `@openfeature/open-telemetry-hooks`
+ */
 export class OpenTelemetryHook implements Hook {
   after(hookContext: HookContext, evaluationDetails: EvaluationDetails<FlagValue>) {
     const currentTrace = trace.getActiveSpan();


### PR DESCRIPTION
Giving some warning and redirecting people to the new package.

See discussion [here](https://github.com/open-feature/js-sdk-contrib/issues/447#issuecomment-1625550744).