### PR TITLE
feat!: use new eval/sync protos (requires flagd v0.7.3+) 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,19 +38,19 @@ jobs:
 
       services:
         flagd:
-          image: ghcr.io/open-feature/flagd-testbed:v0.4.11
+          image: ghcr.io/open-feature/flagd-testbed:v0.5.1
           ports:
             - 8013:8013
         flagd-unstable:
-          image: ghcr.io/open-feature/flagd-testbed-unstable:v0.4.11
+          image: ghcr.io/open-feature/flagd-testbed-unstable:v0.5.1
           ports:
             - 8014:8013
         sync:
-          image: ghcr.io/open-feature/sync-testbed:v0.4.11
+          image: ghcr.io/open-feature/sync-testbed:v0.5.1
           ports:
             - 9090:9090
         sync-unstable:
-          image: ghcr.io/open-feature/sync-testbed-unstable:v0.4.11
+          image: ghcr.io/open-feature/sync-testbed-unstable:v0.5.1
           ports:
             - 9091:9090
 

--- a/libs/providers/flagd-web/src/lib/flagd-web-provider.spec.ts
+++ b/libs/providers/flagd-web/src/lib/flagd-web-provider.spec.ts
@@ -10,8 +10,8 @@ import {
   StandardResolutionReasons,
 } from '@openfeature/web-sdk';
 import fetchMock from 'jest-fetch-mock';
-import { Service } from '../proto/ts/schema/v1/schema_connect';
-import { AnyFlag, EventStreamResponse, ResolveAllResponse } from '../proto/ts/schema/v1/schema_pb';
+import { Service } from '../proto/ts/flagd/evaluation/v1/evaluation_connect';
+import { AnyFlag, EventStreamResponse, ResolveAllResponse } from '../proto/ts/flagd/evaluation/v1/evaluation_pb';
 import { FlagdWebProvider } from './flagd-web-provider';
 
 const EVENT_CONFIGURATION_CHANGE = 'configuration_change';

--- a/libs/providers/flagd-web/src/lib/flagd-web-provider.ts
+++ b/libs/providers/flagd-web/src/lib/flagd-web-provider.ts
@@ -16,8 +16,8 @@ import {
   StandardResolutionReasons,
   TypeMismatchError,
 } from '@openfeature/web-sdk';
-import { Service } from '../proto/ts/schema/v1/schema_connect';
-import { AnyFlag } from '../proto/ts/schema/v1/schema_pb';
+import { Service } from '../proto/ts/flagd/evaluation/v1/evaluation_connect';
+import { AnyFlag } from '../proto/ts/flagd/evaluation/v1/evaluation_pb';
 import { FlagdProviderOptions, getOptions } from './options';
 
 export const ERROR_DISABLED = 'DISABLED';

--- a/libs/providers/flagd/src/lib/flagd-provider.spec.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.spec.ts
@@ -24,7 +24,7 @@ import {
   ResolveStringRequest,
   ResolveStringResponse,
   ServiceClient,
-} from '../proto/ts/schema/v1/schema';
+} from '../proto/ts/flagd/evaluation/v1/evaluation';
 import { EVENT_CONFIGURATION_CHANGE, EVENT_PROVIDER_READY } from './constants';
 import { FlagdProvider } from './flagd-provider';
 import { FlagChangeMessage, GRPCService } from './service/grpc/grpc-service';

--- a/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
+++ b/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
@@ -27,7 +27,7 @@ import {
   ResolveStringRequest,
   ResolveStringResponse,
   ServiceClient,
-} from '../../../proto/ts/schema/v1/schema';
+} from '../../../proto/ts/flagd/evaluation/v1/evaluation';
 import { Config } from '../../configuration';
 import { DEFAULT_MAX_CACHE_SIZE, EVENT_CONFIGURATION_CHANGE, EVENT_PROVIDER_READY } from '../../constants';
 import { FlagdProvider } from '../../flagd-provider';

--- a/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.spec.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.spec.ts
@@ -1,6 +1,6 @@
 import { GrpcFetch } from './grpc-fetch';
 import { Config } from '../../../configuration';
-import { FlagSyncServiceClient, SyncFlagsResponse, SyncState } from '../../../../proto/ts/sync/v1/sync_service';
+import { FlagSyncServiceClient, SyncFlagsResponse } from '../../../../proto/ts/flagd/sync/v1/sync';
 import { ConnectivityState } from '@grpc/grpc-js/build/src/connectivity-state';
 
 let watchStateCallback: () => void = () => ({});
@@ -70,7 +70,7 @@ describe('grpc fetch', () => {
         done(err);
       });
 
-    onDataCallback({ flagConfiguration, state: SyncState.SYNC_STATE_ALL });
+    onDataCallback({ flagConfiguration });
   });
 
   it('should handle data sync reconnection', (done) => {
@@ -86,13 +86,13 @@ describe('grpc fetch', () => {
       .then(() => {
         try {
           // Updated flags
-          onDataCallback({ flagConfiguration: updatedFlagConfig, state: SyncState.SYNC_STATE_ALL });
+          onDataCallback({ flagConfiguration: updatedFlagConfig });
           // Stream error
           onErrorCallback(new Error('Some connection error'));
           // Force clearing
           watchStateCallback();
           // Reconnect
-          onDataCallback({ flagConfiguration: reconnectFlagConfig, state: SyncState.SYNC_STATE_ALL });
+          onDataCallback({ flagConfiguration: reconnectFlagConfig });
 
           // Callback assertions
           expect(dataCallback).toHaveBeenCalledTimes(3);
@@ -117,7 +117,7 @@ describe('grpc fetch', () => {
     dataCallback.mockReturnValue(['test']);
 
     // First connection
-    onDataCallback({ flagConfiguration: initFlagConfig, state: SyncState.SYNC_STATE_ALL });
+    onDataCallback({ flagConfiguration: initFlagConfig });
   });
 
   it('should handle error and watch channel for reconnect', (done) => {

--- a/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
@@ -1,7 +1,7 @@
 import { ClientReadableStream, ServiceError, credentials } from '@grpc/grpc-js';
 import { Logger } from '@openfeature/core';
 import { GeneralError } from '@openfeature/server-sdk';
-import { FlagSyncServiceClient, SyncFlagsRequest, SyncFlagsResponse } from '../../../../proto/ts/sync/v1/sync_service';
+import { FlagSyncServiceClient, SyncFlagsRequest, SyncFlagsResponse } from '../../../../proto/ts/flagd/sync/v1/sync';
 import { Config } from '../../../configuration';
 import { DataFetch } from '../data-fetch';
 import { closeStreamIfDefined } from '../../common';


### PR DESCRIPTION
* use new evaluation.proto
* use new sync.proto
* requires usage of flagd v0.7.3+

Resolves: https://github.com/open-feature/js-sdk-contrib/issues/743