### PR TITLE
feat: add custom attrs to traces

### DIFF
--- a/libs/hooks/open-telemetry/README.md
+++ b/libs/hooks/open-telemetry/README.md
@@ -66,10 +66,12 @@ const client = OpenFeature.getClient('my-app');
 client.addHooks(new MetricsHook());
 ```
 
-### Custom Metric Attributes
+### Custom Attributes
 
-Custom attributes can be extracted from [flag metadata](https://openfeature.dev/specification/types#flag-metadata) by supplying a `attributeMapper` in the `MetricsHookOptions`.
-These will be added to the `feature_flag.evaluation_success_total` metric.
+Custom attributes can be extracted from [flag metadata](https://openfeature.dev/specification/types#flag-metadata) by supplying a `attributeMapper` in the `MetricsHookOptions` or `TracingHookOptions`.
+
+In the case of the `MetricsHook`, these will be added to the `feature_flag.evaluation_success_total` metric.
+The `TracingHook` adds them as [span event attributes](https://opentelemetry.io/docs/instrumentation/ruby/manual/#add-span-events).
 
 ```typescript
 // configure an attributeMapper function for a custom property
@@ -78,7 +80,8 @@ const attributeMapper: AttributeMapper = (flagMetadata) => {
         myCustomAttribute: flagMetadata.someFlagMetadataField,
     };
 };
-const hook = new MetricsHook({ attributeMapper });
+const metricsHook = new MetricsHook({ attributeMapper });
+const tracingHook = new TracingHook({ attributeMapper });
 ```
 
 ## Development

--- a/libs/hooks/open-telemetry/README.md
+++ b/libs/hooks/open-telemetry/README.md
@@ -71,7 +71,7 @@ client.addHooks(new MetricsHook());
 Custom attributes can be extracted from [flag metadata](https://openfeature.dev/specification/types#flag-metadata) by supplying a `attributeMapper` in the `MetricsHookOptions` or `TracingHookOptions`.
 
 In the case of the `MetricsHook`, these will be added to the `feature_flag.evaluation_success_total` metric.
-The `TracingHook` adds them as [span event attributes](https://opentelemetry.io/docs/instrumentation/ruby/manual/#add-span-events).
+The `TracingHook` adds them as [span event attributes](https://opentelemetry.io/docs/instrumentation/js/manual/#span-events).
 
 ```typescript
 // configure an attributeMapper function for a custom property

--- a/libs/hooks/open-telemetry/src/lib/conventions.ts
+++ b/libs/hooks/open-telemetry/src/lib/conventions.ts
@@ -1,3 +1,4 @@
+
 // see: https://opentelemetry.io/docs/specs/otel/logs/semantic_conventions/feature-flags/
 export const FEATURE_FLAG = 'feature_flag';
 export const EXCEPTION_ATTR = 'exception'

--- a/libs/hooks/open-telemetry/src/lib/conventions.ts
+++ b/libs/hooks/open-telemetry/src/lib/conventions.ts
@@ -1,4 +1,3 @@
-
 // see: https://opentelemetry.io/docs/specs/otel/logs/semantic_conventions/feature-flags/
 export const FEATURE_FLAG = 'feature_flag';
 export const EXCEPTION_ATTR = 'exception'

--- a/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.spec.ts
+++ b/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.spec.ts
@@ -225,7 +225,7 @@ describe(MetricsHook.name, () => {
         } as EvaluationDetails<number>;
 
         // configure a mapper that throws
-        const attributeMapper: AttributeMapper = (flagMetadata) => {
+        const attributeMapper: AttributeMapper = (_) => {
           throw new Error('fake error');
         };
         const hook = new MetricsHook({ attributeMapper });

--- a/libs/hooks/open-telemetry/src/lib/otel-hook.ts
+++ b/libs/hooks/open-telemetry/src/lib/otel-hook.ts
@@ -1,0 +1,30 @@
+import { FlagMetadata, Logger } from '@openfeature/js-sdk';
+import { Attributes } from '@opentelemetry/api';
+
+export type AttributeMapper = (flagMetadata: FlagMetadata) => Attributes;
+
+export type OpenTelemetryHookOptions = {
+  /**
+   * A function that maps OpenFeature flag metadata values to OpenTelemetry attributes.
+   */
+  attributeMapper?: AttributeMapper;
+};
+
+/**
+ * Base class that does some logging and safely wraps the AttributeMapper.
+ */
+export abstract class OpenTelemetryHook {
+  protected safeAttributeMapper: AttributeMapper;
+  protected abstract name: string;
+
+  constructor(options?: OpenTelemetryHookOptions, logger?: Logger) {
+    this.safeAttributeMapper = (flagMetadata: FlagMetadata) => {
+      try {
+        return options?.attributeMapper?.(flagMetadata) || {};
+      } catch (err) {
+        logger?.debug(`${this.name}: error in attributeMapper, ${err.message}, ${err.stack}`);
+        return {};
+      }
+    };
+  }
+}

--- a/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.spec.ts
+++ b/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.spec.ts
@@ -19,7 +19,7 @@ describe('OpenTelemetry Hooks', () => {
     flagKey: 'testFlagKey',
     clientMetadata: {
       providerMetadata: {
-        name: "fake"
+        name: 'fake',
       },
       name: 'testClient',
     },
@@ -32,76 +32,151 @@ describe('OpenTelemetry Hooks', () => {
     logger: console,
   };
 
-  let otelHook: TracingHook;
-
-  beforeEach(() => {
-    otelHook = new TracingHook();
-  });
+  let tracingHook: TracingHook;
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   describe('after stage', () => {
-    it('should use the variant value on the span event', () => {
-      const evaluationDetails: EvaluationDetails<boolean> = {
-        flagKey: hookContext.flagKey,
-        value: true,
-        variant: 'enabled',
-        flagMetadata: {}
-      };
+    describe('no attribute mapper', () => {
+      beforeEach(() => {
+        tracingHook = new TracingHook();
+      });
 
-      otelHook.after(hookContext, evaluationDetails);
-
-      expect(addEvent).toBeCalledWith('feature_flag', {
-        'feature_flag.key': 'testFlagKey',
-        'feature_flag.provider_name': 'testProvider',
-        'feature_flag.variant': 'enabled',
+      it('should use the variant value on the span event', () => {
+        const evaluationDetails: EvaluationDetails<boolean> = {
+          flagKey: hookContext.flagKey,
+          value: true,
+          variant: 'enabled',
+          flagMetadata: {},
+        };
+  
+        tracingHook.after(hookContext, evaluationDetails);
+  
+        expect(addEvent).toBeCalledWith('feature_flag', {
+          'feature_flag.key': 'testFlagKey',
+          'feature_flag.provider_name': 'testProvider',
+          'feature_flag.variant': 'enabled',
+        });
+      });
+  
+      it('should use a stringified value as the variant value on the span event', () => {
+        const evaluationDetails: EvaluationDetails<boolean> = {
+          flagKey: hookContext.flagKey,
+          value: true,
+          flagMetadata: {},
+        };
+  
+        tracingHook.after(hookContext, evaluationDetails);
+  
+        expect(addEvent).toBeCalledWith('feature_flag', {
+          'feature_flag.key': 'testFlagKey',
+          'feature_flag.provider_name': 'testProvider',
+          'feature_flag.variant': 'true',
+        });
+      });
+  
+      it('should set the value without extra quotes if value is already a string', () => {
+        const evaluationDetails: EvaluationDetails<string> = {
+          flagKey: hookContext.flagKey,
+          value: 'already-string',
+          flagMetadata: {},
+        };
+        tracingHook.after(hookContext, evaluationDetails);
+  
+        expect(addEvent).toBeCalledWith('feature_flag', {
+          'feature_flag.key': 'testFlagKey',
+          'feature_flag.provider_name': 'testProvider',
+          'feature_flag.variant': 'already-string',
+        });
+      });
+  
+      it('should not call addEvent because there is no active span', () => {
+        getActiveSpan.mockReturnValueOnce(undefined);
+        const evaluationDetails: EvaluationDetails<boolean> = {
+          flagKey: hookContext.flagKey,
+          value: true,
+          variant: 'enabled',
+          flagMetadata: {},
+        };
+  
+        tracingHook.after(hookContext, evaluationDetails);
+        expect(addEvent).not.toBeCalled();
       });
     });
 
-    it('should use a stringified value as the variant value on the span event', () => {
-      const evaluationDetails: EvaluationDetails<boolean> = {
-        flagKey: hookContext.flagKey,
-        value: true,
-        flagMetadata: {},
-      };
+    describe('attribute mapper configured', () => {
+      describe('no error in mapper', () => {
 
-      otelHook.after(hookContext, evaluationDetails);
+        beforeEach(() => {
+          tracingHook = new TracingHook({
+            attributeMapper: (flagMetadata) => {
+              return {
+                customAttr1: flagMetadata.metadata1,
+                customAttr2: flagMetadata.metadata2,
+                customAttr3: flagMetadata.metadata3,
+              };
+            },
+          });
+        });
 
-      expect(addEvent).toBeCalledWith('feature_flag', {
-        'feature_flag.key': 'testFlagKey',
-        'feature_flag.provider_name': 'testProvider',
-        'feature_flag.variant': 'true',
+        it('should run the attribute mapper to add custom attributes, if set', () => {
+          const evaluationDetails: EvaluationDetails<boolean> = {
+            flagKey: hookContext.flagKey,
+            value: true,
+            variant: 'enabled',
+            flagMetadata: {
+              metadata1: 'one',
+              metadata2: 2,
+              metadata3: true,
+            },
+          };
+      
+          tracingHook.after(hookContext, evaluationDetails);
+    
+          expect(addEvent).toBeCalledWith('feature_flag', {
+            'feature_flag.key': 'testFlagKey',
+            'feature_flag.provider_name': 'testProvider',
+            'feature_flag.variant': 'enabled',
+            customAttr1: 'one',
+            customAttr2: 2,
+            customAttr3: true,
+          });
+        });
       });
-    });
 
-    it('should set the value without extra quotes if value is already a string', () => {
-      const evaluationDetails: EvaluationDetails<string> = {
-        flagKey: hookContext.flagKey,
-        value: 'already-string',
-        flagMetadata: {},
-      };
-      otelHook.after(hookContext, evaluationDetails);
+      describe('error in mapper', () => {
 
-      expect(addEvent).toBeCalledWith('feature_flag', {
-        'feature_flag.key': 'testFlagKey',
-        'feature_flag.provider_name': 'testProvider',
-        'feature_flag.variant': 'already-string',
+        beforeEach(() => {
+          tracingHook = new TracingHook({
+            attributeMapper: (flagMetadata) => {
+              throw new Error('fake error');
+            },
+          });
+        });
+
+        it('should no-op', () => {
+          const evaluationDetails: EvaluationDetails<boolean> = {
+            flagKey: hookContext.flagKey,
+            value: true,
+            variant: 'enabled',
+            flagMetadata: {
+              metadata1: 'one',
+              metadata2: 2,
+              metadata3: true,
+            },
+          };
+      
+          tracingHook.after(hookContext, evaluationDetails);
+    
+          expect(addEvent).toBeCalledWith('feature_flag', {
+            'feature_flag.key': 'testFlagKey',
+            'feature_flag.provider_name': 'testProvider',
+            'feature_flag.variant': 'enabled',
+          });
+        });
       });
-    });
-
-    it('should not call addEvent because there is no active span', () => {
-      getActiveSpan.mockReturnValueOnce(undefined);
-      const evaluationDetails: EvaluationDetails<boolean> = {
-        flagKey: hookContext.flagKey,
-        value: true,
-        variant: 'enabled',
-        flagMetadata: {},
-      };
-
-      otelHook.after(hookContext, evaluationDetails);
-      expect(addEvent).not.toBeCalled();
     });
   });
 
@@ -109,13 +184,13 @@ describe('OpenTelemetry Hooks', () => {
     const testError = new Error();
 
     it('should call recordException with a test error', () => {
-      otelHook.error(hookContext, testError);
+      tracingHook.error(hookContext, testError);
       expect(recordException).toBeCalledWith(testError);
     });
 
     it('should not call recordException because there is no active span', () => {
       getActiveSpan.mockReturnValueOnce(undefined);
-      otelHook.error(hookContext, testError);
+      tracingHook.error(hookContext, testError);
       expect(recordException).not.toBeCalled();
     });
   });

--- a/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.spec.ts
+++ b/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.spec.ts
@@ -150,7 +150,7 @@ describe('OpenTelemetry Hooks', () => {
 
         beforeEach(() => {
           tracingHook = new TracingHook({
-            attributeMapper: (flagMetadata) => {
+            attributeMapper: (_) => {
               throw new Error('fake error');
             },
           });

--- a/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.ts
+++ b/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.ts
@@ -1,8 +1,22 @@
-import { Hook, HookContext, EvaluationDetails, FlagValue } from '@openfeature/js-sdk';
+import { Hook, HookContext, EvaluationDetails, FlagValue, Logger } from '@openfeature/js-sdk';
 import { trace } from '@opentelemetry/api';
 import { FEATURE_FLAG, KEY_ATTR, PROVIDER_NAME_ATTR, VARIANT_ATTR } from '../conventions';
+import { OpenTelemetryHook, OpenTelemetryHookOptions } from '../otel-hook';
 
-export class TracingHook implements Hook {
+export type TracingHookOptions = OpenTelemetryHookOptions;
+
+/**
+ * A hook that adds conventionally-compliant span events to feature flag evaluations.
+ * 
+ * See {@link https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/feature-flags/}
+ */
+export class TracingHook extends OpenTelemetryHook implements Hook {
+  protected name = TracingHook.name;
+
+  constructor(options?: TracingHookOptions, logger?: Logger) {
+    super(options, logger);
+  }
+
   after(hookContext: HookContext, evaluationDetails: EvaluationDetails<FlagValue>) {
     const currentTrace = trace.getActiveSpan();
     if (currentTrace) {
@@ -20,6 +34,7 @@ export class TracingHook implements Hook {
         [KEY_ATTR]: hookContext.flagKey,
         [PROVIDER_NAME_ATTR]: hookContext.providerMetadata.name,
         [VARIANT_ATTR]: variant,
+        ...this.safeAttributeMapper(evaluationDetails.flagMetadata),
       });
     }
   }


### PR DESCRIPTION
This PR: 

- adds custom attrs to the `TracesHook`, similarly to what we have in the `MetricsHook`
- adds tests, and reformats tests
- adds js-doc