### PR TITLE
fix: [GO Feature Flag server] handle PROVIDER_NOT_READY from the spec

### DIFF
--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.spec.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.spec.ts
@@ -190,7 +190,6 @@ describe('GoFeatureFlagProvider', () => {
       const flagName = 'random-flag';
       const targetingKey = 'user-key';
       const dns = `${endpoint}v1/feature/${flagName}/eval`;
-      const apiKey = 'valid-api-key';
 
       axiosMock.onPost(dns).reply(200, {
         value: true,

--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
@@ -272,6 +272,16 @@ export class GoFeatureFlagProvider implements Provider {
     user: GoFeatureFlagUser,
     expectedType: string
   ): Promise<ResolutionDetails<T>> {
+    // Check if the provider is ready to serve
+    if(this._status === ProviderStatus.NOT_READY){
+      return {
+        value: defaultValue,
+        reason: StandardResolutionReasons.ERROR,
+        errorCode: ErrorCode.PROVIDER_NOT_READY,
+        errorMessage: `Provider in a status that does not allow to serve flag: ${this.status}`,
+      };
+    }
+
     const cacheKey = `${flagKey}-${user.key}`;
     // check if flag is available in the cache
     if (this.cache !== undefined) {


### PR DESCRIPTION
## This PR
- Return an error if we try to evaluate before the provider is ready.
- Rewrite the tests to use the SDK and not test only the provider.


