### PR TITLE
fix: falsy boolean shorthand logic

### DIFF
--- a/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
@@ -168,25 +168,29 @@ describe('flagd-core validations', () => {
 });
 
 describe('flagd-core common flag definitions', () => {
-  it('should support boolean variant shorthand', () => {
+  describe('boolean variant shorthand', () => {
     const core = new FlagdCore();
     const flagCfg = `{"flags":{"myBoolFlag":{"state":"ENABLED","variants":{"true":true,"false":false},"defaultVariant":"false", "targeting":{"in":["@openfeature.dev",{"var":"email"}]}}}}`;
     core.setConfigurations(flagCfg);
 
-    const resolvedTruthy = core.resolveBooleanEvaluation(
-      'myBoolFlag',
-      false,
-      { email: 'user@openfeature.dev' },
-      console,
-    );
-    expect(resolvedTruthy.value).toBe(true);
-    expect(resolvedTruthy.reason).toBe(StandardResolutionReasons.TARGETING_MATCH);
-    expect(resolvedTruthy.variant).toBe('true');
+    it('should support truthy values', () => {
+      const resolvedTruthy = core.resolveBooleanEvaluation(
+        'myBoolFlag',
+        false,
+        { email: 'user@openfeature.dev' },
+        console,
+      );
+      expect(resolvedTruthy.value).toBe(true);
+      expect(resolvedTruthy.reason).toBe(StandardResolutionReasons.TARGETING_MATCH);
+      expect(resolvedTruthy.variant).toBe('true');
+    });
 
-    const resolvedFalsy = core.resolveBooleanEvaluation('myBoolFlag', false, { email: 'user@flagd.dev' }, console);
-    expect(resolvedFalsy.value).toBe(false);
-    expect(resolvedFalsy.reason).toBe(StandardResolutionReasons.TARGETING_MATCH);
-    expect(resolvedFalsy.variant).toBe('false');
+    it('should support falsy values', () => {
+      const resolvedFalsy = core.resolveBooleanEvaluation('myBoolFlag', false, { email: 'user@flagd.dev' }, console);
+      expect(resolvedFalsy.value).toBe(false);
+      expect(resolvedFalsy.reason).toBe(StandardResolutionReasons.TARGETING_MATCH);
+      expect(resolvedFalsy.variant).toBe('false');
+    });
   });
 
   it('should support fractional logic', () => {

--- a/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
@@ -173,10 +173,20 @@ describe('flagd-core common flag definitions', () => {
     const flagCfg = `{"flags":{"myBoolFlag":{"state":"ENABLED","variants":{"true":true,"false":false},"defaultVariant":"false", "targeting":{"in":["@openfeature.dev",{"var":"email"}]}}}}`;
     core.setConfigurations(flagCfg);
 
-    const resolved = core.resolveBooleanEvaluation('myBoolFlag', false, { email: 'user@openfeature.dev' }, console);
-    expect(resolved.value).toBe(true);
-    expect(resolved.reason).toBe(StandardResolutionReasons.TARGETING_MATCH);
-    expect(resolved.variant).toBe('true');
+    const resolvedTruthy = core.resolveBooleanEvaluation(
+      'myBoolFlag',
+      false,
+      { email: 'user@openfeature.dev' },
+      console,
+    );
+    expect(resolvedTruthy.value).toBe(true);
+    expect(resolvedTruthy.reason).toBe(StandardResolutionReasons.TARGETING_MATCH);
+    expect(resolvedTruthy.variant).toBe('true');
+
+    const resolvedFalsy = core.resolveBooleanEvaluation('myBoolFlag', false, { email: 'user@flagd.dev' }, console);
+    expect(resolvedFalsy.value).toBe(false);
+    expect(resolvedFalsy.reason).toBe(StandardResolutionReasons.TARGETING_MATCH);
+    expect(resolvedFalsy.variant).toBe('false');
   });
 
   it('should support fractional logic', () => {

--- a/libs/shared/flagd-core/src/lib/flagd-core.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.ts
@@ -169,7 +169,8 @@ export class FlagdCore implements Storage {
         targetingResolution = null;
       }
 
-      if (!targetingResolution) {
+      // Return default variant if targeting resolution is null or undefined
+      if (targetingResolution == null) {
         variant = flag.defaultVariant;
         reason = StandardResolutionReasons.DEFAULT;
       } else {


### PR DESCRIPTION
## This PR

- fixes falsy boolean shorthand logic

### Notes

Prior to the change, the default variant would be returned when the logic was falsy. After the change, the "false" variant is used.
