### PR TITLE
test: add target value casting test

### DIFF
--- a/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
@@ -109,6 +109,24 @@ describe('flagd-core targeting evaluations', () => {
     expect(resolved.reason).toBe(StandardResolutionReasons.TARGETING_MATCH);
     expect(resolved.variant).toBe('true');
   });
+
+  it('should match the variant "true" by casting the boolean response from the targeting evaluation', () => {
+    const caseVariantValueFlag =
+      '{"flags":{"new-welcome-banner":{"state":"ENABLED","variants":{"true":true,"false":false},"defaultVariant":"false","targeting":{"in":["@example.com",{"var":"email"}]}}}}';
+
+    const core = new FlagdCore();
+    core.setConfigurations(caseVariantValueFlag);
+
+    const evaluation = core.resolveBooleanEvaluation(
+      'new-welcome-banner',
+      false,
+      { email: 'test@example.com' },
+      console,
+    );
+    expect(evaluation.value).toBe(true);
+    expect(evaluation.variant).toBe('true');
+    expect(evaluation.reason).toBe(StandardResolutionReasons.TARGETING_MATCH);
+  });
 });
 
 describe('flagd-core validations', () => {
@@ -141,4 +159,17 @@ describe('flagd-core validations', () => {
   it('should validate variant existence', () => {
     expect(() => core.resolveNumberEvaluation('myIntFlag', 100, {}, console)).toThrow(GeneralError);
   });
+});
+
+describe('flagd-core cast targeting variant to string', () => {
+  const caseVariantValueFlag =
+    '{"flags":{"new-welcome-banner":{"state":"ENABLED","variants":{"true":true,"false":false},"defaultVariant":"false","targeting":{"in":["@example.com",{"var":"email"}]}}}}';
+
+  const core = new FlagdCore();
+  core.setConfigurations(caseVariantValueFlag);
+
+  const evaluation = core.resolveBooleanEvaluation('new-welcome-banner', false, { email: 'test@example.com' }, console);
+  expect(evaluation.value).toBe(true);
+  expect(evaluation.variant).toBe('true');
+  expect(evaluation.reason).toBe(StandardResolutionReasons.TARGETING_MATCH);
 });

--- a/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
@@ -160,16 +160,3 @@ describe('flagd-core validations', () => {
     expect(() => core.resolveNumberEvaluation('myIntFlag', 100, {}, console)).toThrow(GeneralError);
   });
 });
-
-describe('flagd-core cast targeting variant to string', () => {
-  const caseVariantValueFlag =
-    '{"flags":{"new-welcome-banner":{"state":"ENABLED","variants":{"true":true,"false":false},"defaultVariant":"false","targeting":{"in":["@example.com",{"var":"email"}]}}}}';
-
-  const core = new FlagdCore();
-  core.setConfigurations(caseVariantValueFlag);
-
-  const evaluation = core.resolveBooleanEvaluation('new-welcome-banner', false, { email: 'test@example.com' }, console);
-  expect(evaluation.value).toBe(true);
-  expect(evaluation.variant).toBe('true');
-  expect(evaluation.reason).toBe(StandardResolutionReasons.TARGETING_MATCH);
-});


### PR DESCRIPTION
## This PR

- add target value casting test

### Notes

Confirms that the example provided in the flagd docs works as expected.

https://flagd.dev/reference/flag-definitions/#flag-properties

