### PR TITLE
feat(flagd-core): add update config support, returns changed keys

### DIFF
--- a/libs/shared/flagd-core/src/lib/feature-flag.ts
+++ b/libs/shared/flagd-core/src/lib/feature-flag.ts
@@ -21,7 +21,6 @@ export class FeatureFlag {
   private readonly _targeting: unknown;
   private readonly _hash: string;
 
-
   constructor(flag: Flag) {
     this._state = flag['state'];
     this._defaultVariant = flag['defaultVariant'];

--- a/libs/shared/flagd-core/src/lib/feature-flag.ts
+++ b/libs/shared/flagd-core/src/lib/feature-flag.ts
@@ -1,4 +1,5 @@
 import { FlagValue } from '@openfeature/core';
+import { createHash } from 'crypto';
 
 /**
  * Flagd flag configuration structure mapping to schema definition.
@@ -18,12 +19,19 @@ export class FeatureFlag {
   private readonly _defaultVariant: string;
   private readonly _variants: Map<string, FlagValue>;
   private readonly _targeting: unknown;
+  private readonly _hash: string;
+
 
   constructor(flag: Flag) {
     this._state = flag['state'];
     this._defaultVariant = flag['defaultVariant'];
     this._variants = new Map<string, FlagValue>(Object.entries(flag['variants']));
     this._targeting = flag['targeting'];
+    this._hash = createHash('sha1').update(JSON.stringify(flag)).digest('base64');
+  }
+
+  get hash(): string {
+    return this._hash;
   }
 
   get state(): string {

--- a/libs/shared/flagd-core/src/lib/flagd-core.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.ts
@@ -40,12 +40,8 @@ export class FlagdCore implements Storage {
     return this;
   }
 
-  setConfigurations(cfg: string): void {
-    this._storage.setConfigurations(cfg);
-  }
-
-  updateConfigurations(cfg: string): string[] {
-    return this._storage.updateConfigurations(cfg);
+  setConfigurations(cfg: string): string[] {
+    return this._storage.setConfigurations(cfg);
   }
 
   getFlag(key: string): FeatureFlag | undefined {

--- a/libs/shared/flagd-core/src/lib/flagd-core.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.ts
@@ -44,6 +44,10 @@ export class FlagdCore implements Storage {
     this._storage.setConfigurations(cfg);
   }
 
+  updateConfigurations(cfg: string): string[] {
+    return this._storage.updateConfigurations(cfg);
+  }
+
   getFlag(key: string): FeatureFlag | undefined {
     return this._storage.getFlag(key);
   }

--- a/libs/shared/flagd-core/src/lib/storage.spec.ts
+++ b/libs/shared/flagd-core/src/lib/storage.spec.ts
@@ -9,13 +9,23 @@ describe('MemoryStorage', () => {
   });
 
   it('should set configurations correctly', () => {
-    const cfg = '{"flags":{"flag1":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}}}}';
+    const cfg =
+      '{"flags":{"flag1":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}}}}';
     storage.setConfigurations(cfg);
 
     // Assert that the configurations are set correctly
-    expect(storage['_flags']).toEqual(new Map([
-      ['flag1', new FeatureFlag({ "state": "ENABLED", "defaultVariant": "variant1", "variants": { "variant1": true, "variant2": false } })],
-    ]));
+    expect(storage['_flags']).toEqual(
+      new Map([
+        [
+          'flag1',
+          new FeatureFlag({
+            state: 'ENABLED',
+            defaultVariant: 'variant1',
+            variants: { variant1: true, variant2: false },
+          }),
+        ],
+      ]),
+    );
   });
 
   it('should update configurations correctly', () => {
@@ -32,12 +42,17 @@ describe('MemoryStorage', () => {
   });
 
   it('should get flag correctly', () => {
-    const cfg = '{"flags":{"flag1":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}},"flag2":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}}}}';
+    const cfg =
+      '{"flags":{"flag1":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}},"flag2":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}}}}';
     storage.setConfigurations(cfg);
 
     // Assert that the correct flag is returned
-    expect(storage.getFlag('flag1')).toEqual(new FeatureFlag({ "state": "ENABLED", "defaultVariant": "variant1", "variants": { "variant1": true, "variant2": false } }));
-    expect(storage.getFlag('flag2')).toEqual(new FeatureFlag({ "state": "ENABLED", "defaultVariant": "variant1", "variants": { "variant1": true, "variant2": false } }));
+    expect(storage.getFlag('flag1')).toEqual(
+      new FeatureFlag({ state: 'ENABLED', defaultVariant: 'variant1', variants: { variant1: true, variant2: false } }),
+    );
+    expect(storage.getFlag('flag2')).toEqual(
+      new FeatureFlag({ state: 'ENABLED', defaultVariant: 'variant1', variants: { variant1: true, variant2: false } }),
+    );
 
     // Assert that undefined is returned for non-existing flag
     expect(storage.getFlag('flag3')).toBeUndefined();

--- a/libs/shared/flagd-core/src/lib/storage.spec.ts
+++ b/libs/shared/flagd-core/src/lib/storage.spec.ts
@@ -1,0 +1,45 @@
+import { FeatureFlag } from './feature-flag';
+import { MemoryStorage } from './storage';
+
+describe('MemoryStorage', () => {
+  let storage: MemoryStorage;
+
+  beforeEach(() => {
+    storage = new MemoryStorage();
+  });
+
+  it('should set configurations correctly', () => {
+    const cfg = '{"flags":{"flag1":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}}}}';
+    storage.setConfigurations(cfg);
+
+    // Assert that the configurations are set correctly
+    expect(storage['_flags']).toEqual(new Map([
+      ['flag1', new FeatureFlag({ "state": "ENABLED", "defaultVariant": "variant1", "variants": { "variant1": true, "variant2": false } })],
+    ]));
+  });
+
+  it('should update configurations correctly', () => {
+    const flags1 = `{"flags":{"flag1":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}}}}`;
+    const flags2 = `{"flags":{"flag1":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}},"flag2":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}}}}`;
+    const flags3 = `{"flags":{"flag1":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false},"targeting":{"if":[true,"variant1"]}},"flag2":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}},"flag3":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}}}}`;
+    const flags4 = `{"flags":{"flag1":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false},"targeting":{"if":[true,"variant2"]}},"flag2":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}},"flag3":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}}}}`;
+
+    storage.setConfigurations(flags1);
+
+    expect(storage.updateConfigurations(flags2)).toEqual(['flag2']);
+    expect(storage.updateConfigurations(flags3)).toEqual(['flag3', 'flag1']);
+    expect(storage.updateConfigurations(flags4)).toEqual(['flag1']);
+  });
+
+  it('should get flag correctly', () => {
+    const cfg = '{"flags":{"flag1":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}},"flag2":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}}}}';
+    storage.setConfigurations(cfg);
+
+    // Assert that the correct flag is returned
+    expect(storage.getFlag('flag1')).toEqual(new FeatureFlag({ "state": "ENABLED", "defaultVariant": "variant1", "variants": { "variant1": true, "variant2": false } }));
+    expect(storage.getFlag('flag2')).toEqual(new FeatureFlag({ "state": "ENABLED", "defaultVariant": "variant1", "variants": { "variant1": true, "variant2": false } }));
+
+    // Assert that undefined is returned for non-existing flag
+    expect(storage.getFlag('flag3')).toBeUndefined();
+  });
+});

--- a/libs/shared/flagd-core/src/lib/storage.spec.ts
+++ b/libs/shared/flagd-core/src/lib/storage.spec.ts
@@ -34,11 +34,10 @@ describe('MemoryStorage', () => {
     const flags3 = `{"flags":{"flag1":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false},"targeting":{"if":[true,"variant1"]}},"flag2":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}},"flag3":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}}}}`;
     const flags4 = `{"flags":{"flag1":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false},"targeting":{"if":[true,"variant2"]}},"flag2":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}},"flag3":{"state":"ENABLED","defaultVariant":"variant1","variants":{"variant1":true,"variant2":false}}}}`;
 
-    storage.setConfigurations(flags1);
-
-    expect(storage.updateConfigurations(flags2)).toEqual(['flag2']);
-    expect(storage.updateConfigurations(flags3)).toEqual(['flag3', 'flag1']);
-    expect(storage.updateConfigurations(flags4)).toEqual(['flag1']);
+    expect(storage.setConfigurations(flags1)).toEqual(['flag1']);
+    expect(storage.setConfigurations(flags2)).toEqual(['flag2']);
+    expect(storage.setConfigurations(flags3)).toEqual(['flag3', 'flag1']);
+    expect(storage.setConfigurations(flags4)).toEqual(['flag1']);
   });
 
   it('should get flag correctly', () => {

--- a/libs/shared/flagd-core/src/lib/storage.ts
+++ b/libs/shared/flagd-core/src/lib/storage.ts
@@ -6,19 +6,12 @@ import { parse } from './parser';
  */
 export interface Storage {
   /**
-   * Sets the configurations from the given string.
-   * @param cfg The configuration string to be parsed and stored.
-   * @throws {Error} If the configuration string is invalid.
-   */
-  setConfigurations(cfg: string): void;
-
-  /**
-   * Updates the configurations and returns the list of flags that have changed.
+   * Sets the configurations and returns the list of flags that have changed.
    * @param cfg The configuration string to be parsed and stored.
    * @returns The list of flags that have changed.
    * @throws {Error} If the configuration string is invalid.
    */
-  updateConfigurations(cfg: string): string[];
+  setConfigurations(cfg: string): string[];
 
   /**
    * Gets the feature flag configuration with the given key.
@@ -52,11 +45,7 @@ export class MemoryStorage implements Storage {
     return this._flags;
   }
 
-  setConfigurations(cfg: string): void {
-    this._flags = parse(cfg);
-  }
-
-  updateConfigurations(cfg: string): string[] {
+  setConfigurations(cfg: string): string[] {
     const newFlags = parse(cfg);
     const oldFlags = this._flags;
     const added: string[] = [];

--- a/libs/shared/flagd-core/src/lib/storage.ts
+++ b/libs/shared/flagd-core/src/lib/storage.ts
@@ -13,6 +13,14 @@ export interface Storage {
   setConfigurations(cfg: string): void;
 
   /**
+   * Updates the configurations and returns the list of flags that have changed.
+   * @param cfg The configuration string to be parsed and stored.
+   * @returns The list of flags that have changed.
+   * @throws {Error} If the configuration string is invalid.
+   */
+  updateConfigurations(cfg: string): string[];
+
+  /**
    * Gets the feature flag configuration with the given key.
    * @param key The key of the flag to be retrieved.
    * @returns The flag with the given key or undefined if not found.
@@ -46,5 +54,30 @@ export class MemoryStorage implements Storage {
 
   setConfigurations(cfg: string): void {
     this._flags = parse(cfg);
+  }
+
+  updateConfigurations(cfg: string): string[] {
+    const newFlags = parse(cfg);
+    const oldFlags = this._flags;
+    const added: string[] = [];
+    const removed: string[] = [];
+    const changed: string[] = [];
+
+    newFlags.forEach((value, key) => {
+      if (!oldFlags.has(key)) {
+        added.push(key);
+      } else if (oldFlags.get(key)?.hash !== value.hash) {
+        changed.push(key);
+      }
+    });
+
+    oldFlags.forEach((_, key) => {
+      if (!newFlags.has(key)) {
+        removed.push(key);
+      }
+    });
+
+    this._flags = newFlags;
+    return [...added, ...removed, ...changed];
   }
 }


### PR DESCRIPTION
## This PR

- adds an update config method that returns all affected flag keys
- adds hash to internal feature flag class
