### PR TITLE
chore: Disable NX update via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,9 +9,8 @@
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": ["^@nrwl/"],
-      "matchPackageNames": ["nx"],
-      "groupName": "NX"
+      "matchPackagePatterns": ["^@nx/", "nx"],
+      "enabled": false
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
## This PR

-  Disable NX update via Renovate

### Notes

NX upgrades require a migration process that can't easily be handled by renovate.

https://nx.dev/core-features/automate-updating-dependencies



