### PR TITLE
feat!: events, init, shutdown

### DIFF
--- a/libs/providers/flagd/README.md
+++ b/libs/providers/flagd/README.md
@@ -50,6 +50,18 @@ Options can be defined in the constructor or as environment variables, with cons
   }))
 ```
 
+### Supported events
+
+The flagd provider emits `PROVIDER_READY`, `PROVIDER_ERROR` and `PROVIDER_CONFIGURATION_CHANGED` events.
+
+| SDK event                        | Originating action in flagd                                                     |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| `PROVIDER_READY`                 | The streaming connection with flagd has been established.                       |
+| `PROVIDER_ERROR`                 | The streaming connection with flagd has been broken.                            |
+| `PROVIDER_CONFIGURATION_CHANGED` | A flag configuration (default value, targeting rule, etc) in flagd has changed. |
+
+For general information on events, see the [official documentation](https://openfeature.dev/docs/reference/concepts/events).
+
 ## Building
 
 Run `nx package providers-flagd` to build the library.

--- a/libs/providers/flagd/package.json
+++ b/libs/providers/flagd/package.json
@@ -7,6 +7,6 @@
   },
   "peerDependencies": {
     "@grpc/grpc-js": "^1.6.0",
-    "@openfeature/js-sdk": "^1.1.0"
+    "@openfeature/js-sdk": ">=1.3.0"
   }
 }

--- a/libs/providers/flagd/src/lib/flagd-provider.spec.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.spec.ts
@@ -114,7 +114,7 @@ describe(FlagdProvider.name, () => {
     beforeEach(() => {
       // inject our mock GRPCService and ServiceClient
       OpenFeature.setProvider('basic test',
-        new FlagdProvider(undefined, new GRPCService({ host: '', port: 123, tls: false }, basicServiceClientMock))
+        new FlagdProvider(undefined, undefined, new GRPCService({ host: '', port: 123, tls: false }, basicServiceClientMock))
       );
       client = OpenFeature.getClient('basic test');
     });
@@ -237,7 +237,7 @@ describe(FlagdProvider.name, () => {
     beforeEach(() => {
       // inject our mock GRPCService and ServiceClient
       OpenFeature.setProvider('zero test',
-        new FlagdProvider(undefined, new GRPCService({ host: '', port: 123, tls: false }, basicServiceClientMock))
+        new FlagdProvider(undefined, undefined, new GRPCService({ host: '', port: 123, tls: false }, basicServiceClientMock))
       );
       client = OpenFeature.getClient('zero test');
     });
@@ -341,6 +341,7 @@ describe(FlagdProvider.name, () => {
       it(`should call ${ServiceClient.prototype.eventStream} and register onMessageHandler`, (done) => {
         new FlagdProvider(
           undefined,
+          undefined,
           new GRPCService({ host: '', port: 123, tls: false, cache: 'lru' }, streamingServiceClientMock)
         ).initialize().then(() => {
           try {
@@ -361,6 +362,7 @@ describe(FlagdProvider.name, () => {
       beforeAll(() => {
         OpenFeature.setProvider('change events test',
           new FlagdProvider(
+            undefined,
             undefined,
             new GRPCService({ host: '', port: 123, tls: false, cache: 'lru' }, streamingServiceClientMock)
           )
@@ -409,6 +411,7 @@ describe(FlagdProvider.name, () => {
         OpenFeature.setProvider('streaming test',
           new FlagdProvider(
             undefined,
+            undefined,
             new GRPCService({ host: '', port: 123, tls: false, cache: 'lru' }, streamingServiceClientMock)
           )
         );
@@ -438,6 +441,7 @@ describe(FlagdProvider.name, () => {
       beforeAll(() => {
         OpenFeature.setProvider('cache invalidation',
           new FlagdProvider(
+            undefined,
             undefined,
             new GRPCService({ host: '', port: 123, tls: false, cache: 'lru' }, streamingServiceClientMock)
           )
@@ -527,6 +531,7 @@ describe(FlagdProvider.name, () => {
       it('should attempt to inital connection multiple times', (done) => {
         const provider = new FlagdProvider(
           undefined,
+          undefined,
           new GRPCService({ host: '', port: 123, tls: false, cache: 'lru' }, streamingServiceClientMock)
         );
         provider.initialize();
@@ -556,6 +561,7 @@ describe(FlagdProvider.name, () => {
 
       it('should attempt re-connection multiple times', (done) => {
         const provider = new FlagdProvider(
+          undefined,
           undefined,
           new GRPCService({ host: '', port: 123, tls: false, cache: 'lru' }, streamingServiceClientMock)
         );
@@ -628,7 +634,7 @@ describe(FlagdProvider.name, () => {
     beforeEach(() => {
       // inject our mock GRPCService and ServiceClient
       OpenFeature.setProvider('errors test',
-        new FlagdProvider(undefined, new GRPCService({ host: '', port: 123, tls: false }, errServiceClientMock))
+        new FlagdProvider(undefined, undefined, new GRPCService({ host: '', port: 123, tls: false }, errServiceClientMock))
       );
       client = OpenFeature.getClient('errors test');
     });
@@ -706,7 +712,7 @@ describe(FlagdProvider.name, () => {
 
     beforeEach(() => {
       OpenFeature.setProvider('shutdown test',
-        new FlagdProvider(undefined, new GRPCService({ host: '', port: 123, tls: false }, errServiceClientMock))
+        new FlagdProvider(undefined, undefined, new GRPCService({ host: '', port: 123, tls: false }, errServiceClientMock))
       );
     });
 

--- a/libs/providers/flagd/src/lib/flagd-provider.spec.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.spec.ts
@@ -66,7 +66,7 @@ describe(FlagdProvider.name, () => {
     const basicServiceClientMock: ServiceClient = {
       eventStream: jest.fn(() => {
         return {
-          on: jest.fn((event: string, callback: (message: any) => void) => {
+          on: jest.fn((event: string, callback: (message: unknown) => void) => {
             if (event === 'data') {
               callback({ type: EVENT_PROVIDER_READY });
             }

--- a/libs/providers/flagd/src/lib/flagd-provider.spec.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.spec.ts
@@ -193,7 +193,7 @@ describe(FlagdProvider.name, () => {
     const basicServiceClientMock: ServiceClient = {
       eventStream: jest.fn(() => {
         return {
-          on: jest.fn((event: string, callback: (message: any) => void) => {
+          on: jest.fn((event: string, callback: (message: unknown) => void) => {
             if (event === 'data') {
               callback({ type: EVENT_PROVIDER_READY });
             }
@@ -305,7 +305,7 @@ describe(FlagdProvider.name, () => {
     // ref to callback to fire to fake messages to flagd
     let registeredOnMessageCallback: (message: EventStreamResponse) => void;
     const streamMock = {
-      on: jest.fn((event: string, callback: (message?: any) => void) => {
+      on: jest.fn((event: string, callback: (message?: unknown) => void) => {
         if (event === 'data') {
           registeredOnMessageCallback = callback;
         } else if (event === 'error') {
@@ -603,7 +603,7 @@ describe(FlagdProvider.name, () => {
     const errServiceClientMock: ServiceClient = {
       eventStream: jest.fn(() => {
         return {
-          on: jest.fn((event: string, callback: (message: any) => void) => {
+          on: jest.fn((event: string, callback: (message: unknown) => void) => {
             if (event === 'data') {
               callback({ type: EVENT_PROVIDER_READY });
             }
@@ -692,14 +692,13 @@ describe(FlagdProvider.name, () => {
   });
 
   describe('shutdown', () => {
-    let client: Client;
     const closeMock = jest.fn();
 
     // mock ServiceClient to inject
     const errServiceClientMock: ServiceClient = {
       eventStream: jest.fn(() => {
         return {
-          on: jest.fn((event: string, callback: (message: any) => void) => {
+          on: jest.fn((event: string, callback: (message: unknown) => void) => {
             if (event === 'data') {
               callback({ type: EVENT_PROVIDER_READY });
             }

--- a/libs/providers/flagd/src/lib/flagd-provider.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.ts
@@ -29,10 +29,17 @@ export class FlagdProvider implements Provider {
   private _status = ProviderStatus.NOT_READY;
   private _events = new OpenFeatureEventEmitter();
 
+  /**
+   * Construct a new flagd provider.
+   * 
+   * @param options options, see {@link FlagdProviderOptions}
+   * @param logger optional logger, see {@link Logger}
+   * @param service optional internal service implementation, should not be needed for production
+   */
   constructor(
     options?: FlagdProviderOptions,
-    service?: Service,
     private logger?: Logger,
+    service?: Service,
   ) {
     this._service = service ? service : new GRPCService(getConfig(options), undefined, logger);
   }

--- a/libs/providers/flagd/src/lib/flagd-provider.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.ts
@@ -1,4 +1,13 @@
-import { EvaluationContext, JsonValue, Logger, OpenFeatureEventEmitter, Provider, ProviderEvents, ProviderStatus, ResolutionDetails } from '@openfeature/js-sdk';
+import {
+  EvaluationContext,
+  JsonValue,
+  Logger,
+  OpenFeatureEventEmitter,
+  Provider,
+  ProviderEvents,
+  ProviderStatus,
+  ResolutionDetails,
+} from '@openfeature/js-sdk';
 import { FlagdProviderOptions, getConfig } from './configuration';
 import { GRPCService } from './service/grpc/service';
 import { Service } from './service/service';
@@ -17,34 +26,41 @@ export class FlagdProvider implements Provider {
   }
 
   private readonly _service: Service;
-  private _status = ProviderStatus.NOT_READY; 
+  private _status = ProviderStatus.NOT_READY;
   private _events = new OpenFeatureEventEmitter();
 
-  constructor(options?: FlagdProviderOptions, service?: Service, private logger?: Logger) {
+  constructor(
+    options?: FlagdProviderOptions,
+    service?: Service,
+    private logger?: Logger,
+  ) {
     this._service = service ? service : new GRPCService(getConfig(options), undefined, logger);
   }
 
   initialize(): Promise<void> {
-    return this._service.connect(this.setReady.bind(this), this.emitChanged.bind(this), this.setError.bind(this)).then(() => {
-      this.logger?.debug(`${this.metadata.name}: ready`);
-      this._status = ProviderStatus.READY;
-    }).catch((err) => {
-      this._status = ProviderStatus.ERROR;
-      this.logger?.error(`${this.metadata.name}: error during initialization: ${err.message}, ${err.stack}`);
-      throw err;
-    });
+    return this._service
+      .connect(this.setReady.bind(this), this.emitChanged.bind(this), this.setError.bind(this))
+      .then(() => {
+        this.logger?.debug(`${this.metadata.name}: ready`);
+        this._status = ProviderStatus.READY;
+      })
+      .catch((err) => {
+        this._status = ProviderStatus.ERROR;
+        this.logger?.error(`${this.metadata.name}: error during initialization: ${err.message}, ${err.stack}`);
+        throw err;
+      });
   }
 
   onClose(): Promise<void> {
-    this.logger?.debug(`${this.metadata.name}: shutting down`)
-    return this._service.disconnect();  
+    this.logger?.debug(`${this.metadata.name}: shutting down`);
+    return this._service.disconnect();
   }
 
   resolveBooleanEvaluation(
     flagKey: string,
     _: boolean,
     transformedContext: EvaluationContext,
-    logger: Logger
+    logger: Logger,
   ): Promise<ResolutionDetails<boolean>> {
     return this._service
       .resolveBoolean(flagKey, transformedContext, logger)
@@ -55,7 +71,7 @@ export class FlagdProvider implements Provider {
     flagKey: string,
     _: string,
     transformedContext: EvaluationContext,
-    logger: Logger
+    logger: Logger,
   ): Promise<ResolutionDetails<string>> {
     return this._service
       .resolveString(flagKey, transformedContext, logger)
@@ -66,7 +82,7 @@ export class FlagdProvider implements Provider {
     flagKey: string,
     _: number,
     transformedContext: EvaluationContext,
-    logger: Logger
+    logger: Logger,
   ): Promise<ResolutionDetails<number>> {
     return this._service
       .resolveNumber(flagKey, transformedContext, logger)
@@ -77,7 +93,7 @@ export class FlagdProvider implements Provider {
     flagKey: string,
     _: T,
     transformedContext: EvaluationContext,
-    logger: Logger
+    logger: Logger,
   ): Promise<ResolutionDetails<T>> {
     return this._service
       .resolveObject<T>(flagKey, transformedContext, logger)

--- a/libs/providers/flagd/src/lib/service/grpc/service.ts
+++ b/libs/providers/flagd/src/lib/service/grpc/service.ts
@@ -194,7 +194,7 @@ export class GRPCService implements Service {
   }
 
   private handleError(
-    reject: (reason?: any) => void,
+    reject: (reason?: Error) => void,
     connectCallback: () => void,
     changedCallback: (flagsChanged: string[]) => void,
     disconnectCallback: () => void,
@@ -253,7 +253,7 @@ export class GRPCService implements Service {
     return 0;
   };
 
-  private async resolve<T extends FlagValue, Rq extends AnyRequest, Rs extends AnyResponse>(
+  private async resolve<T extends FlagValue>(
     promise: (
       request: AnyRequest,
       callback: (error: ServiceError | null, response: AnyResponse) => void,

--- a/libs/providers/flagd/src/lib/service/grpc/service.ts
+++ b/libs/providers/flagd/src/lib/service/grpc/service.ts
@@ -1,4 +1,4 @@
-import * as grpc from '@grpc/grpc-js';
+import { ClientReadableStream, ClientUnaryCall, ServiceError, credentials, status } from '@grpc/grpc-js';
 import {
   EvaluationContext,
   FlagNotFoundError,
@@ -9,13 +9,10 @@ import {
   ParseError,
   ResolutionDetails,
   StandardResolutionReasons,
-  TypeMismatchError
+  TypeMismatchError,
 } from '@openfeature/js-sdk';
-import { GrpcTransport } from '@protobuf-ts/grpc-transport';
-import type { UnaryCall } from '@protobuf-ts/runtime-rpc';
-import { RpcError } from '@protobuf-ts/runtime-rpc';
 import { LRUCache } from 'lru-cache';
-import { Struct } from '../../../proto/ts/google/protobuf/struct';
+import { promisify } from 'util';
 import {
   EventStreamResponse,
   ResolveBooleanRequest,
@@ -27,16 +24,16 @@ import {
   ResolveObjectRequest,
   ResolveObjectResponse,
   ResolveStringRequest,
-  ResolveStringResponse
+  ResolveStringResponse,
+  ServiceClient,
 } from '../../../proto/ts/schema/v1/schema';
-import { ServiceClient } from '../../../proto/ts/schema/v1/schema.client';
 import { Config } from '../../configuration';
 import {
   BASE_EVENT_STREAM_RETRY_BACKOFF_MS,
   DEFAULT_MAX_CACHE_SIZE,
   DEFAULT_MAX_EVENT_STREAM_RETRIES,
   EVENT_CONFIGURATION_CHANGE,
-  EVENT_PROVIDER_READY
+  EVENT_PROVIDER_READY,
 } from '../../constants';
 import { FlagdProvider } from '../../flagd-provider';
 import { Service } from '../service';
@@ -78,6 +75,7 @@ export class GRPCService implements Service {
   private _cacheEnabled = false;
   private _streamAlive = false;
   private _streamConnectAttempt = 0;
+  private _stream: ClientReadableStream<EventStreamResponse> | undefined = undefined;
   private _streamConnectBackoff = BASE_EVENT_STREAM_RETRY_BACKOFF_MS;
   private _maxEventStreamRetries;
   private get _cacheActive() {
@@ -85,33 +83,44 @@ export class GRPCService implements Service {
     return this._cacheEnabled && this._streamAlive;
   }
 
-  // default to false here - reassigned in the constructor if we actaully need to connect
-  readonly streamConnection = Promise.resolve(false);
-
-  constructor(config: Config, client?: ServiceClient, private logger?: Logger) {
+  constructor(
+    config: Config,
+    client?: ServiceClient,
+    private logger?: Logger,
+  ) {
     const { host, port, tls, socketPath } = config;
     this._maxEventStreamRetries = config.maxEventStreamRetries ?? DEFAULT_MAX_EVENT_STREAM_RETRIES;
     this._client = client
       ? client
       : new ServiceClient(
-          new GrpcTransport({
-            host: socketPath ? `unix://${socketPath}` : `${host}:${port}`,
-            channelCredentials: tls ? grpc.credentials.createSsl() : grpc.credentials.createInsecure(),
-          })
+          socketPath ? `unix://${socketPath}` : `${host}:${port}`,
+          tls ? credentials.createSsl() : credentials.createInsecure(),
         );
 
     // for now, we only need streaming if the cache is enabled (will need to be pulled out once we support events)
     if (config.cache === 'lru') {
       this._cacheEnabled = true;
       this._cache = new LRUCache({ maxSize: config.maxCacheSize || DEFAULT_MAX_CACHE_SIZE, sizeCalculation: () => 1 });
-      this.streamConnection = this.connectStream();
     }
+  }
+
+  connect(
+    connectCallback: () => void,
+    changedCallback: (flagsChanged: string[]) => void,
+    disconnectCallback: () => void,
+  ): Promise<void> {
+    return this.connectStream(connectCallback, changedCallback, disconnectCallback);
+  }
+
+  disconnect(): Promise<void> {
+    this._stream?.destroy();
+    return Promise.resolve();
   }
 
   async resolveBoolean(
     flagKey: string,
     context: EvaluationContext,
-    logger: Logger
+    logger: Logger,
   ): Promise<ResolutionDetails<boolean>> {
     return this.resolve(this._client.resolveBoolean, flagKey, context, logger, this.booleanParser);
   }
@@ -127,56 +136,70 @@ export class GRPCService implements Service {
   async resolveObject<T extends JsonValue>(
     flagKey: string,
     context: EvaluationContext,
-    logger: Logger
+    logger: Logger,
   ): Promise<ResolutionDetails<T>> {
     return this.resolve(this._client.resolveObject, flagKey, context, logger, this.objectParser);
   }
 
-  private connectStream(): Promise<boolean> {
+  private connectStream(
+    connectCallback: () => void,
+    changedCallback: (flagsChanged: string[]) => void,
+    disconnectCallback: () => void,
+  ): Promise<void> {
     return new Promise((resolve, reject) => {
       this.logger?.debug(`${FlagdProvider.name}: connecting stream, attempt ${this._streamConnectAttempt}...`);
       const stream = this._client.eventStream({});
-      stream.responses.onError(() => {
-        this.handleError(reject);
+      stream.on('error', () => {
+        this.handleError(reject, connectCallback, changedCallback, disconnectCallback);
       });
-      stream.responses.onComplete(() => {
-        this.handleComplete();
+      stream.on('close', () => {
+        this.handleClose();
       });
-      stream.responses.onMessage((message) => {
+      stream.on('data', (message) => {
         if (message.type === EVENT_PROVIDER_READY) {
-          this.handleProviderReady(resolve);
+          this.handleProviderReady(resolve, connectCallback);
         } else if (message.type === EVENT_CONFIGURATION_CHANGE) {
-          this.handleFlagsChanged(message);
+          this.handleFlagsChanged(message, changedCallback);
         }
       });
+      this._stream = stream;
     });
   }
 
-  private handleProviderReady(resolve: (value: boolean | PromiseLike<boolean>) => void) {
+  private handleProviderReady(resolve: () => void, connectCallback: () => void) {
+    connectCallback();
     this.logger?.info(`${FlagdProvider.name}: streaming connection established with flagd`);
     this._streamAlive = true;
     this._streamConnectAttempt = 0;
     this._streamConnectBackoff = BASE_EVENT_STREAM_RETRY_BACKOFF_MS;
-    resolve(true);
+    resolve();
   }
 
-  private handleFlagsChanged(message: EventStreamResponse) {
+  private handleFlagsChanged(message: EventStreamResponse, changedCallback: (flagsChanged: string[]) => void) {
     if (message.data) {
-      const data = Struct.toJson(message.data);
+      const data = message.data;
       this.logger?.debug(`${FlagdProvider.name}: got message: ${JSON.stringify(data, undefined, 2)}`);
       if (data && typeof data === 'object' && 'flags' in data && data?.['flags']) {
         const flagChangeMessage = data as FlagChangeMessage;
+        const flagsChanged: string[] = Object.keys(flagChangeMessage.flags || []);
         // remove each changed key from cache
-        Object.keys(flagChangeMessage.flags || []).forEach((key) => {
+        flagsChanged.forEach((key) => {
           if (this._cache?.delete(key)) {
             this.logger?.debug(`${FlagdProvider.name}: evicted key: ${key} from cache.`);
           }
         });
+        changedCallback(flagsChanged);
       }
     }
   }
 
-  private handleError(reject: (reason?: any) => void) {
+  private handleError(
+    reject: (reason?: any) => void,
+    connectCallback: () => void,
+    changedCallback: (flagsChanged: string[]) => void,
+    disconnectCallback: () => void,
+  ) {
+    disconnectCallback();
     this.logger?.error(`${FlagdProvider.name}: streaming connection error, will attempt reconnect...`);
     this._cache?.clear();
     this._streamAlive = false;
@@ -186,7 +209,7 @@ export class GRPCService implements Service {
       this._streamConnectAttempt++;
       setTimeout(() => {
         this._streamConnectBackoff = this._streamConnectBackoff * 2;
-        this.connectStream();
+        this.connectStream(connectCallback, changedCallback, disconnectCallback);
       }, this._streamConnectBackoff);
     } else {
       // after max attempts, give up
@@ -196,47 +219,51 @@ export class GRPCService implements Service {
     }
   }
 
-  private handleComplete() {
+  private handleClose() {
     this.logger?.info(`${FlagdProvider.name}: streaming connection closed gracefully`);
     this._cache?.clear();
     this._streamAlive = false;
   }
 
-  private objectParser = (struct: Struct) => {
+  private objectParser = (struct: unknown): unknown => {
     if (struct) {
-      return Struct.toJson(struct);
+      return struct;
     }
-    return {}
+    return {};
   };
 
-  private booleanParser = (value: boolean) => {
+  private booleanParser = (value: boolean): boolean => {
     if (value) {
       return value;
     }
-    return false
+    return false;
   };
 
-  private stringParser = (value: string) => {
+  private stringParser = (value: string): string => {
     if (value) {
       return value;
     }
-    return ''
+    return '';
   };
 
-  private numberParser = (value: number) => {
+  private numberParser = (value: number): number => {
     if (value) {
       return value;
     }
-    return 0
+    return 0;
   };
 
   private async resolve<T extends FlagValue, Rq extends AnyRequest, Rs extends AnyResponse>(
-    resolver: (request: AnyRequest) => UnaryCall<Rq, Rs>,
+    promise: (
+      request: AnyRequest,
+      callback: (error: ServiceError | null, response: AnyResponse) => void,
+    ) => ClientUnaryCall,
     flagKey: string,
     context: EvaluationContext,
     logger: Logger,
-    parser?: (value: any) => any
+    parser?: (value: any) => any,
   ): Promise<ResolutionDetails<T>> {
+    const resolver = promisify(promise);
     if (this._cacheActive) {
       const cached = this._cache?.get(flagKey);
       if (cached) {
@@ -245,8 +272,8 @@ export class GRPCService implements Service {
     }
 
     // invoke the passed resolver method
-    const { response } = await resolver
-      .call(this._client, { flagKey, context: this.convertContext(context, logger) })
+    const response = await resolver
+      .call(this._client, { flagKey, context })
       .then((resolved) => resolved, this.onRejected);
 
     const resolved = {
@@ -254,41 +281,28 @@ export class GRPCService implements Service {
       value: parser ? parser.call(this, response.value) : response.value,
       reason: response.reason,
       variant: response.variant,
-    } as ResolutionDetails<T>;
+    };
 
     if (this._cacheActive && response.reason === StandardResolutionReasons.STATIC) {
       // cache this static value
-      this._cache?.set(flagKey, { ...resolved });
+      this._cache?.set(flagKey, resolved);
     }
     return resolved;
   }
 
-  private convertContext(context: EvaluationContext, logger: Logger): Struct {
-    try {
-      // stringify to remove invalid js props
-      return Struct.fromJsonString(JSON.stringify(context));
-    } catch (e) {
-      const message = 'Error serializing context.';
-      const error = e as Error;
-      logger.error(`${message}: ${error?.message}`);
-      logger.error(error?.stack);
-      throw new ParseError(message);
-    }
-  }
-
-  private onRejected = (err: RpcError) => {
+  private onRejected = (err: ServiceError | undefined) => {
     // map the errors
     switch (err?.code) {
-      case Codes.DataLoss:
-        throw new ParseError(err.message);
-      case Codes.InvalidArgument:
-        throw new TypeMismatchError(err.message);
-      case Codes.NotFound:
-        throw new FlagNotFoundError(err.message);
-      case Codes.Unavailable:
-        throw new FlagNotFoundError(err.message);
+      case status.DATA_LOSS:
+        throw new ParseError(err.details);
+      case status.INVALID_ARGUMENT:
+        throw new TypeMismatchError(err.details);
+      case status.NOT_FOUND:
+        throw new FlagNotFoundError(err.details);
+      case status.UNAVAILABLE:
+        throw new FlagNotFoundError(err.details);
       default:
-        throw new GeneralError(err.message);
+        throw new GeneralError(err?.details);
     }
   };
 }

--- a/libs/providers/flagd/src/lib/service/service.ts
+++ b/libs/providers/flagd/src/lib/service/service.ts
@@ -1,14 +1,18 @@
-import {
-    EvaluationContext,
-    JsonValue,
-    Logger,
-    ResolutionDetails
-} from '@openfeature/js-sdk'
+import { EvaluationContext, JsonValue, Logger, ResolutionDetails } from '@openfeature/js-sdk';
 
 export interface Service {
-    readonly streamConnection: Promise<boolean>;
-    resolveBoolean(flagKey: string, context: EvaluationContext, logger: Logger): Promise<ResolutionDetails<boolean>>
-    resolveString(flagKey: string, context: EvaluationContext, logger: Logger): Promise<ResolutionDetails<string>>
-    resolveNumber(flagKey: string, context: EvaluationContext, logger: Logger): Promise<ResolutionDetails<number>>
-    resolveObject<T extends JsonValue>(flagKey: string, context: EvaluationContext, logger: Logger): Promise<ResolutionDetails<T>>
+  connect(
+    reconnectCallback: () => void,
+    changedCallback: (flagsChanged: string[]) => void,
+    disconnectCallback: () => void,
+  ): Promise<void>;
+  disconnect(): Promise<void>;
+  resolveBoolean(flagKey: string, context: EvaluationContext, logger: Logger): Promise<ResolutionDetails<boolean>>;
+  resolveString(flagKey: string, context: EvaluationContext, logger: Logger): Promise<ResolutionDetails<string>>;
+  resolveNumber(flagKey: string, context: EvaluationContext, logger: Logger): Promise<ResolutionDetails<number>>;
+  resolveObject<T extends JsonValue>(
+    flagKey: string,
+    context: EvaluationContext,
+    logger: Logger,
+  ): Promise<ResolutionDetails<T>>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@protobuf-ts/grpc-transport": "^2.9.0",
         "@protobuf-ts/runtime-rpc": "^2.9.0",
         "@swc/helpers": "~0.5.0",
+        "abort-controller": "^3.0.0",
         "axios": "1.4.0",
         "configcat-js": "^8.0.0",
         "copy-anything": "^3.0.5",
@@ -24,6 +25,7 @@
         "lodash.isempty": "^4.4.0",
         "lodash.isequal": "^4.5.0",
         "lru-cache": "^10.0.0",
+        "node-abort-controller": "^3.1.1",
         "object-hash": "^3.0.0",
         "tslib": "2.6.0"
       },
@@ -4221,6 +4223,17 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.9.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
@@ -6617,6 +6630,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -9114,6 +9135,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
     },
     "node_modules/node-addon-api": {
       "version": "3.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@protobuf-ts/grpc-transport": "^2.9.0",
         "@protobuf-ts/runtime-rpc": "^2.9.0",
         "@swc/helpers": "~0.5.0",
-        "abort-controller": "^3.0.0",
         "axios": "1.4.0",
         "configcat-js": "^8.0.0",
         "copy-anything": "^3.0.5",
@@ -25,7 +24,6 @@
         "lodash.isempty": "^4.4.0",
         "lodash.isequal": "^4.5.0",
         "lru-cache": "^10.0.0",
-        "node-abort-controller": "^3.1.1",
         "object-hash": "^3.0.0",
         "tslib": "2.6.0"
       },
@@ -4223,17 +4221,6 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.9.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
@@ -6630,14 +6617,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -9135,11 +9114,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
-    },
-    "node_modules/node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
     },
     "node_modules/node-addon-api": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@protobuf-ts/grpc-transport": "^2.9.0",
     "@protobuf-ts/runtime-rpc": "^2.9.0",
     "@swc/helpers": "~0.5.0",
-    "abort-controller": "^3.0.0",
     "axios": "1.4.0",
     "configcat-js": "^8.0.0",
     "copy-anything": "^3.0.5",
@@ -28,7 +27,6 @@
     "lodash.isempty": "^4.4.0",
     "lodash.isequal": "^4.5.0",
     "lru-cache": "^10.0.0",
-    "node-abort-controller": "^3.1.1",
     "object-hash": "^3.0.0",
     "tslib": "2.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@protobuf-ts/grpc-transport": "^2.9.0",
     "@protobuf-ts/runtime-rpc": "^2.9.0",
     "@swc/helpers": "~0.5.0",
+    "abort-controller": "^3.0.0",
     "axios": "1.4.0",
     "configcat-js": "^8.0.0",
     "copy-anything": "^3.0.5",
@@ -27,6 +28,7 @@
     "lodash.isempty": "^4.4.0",
     "lodash.isequal": "^4.5.0",
     "lru-cache": "^10.0.0",
+    "node-abort-controller": "^3.1.1",
     "object-hash": "^3.0.0",
     "tslib": "2.6.0"
   },
@@ -69,4 +71,3 @@
     "typescript": "5.1.6"
   }
 }
-


### PR DESCRIPTION
This PR:

- absorbs changes related to updating our proto generation plugin
- adds change events when change messages received from flagd
- adds shutdown

:warning: depends on https://github.com/open-feature/schemas/pull/99 (must be merged first). Will keep this as draft until then.

Fixes: https://github.com/open-feature/js-sdk-contrib/issues/382