### PR TITLE
fix: treat empty targeting rules as static

### DIFF
--- a/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
@@ -194,4 +194,15 @@ describe('flagd-core common flag definitions', () => {
     expect(resolved.reason).toBe(StandardResolutionReasons.TARGETING_MATCH);
     expect(resolved.variant).toBe('red');
   });
+
+  it('should support empty targeting rules', () => {
+    const core = new FlagdCore();
+    const flagCfg = `{"flags":{"isEnabled":{"state":"ENABLED","variants":{"true":true,"false":false},"defaultVariant":"false","targeting":{}}}}`;
+    core.setConfigurations(flagCfg);
+
+    const resolved = core.resolveBooleanEvaluation('isEnabled', false, {}, console);
+    expect(resolved.value).toBe(false);
+    expect(resolved.reason).toBe(StandardResolutionReasons.STATIC);
+    expect(resolved.variant).toBe('false');
+  });
 });

--- a/libs/shared/flagd-core/src/lib/flagd-core.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.ts
@@ -160,7 +160,7 @@ export class FlagdCore implements Storage {
     let variant;
     let reason;
 
-    if (!flag.targeting) {
+    if (!flag.targeting || Object.keys(flag.targeting).length === 0) {
       logger.debug(`Flag ${flagKey} has no targeting rules`);
       variant = flag.defaultVariant;
       reason = StandardResolutionReasons.STATIC;


### PR DESCRIPTION
## This PR

- fixes an issue where an empty targeting rule would be stringified and used as the variant.

### Notes

I've also updated the Gherkin test suite to handle this scenario.
https://github.com/open-feature/flagd-testbed/pull/88
