### PR TITLE
fix: add status to flagd web

### DIFF
--- a/libs/providers/flagd-web/src/lib/flagd-web-provider.spec.ts
+++ b/libs/providers/flagd-web/src/lib/flagd-web-provider.spec.ts
@@ -193,6 +193,14 @@ describe(FlagdWebProvider.name, () => {
 
     describe(ProviderEvents.Ready, () => {
       it('should fire as soon as client subscribes, if ready', (done) => {
+        try {
+          // should start NOT_READY
+          expect(provider.status).toEqual(ProviderStatus.NOT_READY);
+          done();
+        } catch (err) {
+          done(err);
+        }
+
         mockCallbackClient.mockMessage({
           type: EVENT_PROVIDER_READY,
         });
@@ -208,6 +216,14 @@ describe(FlagdWebProvider.name, () => {
       });
 
       it('should fire and be ready if message received', (done) => {
+        try {
+          // should start NOT_READY
+          expect(provider.status).toEqual(ProviderStatus.NOT_READY);
+          done();
+        } catch (err) {
+          done(err);
+        }
+
         client.addHandler(ProviderEvents.Ready, () => {
           try {
             expect(provider.status).toEqual(ProviderStatus.READY);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bufbuild/connect-web": "^0.11.0",
         "@bufbuild/protobuf": "^1.2.0",
         "@grpc/grpc-js": "^1.8.20",
-        "@openfeature/web-sdk": "^0.3.6-experimental",
+        "@openfeature/web-sdk": "^0.3.10-experimental",
         "@opentelemetry/api": "^1.3.0",
         "@protobuf-ts/grpc-transport": "^2.9.0",
         "@protobuf-ts/runtime-rpc": "^2.9.0",
@@ -3131,9 +3131,9 @@
       }
     },
     "node_modules/@openfeature/web-sdk": {
-      "version": "0.3.6-experimental",
-      "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-0.3.6-experimental.tgz",
-      "integrity": "sha512-Pj8j4rz99uhV6V1eGSgogt+kOx6r7TiWG9Y2TP1yYKi1c0IwsdsqRXK2J65DkPTpmcxW94y5WHjNbcOqwnoiLw=="
+      "version": "0.3.10-experimental",
+      "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-0.3.10-experimental.tgz",
+      "integrity": "sha512-WZp3MhhycHJFX9PM11quEcA8PEfI7PMkHYucvqxcbgYxpwF84T7KytppJ+Jkr6ErrwYbczWNAmlPOD4kEGZR0w=="
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@bufbuild/connect-web": "^0.11.0",
     "@bufbuild/protobuf": "^1.2.0",
     "@grpc/grpc-js": "^1.8.20",
-    "@openfeature/web-sdk": "^0.3.6-experimental",
+    "@openfeature/web-sdk": "^0.3.10-experimental",
     "@opentelemetry/api": "^1.3.0",
     "@protobuf-ts/grpc-transport": "^2.9.0",
     "@protobuf-ts/runtime-rpc": "^2.9.0",


### PR DESCRIPTION
Adds status to flagd web, adds provider scoping to unit tests to reduce interference.

Fixes: https://github.com/open-feature/js-sdk-contrib/issues/490