### PR TITLE
chore!: use @openfeature/server-sdk peer

### DIFF
--- a/libs/hooks/open-telemetry/README.md
+++ b/libs/hooks/open-telemetry/README.md
@@ -15,7 +15,7 @@ $ npm install @openfeature/open-telemetry-hooks
 Confirm that the following peer dependencies are installed.
 
 ```
-$ npm install @openfeature/js-sdk @opentelemetry/api
+$ npm install @openfeature/server-sdk @opentelemetry/api
 ```
 
 ## Hooks
@@ -47,7 +47,7 @@ The `TracingHook` and `MetricsHook` can both be set on the OpenFeature singleton
 This will ensure that every flag evaluation will always generate the applicable telemetry signals.
 
 ```typescript
-import { OpenFeature } from '@openfeature/js-sdk';
+import { OpenFeature } from '@openfeature/server-sdk';
 import { TracingHook } from '@openfeature/open-telemetry-hooks';
 
 OpenFeature.addHooks(new TracingHook());
@@ -59,7 +59,7 @@ OpenFeature.addHooks(new TracingHook());
  Setting the hook on the client will ensure that every flag evaluation performed by this client will always generate the applicable telemetry signals.
 
 ```typescript
-import { OpenFeature } from '@openfeature/js-sdk';
+import { OpenFeature } from '@openfeature/server-sdk';
 import { MetricsHook } from '@openfeature/open-telemetry-hooks';
 
 const client = OpenFeature.getClient('my-app');

--- a/libs/hooks/open-telemetry/package.json
+++ b/libs/hooks/open-telemetry/package.json
@@ -14,7 +14,7 @@
     "current-version": "echo $npm_package_version"
   },
   "peerDependencies": {
-    "@openfeature/js-sdk": "^1.0.0",
+    "@openfeature/server-sdk": "^1.6.0",
     "@opentelemetry/api": ">=1.3.0"
   },
   "license": "Apache-2.0"

--- a/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.spec.ts
+++ b/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.spec.ts
@@ -1,4 +1,4 @@
-import { BeforeHookContext, EvaluationDetails, HookContext, StandardResolutionReasons } from '@openfeature/js-sdk';
+import { BeforeHookContext, EvaluationDetails, HookContext, StandardResolutionReasons } from '@openfeature/server-sdk';
 import opentelemetry from '@opentelemetry/api';
 import { DataPoint, MeterProvider, MetricReader, ScopeMetrics } from '@opentelemetry/sdk-metrics';
 import {

--- a/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.ts
+++ b/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.ts
@@ -6,7 +6,7 @@ import {
   type FlagValue,
   type Hook,
   type HookContext
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 import { Attributes, Counter, UpDownCounter, ValueType, metrics } from '@opentelemetry/api';
 import {
   ACTIVE_COUNT_NAME,

--- a/libs/hooks/open-telemetry/src/lib/otel-hook.ts
+++ b/libs/hooks/open-telemetry/src/lib/otel-hook.ts
@@ -1,4 +1,4 @@
-import { FlagMetadata, Logger } from '@openfeature/js-sdk';
+import { FlagMetadata, Logger } from '@openfeature/server-sdk';
 import { Attributes } from '@opentelemetry/api';
 
 export type AttributeMapper = (flagMetadata: FlagMetadata) => Attributes;

--- a/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.spec.ts
+++ b/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.spec.ts
@@ -1,4 +1,4 @@
-import { EvaluationDetails, HookContext } from '@openfeature/js-sdk';
+import { EvaluationDetails, HookContext } from '@openfeature/server-sdk';
 
 const addEvent = jest.fn();
 const recordException = jest.fn();

--- a/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.ts
+++ b/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.ts
@@ -1,4 +1,4 @@
-import { Hook, HookContext, EvaluationDetails, FlagValue, Logger } from '@openfeature/js-sdk';
+import { Hook, HookContext, EvaluationDetails, FlagValue, Logger } from '@openfeature/server-sdk';
 import { trace } from '@opentelemetry/api';
 import { FEATURE_FLAG, KEY_ATTR, PROVIDER_NAME_ATTR, VARIANT_ATTR } from '../conventions';
 import { OpenTelemetryHook, OpenTelemetryHookOptions } from '../otel-hook';

--- a/libs/providers/config-cat/README.md
+++ b/libs/providers/config-cat/README.md
@@ -12,12 +12,12 @@ $ npm install @openfeature/config-cat-provider
 
 The OpenFeature SDK is required as peer dependency.
 
-The minimum required version of `@openfeature/js-sdk` currently is `1.3.0`.
+The minimum required version of `@openfeature/server-sdk` currently is `1.6.0`.
 
 The minimum required version of `configcat-js` currently is `8.0.0`.
 
 ```
-$ npm install @openfeature/js-sdk configcat-js
+$ npm install @openfeature/server-sdk configcat-js
 ```
 
 ## Usage

--- a/libs/providers/config-cat/package.json
+++ b/libs/providers/config-cat/package.json
@@ -6,7 +6,7 @@
     "current-version": "echo $npm_package_version"
   },
   "peerDependencies": {
-    "@openfeature/js-sdk": "^1.3.0",
+    "@openfeature/server-sdk": "^1.6.0",
     "configcat-js": "^8.0.0"
   }
 }

--- a/libs/providers/config-cat/src/lib/config-cat-provider.spec.ts
+++ b/libs/providers/config-cat/src/lib/config-cat-provider.spec.ts
@@ -1,5 +1,5 @@
 import { ConfigCatProvider } from './config-cat-provider';
-import { ParseError, ProviderEvents, ProviderStatus, TypeMismatchError } from '@openfeature/js-sdk';
+import { ParseError, ProviderEvents, ProviderStatus, TypeMismatchError } from '@openfeature/server-sdk';
 import {
   createConsoleLogger,
   createFlagOverridesFromMap,

--- a/libs/providers/config-cat/src/lib/config-cat-provider.ts
+++ b/libs/providers/config-cat/src/lib/config-cat-provider.ts
@@ -11,7 +11,7 @@ import {
   ResolutionReason,
   StandardResolutionReasons,
   TypeMismatchError,
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 import { getClient, IConfig, IConfigCatClient, IEvaluationDetails, SettingValue } from 'configcat-js';
 import { transformContext } from './context-transformer';
 

--- a/libs/providers/config-cat/src/lib/context-transformer.spec.ts
+++ b/libs/providers/config-cat/src/lib/context-transformer.spec.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext, TargetingKeyMissingError } from '@openfeature/js-sdk';
+import { EvaluationContext, TargetingKeyMissingError } from '@openfeature/server-sdk';
 import { transformContext } from './context-transformer';
 
 describe('context-transformer', () => {

--- a/libs/providers/config-cat/src/lib/context-transformer.ts
+++ b/libs/providers/config-cat/src/lib/context-transformer.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext, EvaluationContextValue, TargetingKeyMissingError } from '@openfeature/js-sdk';
+import { EvaluationContext, EvaluationContextValue, TargetingKeyMissingError } from '@openfeature/server-sdk';
 import { User as ConfigCatUser } from 'configcat-common/lib/RolloutEvaluator';
 
 function contextValueToString(contextValue: EvaluationContextValue): string | undefined {

--- a/libs/providers/env-var/README.md
+++ b/libs/providers/env-var/README.md
@@ -15,7 +15,7 @@ $ npm install @openfeature/env-var-provider
 Required peer dependencies
 
 ```
-$ npm install @openfeature/js-sdk
+$ npm install @openfeature/server-sdk
 ```
 
 ## Usage

--- a/libs/providers/env-var/package.json
+++ b/libs/providers/env-var/package.json
@@ -6,6 +6,6 @@
     "current-version": "echo $npm_package_version"
   },
   "peerDependencies": {
-    "@openfeature/js-sdk": "^1.0.0"
+    "@openfeature/server-sdk": "^1.6.0"
   }
 }

--- a/libs/providers/env-var/src/lib/env-var-provider.spec.ts
+++ b/libs/providers/env-var/src/lib/env-var-provider.spec.ts
@@ -1,4 +1,4 @@
-import { FlagNotFoundError, ParseError } from '@openfeature/js-sdk';
+import { FlagNotFoundError, ParseError } from '@openfeature/server-sdk';
 import { EnvVarProvider } from './env-var-provider';
 
 describe('Environment Variable Provider', () => {

--- a/libs/providers/env-var/src/lib/env-var-provider.ts
+++ b/libs/providers/env-var/src/lib/env-var-provider.ts
@@ -5,7 +5,7 @@ import {
   Provider,
   ResolutionDetails,
   StandardResolutionReasons,
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 import { constantCase } from './constant-case';
 
 export type Config = {

--- a/libs/providers/flagd/README.md
+++ b/libs/providers/flagd/README.md
@@ -13,7 +13,7 @@ $ npm install @openfeature/flagd-provider
 Required peer dependencies
 
 ```
-$ npm install @openfeature/js-sdk
+$ npm install @openfeature/server-sdk
 ```
 
 ## Usage

--- a/libs/providers/flagd/package.json
+++ b/libs/providers/flagd/package.json
@@ -7,6 +7,6 @@
   },
   "peerDependencies": {
     "@grpc/grpc-js": "^1.6.0",
-    "@openfeature/js-sdk": ">=1.3.0"
+    "@openfeature/server-sdk": ">=1.6.0"
   }
 }

--- a/libs/providers/flagd/src/e2e/setup.ts
+++ b/libs/providers/flagd/src/e2e/setup.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { OpenFeature } from '@openfeature/js-sdk';
+import { OpenFeature } from '@openfeature/server-sdk';
 import { FlagdProvider } from '../lib/flagd-provider';
 
 const FLAGD_NAME = 'flagd Provider';

--- a/libs/providers/flagd/src/e2e/step-definitions/evaluation.spec.ts
+++ b/libs/providers/flagd/src/e2e/step-definitions/evaluation.spec.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext, EvaluationDetails, JsonObject, JsonValue, OpenFeature, ProviderEvents, ResolutionDetails, StandardResolutionReasons } from '@openfeature/js-sdk';
+import { EvaluationContext, EvaluationDetails, JsonObject, JsonValue, OpenFeature, ProviderEvents, ResolutionDetails, StandardResolutionReasons } from '@openfeature/server-sdk';
 import { defineFeature, loadFeature } from 'jest-cucumber';
 
 // load the feature file.

--- a/libs/providers/flagd/src/lib/flagd-provider.spec.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.spec.ts
@@ -8,7 +8,7 @@ import {
   ProviderEvents,
   ProviderStatus,
   StandardResolutionReasons
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 import type { UnaryCall } from '@protobuf-ts/runtime-rpc';
 import {
   EventStreamResponse,

--- a/libs/providers/flagd/src/lib/flagd-provider.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.ts
@@ -7,7 +7,7 @@ import {
   ProviderEvents,
   ProviderStatus,
   ResolutionDetails,
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 import { FlagdProviderOptions, getConfig } from './configuration';
 import { GRPCService } from './service/grpc/grpc-service';
 import { Service } from './service/service';

--- a/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
+++ b/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
@@ -10,7 +10,7 @@ import {
   ResolutionDetails,
   StandardResolutionReasons,
   TypeMismatchError,
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 import { LRUCache } from 'lru-cache';
 import { promisify } from 'util';
 import {

--- a/libs/providers/flagd/src/lib/service/service.ts
+++ b/libs/providers/flagd/src/lib/service/service.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext, JsonValue, Logger, ResolutionDetails } from '@openfeature/js-sdk';
+import { EvaluationContext, JsonValue, Logger, ResolutionDetails } from '@openfeature/server-sdk';
 
 export interface Service {
   connect(

--- a/libs/providers/go-feature-flag/README.md
+++ b/libs/providers/go-feature-flag/README.md
@@ -14,5 +14,5 @@ $ npm install @openfeature/go-feature-flag-provider
 Required peer dependencies
 
 ```
-$ npm install @openfeature/js-sdk
+$ npm install @openfeature/server-sdk
 ```

--- a/libs/providers/go-feature-flag/package.json
+++ b/libs/providers/go-feature-flag/package.json
@@ -6,6 +6,6 @@
     "current-version": "echo $npm_package_version"
   },
   "peerDependencies": {
-    "@openfeature/js-sdk": "^1.3.0"
+    "@openfeature/server-sdk": "^1.6.0"
   }
 }

--- a/libs/providers/go-feature-flag/src/lib/context-transfomer.spec.ts
+++ b/libs/providers/go-feature-flag/src/lib/context-transfomer.spec.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext } from '@openfeature/js-sdk';
+import { EvaluationContext } from '@openfeature/server-sdk';
 import { GoFeatureFlagUser } from './model';
 import { transformContext } from './context-transformer';
 

--- a/libs/providers/go-feature-flag/src/lib/context-transformer.ts
+++ b/libs/providers/go-feature-flag/src/lib/context-transformer.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext } from '@openfeature/js-sdk';
+import { EvaluationContext } from '@openfeature/server-sdk';
 import { sha1 } from 'object-hash';
 import { GoFeatureFlagUser } from './model';
 

--- a/libs/providers/go-feature-flag/src/lib/data-collector-hook.ts
+++ b/libs/providers/go-feature-flag/src/lib/data-collector-hook.ts
@@ -4,7 +4,7 @@ import {
   Hook,
   HookContext,
   HookHints, Logger, StandardResolutionReasons,
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 import {
   DataCollectorHookOptions,
   DataCollectorRequest,

--- a/libs/providers/go-feature-flag/src/lib/errors/proxyNotReady.ts
+++ b/libs/providers/go-feature-flag/src/lib/errors/proxyNotReady.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, OpenFeatureError } from '@openfeature/js-sdk'
+import { ErrorCode, OpenFeatureError } from '@openfeature/server-sdk'
 
 // ProxyNotReady is an error send when we try to call the relay proxy and he is not ready
 // to return a valid response.

--- a/libs/providers/go-feature-flag/src/lib/errors/proxyTimeout.ts
+++ b/libs/providers/go-feature-flag/src/lib/errors/proxyTimeout.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, OpenFeatureError } from '@openfeature/js-sdk'
+import { ErrorCode, OpenFeatureError } from '@openfeature/server-sdk'
 
 // ProxyTimeout is an error send when we try to call the relay proxy and he his not responding
 // in the appropriate time.

--- a/libs/providers/go-feature-flag/src/lib/errors/unauthorized.ts
+++ b/libs/providers/go-feature-flag/src/lib/errors/unauthorized.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, OpenFeatureError } from '@openfeature/js-sdk'
+import { ErrorCode, OpenFeatureError } from '@openfeature/server-sdk'
 
 // Unauthorized is an error sent when the provider makes an unauthorized call to the relay proxy.
 export class Unauthorized extends OpenFeatureError {

--- a/libs/providers/go-feature-flag/src/lib/errors/unknownError.ts
+++ b/libs/providers/go-feature-flag/src/lib/errors/unknownError.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, OpenFeatureError } from '@openfeature/js-sdk'
+import { ErrorCode, OpenFeatureError } from '@openfeature/server-sdk'
 
 // UnknownError is an error send when something unexpected happened.
 export class UnknownError extends OpenFeatureError {

--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.spec.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.spec.ts
@@ -7,7 +7,7 @@ import {
   OpenFeature,
   ProviderStatus,
   StandardResolutionReasons,
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import {GoFeatureFlagProvider} from './go-feature-flag-provider';

--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
@@ -10,7 +10,7 @@ import {
   ResolutionDetails,
   StandardResolutionReasons,
   TypeMismatchError,
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 import axios from 'axios';
 import {transformContext} from './context-transformer';
 import {ProxyNotReady} from './errors/proxyNotReady';

--- a/libs/providers/go-feature-flag/src/lib/model.ts
+++ b/libs/providers/go-feature-flag/src/lib/model.ts
@@ -1,7 +1,7 @@
 import {
   ErrorCode,
   EvaluationContextValue,
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 
 /**
  * GoFeatureFlagUser is the representation of a user for GO Feature Flag

--- a/libs/providers/in-memory/README.md
+++ b/libs/providers/in-memory/README.md
@@ -19,7 +19,7 @@ $ npm install @openfeature/in-memory-provider
 ### set up the provider with some flag values
 ```
 import { InMemoryProvider } from '@openfeature/in-memory-provider'
-import { OpenFeature } from '@openfeature/js-sdk'
+import { OpenFeature } from '@openfeature/server-sdk'
 
 const flags = {
   'a-boolean-flag': true,

--- a/libs/providers/in-memory/package.json
+++ b/libs/providers/in-memory/package.json
@@ -6,6 +6,6 @@
     "current-version": "echo $npm_package_version"
   },
   "peerDependencies": {
-    "@openfeature/js-sdk": "^1.3.0"
+    "@openfeature/server-sdk": "^1.6.0"
   }
 }

--- a/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.spec.ts
@@ -5,7 +5,7 @@ import {
   ResolutionDetails,
   StandardResolutionReasons,
   TypeMismatchError,
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 import { InMemoryProvider } from './in-memory-provider';
 
 describe(InMemoryProvider, () => {

--- a/libs/providers/in-memory/src/lib/in-memory-provider.ts
+++ b/libs/providers/in-memory/src/lib/in-memory-provider.ts
@@ -9,7 +9,7 @@ import {
   ResolutionDetails,
   StandardResolutionReasons,
   TypeMismatchError,
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 import { FlagConfiguration } from './flag-configuration';
 
 export class InMemoryProvider implements Provider {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@nx/rollup": "16.9.1",
         "@nx/web": "16.9.1",
         "@nx/workspace": "16.9.1",
-        "@openfeature/js-sdk": "^1.4.2",
+        "@openfeature/server-sdk": "^1.6.2",
         "@opentelemetry/sdk-metrics": "^1.15.0",
         "@swc-node/register": "~1.6.0",
         "@swc/cli": "~0.1.62",
@@ -3251,10 +3251,10 @@
         "yargs-parser": "21.1.1"
       }
     },
-    "node_modules/@openfeature/js-sdk": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@openfeature/js-sdk/-/js-sdk-1.4.2.tgz",
-      "integrity": "sha512-Qgi26g3r7agzeY9MqFttH8xFlliWf+fQwp3Y0UxaBAdLG4AguCtM7LHWfAXJBh1mIdxoepx1KEf5xzhC2f/BEQ==",
+    "node_modules/@openfeature/server-sdk": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.6.2.tgz",
+      "integrity": "sha512-GR4bDu+SvNZ+ycp3TKTXcRbY30tmTRMBoFOsgi3/YgttDFEJvDxZBgtpqWrA9C6kVaAYqfsL/Z6iVXX2DUgiQg==",
       "dev": true,
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@nx/rollup": "16.9.1",
     "@nx/web": "16.9.1",
     "@nx/workspace": "16.9.1",
-    "@openfeature/js-sdk": "^1.4.2",
+    "@openfeature/server-sdk": "^1.6.2",
     "@opentelemetry/sdk-metrics": "^1.15.0",
     "@swc-node/register": "~1.6.0",
     "@swc/cli": "~0.1.62",

--- a/tools/workspace-plugin/src/generators/open-feature/files/hook/server/src/lib/__libFileName__.ts__tmpl__
+++ b/tools/workspace-plugin/src/generators/open-feature/files/hook/server/src/lib/__libFileName__.ts__tmpl__
@@ -4,7 +4,7 @@ import {
   Hook,
   HookContext,
   HookHints,
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 
 export class <%= libClassName %> implements Hook {
   before(hookContext: HookContext, hookHints?: HookHints) {}

--- a/tools/workspace-plugin/src/generators/open-feature/files/provider/server/src/lib/__libFileName__.ts__tmpl__
+++ b/tools/workspace-plugin/src/generators/open-feature/files/provider/server/src/lib/__libFileName__.ts__tmpl__
@@ -3,7 +3,7 @@ import {
   Provider,
   JsonValue,
   ResolutionDetails,
-} from '@openfeature/js-sdk';
+} from '@openfeature/server-sdk';
 
 export class <%= libClassName %> implements Provider {
   metadata = {

--- a/tools/workspace-plugin/src/generators/open-feature/index.ts
+++ b/tools/workspace-plugin/src/generators/open-feature/index.ts
@@ -186,7 +186,7 @@ function updatePackage(tree: Tree, projectRoot: string, schema: SchemaOptions) {
     json.peerDependencies = schema.category === 'client' ? {
       '@openfeature/web-sdk': '>=0.4.0',
     } : {
-      '@openfeature/js-sdk': '^1.0.0',
+      '@openfeature/server-sdk': '^1.6.0',
     }
 
     return json;


### PR DESCRIPTION
- updates all relevant hooks/providers/templates to use `@openfeature/server-sdk` as their peer
- updates all imports to use `@openfeature/server-sdk`
- updates all readmes to use `@openfeature/server-sdk`

`@openfeature/js-sdk` now only appears in CHANGELOG.md entries.

see: https://github.com/open-feature/js-sdk/pull/589