### PR TITLE
fix: update disabled behavior to match spec 

### DIFF
--- a/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
@@ -145,14 +145,16 @@ describe('flagd-core validations', () => {
   });
 
   it('should throw because the flag does not exist', () => {
-    expect(() => core.resolveBooleanEvaluation('nonexistentFlagKey', false, {}, console)).toThrow(
-      new FlagNotFoundError("flag: 'nonexistentFlagKey' not found"),
+    const flagKey = 'nonexistentFlagKey';
+    expect(() => core.resolveBooleanEvaluation(flagKey, false, {}, console)).toThrow(
+      new FlagNotFoundError(`flag: '${flagKey}' not found`),
     );
   });
 
   it('should throw because the flag is disabled and should behave like it does not exist', () => {
-    expect(() => core.resolveBooleanEvaluation('myBoolFlag', false, {}, console)).toThrow(
-      new FlagNotFoundError(`flag: 'myBoolFlag' is disabled`),
+    const flagKey = 'myBoolFlag';
+    expect(() => core.resolveBooleanEvaluation(flagKey, false, {}, console)).toThrow(
+      new FlagNotFoundError(`flag: '${flagKey}' is disabled`),
     );
   });
 

--- a/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
@@ -1,5 +1,5 @@
 import { FlagdCore } from './flagd-core';
-import { GeneralError, StandardResolutionReasons, TypeMismatchError } from '@openfeature/core';
+import { FlagNotFoundError, GeneralError, StandardResolutionReasons, TypeMismatchError } from '@openfeature/core';
 
 describe('flagd-core resolving', () => {
   describe('truthy variant values', () => {
@@ -144,12 +144,16 @@ describe('flagd-core validations', () => {
     expect(() => core.resolveBooleanEvaluation('myIntFlag', true, {}, console)).toThrow(GeneralError);
   });
 
-  it('should validate flag status', () => {
-    const evaluation = core.resolveBooleanEvaluation('myBoolFlag', false, {}, console);
+  it('should throw because the flag does not exist', () => {
+    expect(() => core.resolveBooleanEvaluation('nonexistentFlagKey', false, {}, console)).toThrow(
+      new FlagNotFoundError("flag: 'nonexistentFlagKey' not found"),
+    );
+  });
 
-    expect(evaluation).toBeTruthy();
-    expect(evaluation.value).toBe(false);
-    expect(evaluation.reason).toBe(StandardResolutionReasons.DISABLED);
+  it('should throw because the flag is disabled and should behave like it does not exist', () => {
+    expect(() => core.resolveBooleanEvaluation('myBoolFlag', false, {}, console)).toThrow(
+      new FlagNotFoundError(`flag: 'myBoolFlag' is disabled`),
+    );
   });
 
   it('should validate variant', () => {

--- a/libs/shared/flagd-core/src/lib/flagd-core.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.ts
@@ -150,11 +150,7 @@ export class FlagdCore implements Storage {
 
     // flag status check
     if (flag.state === 'DISABLED') {
-      logger.debug(`Flag ${flagKey} is disabled, returning default value ${defaultValue}`);
-      return {
-        value: defaultValue,
-        reason: StandardResolutionReasons.DISABLED,
-      };
+      throw new FlagNotFoundError(`flag: '${flagKey}' is disabled`);
     }
 
     let variant;


### PR DESCRIPTION
## This PR

- update disabled behavior to match spec 

### Related Issues

https://github.com/open-feature/flagd/issues/1035

### Notes

Disabled flags will now behave as if they don't exist. This is consistent with the rest of the flagd ecosystem.

### Follow-up Tasks

- [ ] Update the flagd playground
- [ ] Update the JS flagd provider


