### PR TITLE
fix: tsc issue with flagd-web proto output

### DIFF
--- a/libs/providers/flagd-web/src/e2e/jest.config.ts
+++ b/libs/providers/flagd-web/src/e2e/jest.config.ts
@@ -3,6 +3,9 @@ export default {
   transform: {
     '^.+\\.[tj]s$': ['ts-jest', { tsConfig: './tsconfig.lib.json' }],
   },
+  moduleNameMapper: {
+    '^(.*)\\.js$': ['$1.js', '$1.ts', '$1']
+  },
   testEnvironment: 'node',
   preset: 'ts-jest',
   clearMocks: true,

--- a/libs/providers/flagd-web/src/e2e/jest.config.ts
+++ b/libs/providers/flagd-web/src/e2e/jest.config.ts
@@ -4,7 +4,7 @@ export default {
     '^.+\\.[tj]s$': ['ts-jest', { tsConfig: './tsconfig.lib.json' }],
   },
   moduleNameMapper: {
-    '^(.*)\\.js$': ['$1.js', '$1.ts', '$1']
+    '^(.*)\\.js$': ['$1.js', '$1.ts', '$1'],
   },
   testEnvironment: 'node',
   preset: 'ts-jest',


### PR DESCRIPTION
Absorbs the change here to fix an issue with TSC errors in shipped output. See [here](https://github.com/open-feature/flagd-schemas/pull/118) for submodule change.

Fixes: https://github.com/open-feature/js-sdk-contrib/issues/688