### PR TITLE
chore: fix submodule race

### DIFF
--- a/libs/providers/flagd-web/project.json
+++ b/libs/providers/flagd-web/project.json
@@ -20,7 +20,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "git submodule update --init --recursive",
+          "git submodule update --init schemas",
           "rm -f -r ./src/proto",
           "cd schemas && buf generate buf.build/open-feature/flagd --template protobuf/buf.gen.ts-connect.yaml",
           "mv -v ./proto ./src"

--- a/libs/providers/flagd/project.json
+++ b/libs/providers/flagd/project.json
@@ -20,7 +20,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "git submodule update --init --recursive",
+          "git submodule update --init schemas",
           "rm -f -r ./src/proto",
           "cd schemas && buf generate buf.build/open-feature/flagd --template protobuf/buf.gen.ts.yaml",
           "mv -v ./proto ./src"


### PR DESCRIPTION
This fixes a race condition in the build/test/lint which is caused by simultaneously and recursively pulling submodules.

This fix is to just pull the relevant submodule per component.