### PR TITLE
fix: init in-process error, throw on invalid rules

### DIFF
--- a/libs/providers/flagd/src/e2e/constants.ts
+++ b/libs/providers/flagd/src/e2e/constants.ts
@@ -1,0 +1,4 @@
+export const FLAGD_NAME = 'flagd Provider';
+export const E2E_CLIENT_NAME = 'e2e';
+export const UNSTABLE_CLIENT_NAME = 'unstable';
+export const UNAVAILABLE_CLIENT_NAME = 'unavailable';

--- a/libs/providers/flagd/src/e2e/setup-in-process-provider.ts
+++ b/libs/providers/flagd/src/e2e/setup-in-process-provider.ts
@@ -1,27 +1,32 @@
 import assert from 'assert';
 import { OpenFeature } from '@openfeature/server-sdk';
 import { FlagdProvider } from '../lib/flagd-provider';
-
-const FLAGD_NAME = 'flagd Provider';
-const E2E_CLIENT_NAME = 'e2e';
-const UNSTABLE_CLIENT_NAME = 'unstable';
+import { E2E_CLIENT_NAME, FLAGD_NAME, UNSTABLE_CLIENT_NAME, UNAVAILABLE_CLIENT_NAME } from './constants';
 
 // register the flagd provider before the tests.
 console.log('Setting flagd provider...');
 OpenFeature.setProvider(
   E2E_CLIENT_NAME,
-  new FlagdProvider({ cache: 'disabled', resolverType: 'in-process', host: 'localhost', port: 9090 }),
+  new FlagdProvider({ resolverType: 'in-process', host: 'localhost', port: 9090 }),
 );
 OpenFeature.setProvider(
   UNSTABLE_CLIENT_NAME,
   new FlagdProvider({ resolverType: 'in-process', host: 'localhost', port: 9091 }),
 );
+OpenFeature.setProvider(
+  UNAVAILABLE_CLIENT_NAME,
+  new FlagdProvider({ resolverType: 'in-process', host: 'localhost', port: 9092 }),
+);
 assert(
   OpenFeature.getProviderMetadata(E2E_CLIENT_NAME).name === FLAGD_NAME,
-  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.providerMetadata.name}`),
+  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.getProviderMetadata(E2E_CLIENT_NAME).name}`),
 );
 assert(
   OpenFeature.getProviderMetadata(UNSTABLE_CLIENT_NAME).name === FLAGD_NAME,
-  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.providerMetadata.name}`),
+  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.getProviderMetadata(UNSTABLE_CLIENT_NAME).name}`),
+);
+assert(
+  OpenFeature.getProviderMetadata(UNAVAILABLE_CLIENT_NAME).name === FLAGD_NAME,
+  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.getProviderMetadata(UNAVAILABLE_CLIENT_NAME).name}`),
 );
 console.log('flagd provider configured!');

--- a/libs/providers/flagd/src/e2e/setup-in-process-provider.ts
+++ b/libs/providers/flagd/src/e2e/setup-in-process-provider.ts
@@ -19,14 +19,26 @@ OpenFeature.setProvider(
 );
 assert(
   OpenFeature.getProviderMetadata(E2E_CLIENT_NAME).name === FLAGD_NAME,
-  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.getProviderMetadata(E2E_CLIENT_NAME).name}`),
+  new Error(
+    `Expected ${FLAGD_NAME} provider to be configured, instead got: ${
+      OpenFeature.getProviderMetadata(E2E_CLIENT_NAME).name
+    }`,
+  ),
 );
 assert(
   OpenFeature.getProviderMetadata(UNSTABLE_CLIENT_NAME).name === FLAGD_NAME,
-  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.getProviderMetadata(UNSTABLE_CLIENT_NAME).name}`),
+  new Error(
+    `Expected ${FLAGD_NAME} provider to be configured, instead got: ${
+      OpenFeature.getProviderMetadata(UNSTABLE_CLIENT_NAME).name
+    }`,
+  ),
 );
 assert(
   OpenFeature.getProviderMetadata(UNAVAILABLE_CLIENT_NAME).name === FLAGD_NAME,
-  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.getProviderMetadata(UNAVAILABLE_CLIENT_NAME).name}`),
+  new Error(
+    `Expected ${FLAGD_NAME} provider to be configured, instead got: ${
+      OpenFeature.getProviderMetadata(UNAVAILABLE_CLIENT_NAME).name
+    }`,
+  ),
 );
 console.log('flagd provider configured!');

--- a/libs/providers/flagd/src/e2e/setup-rpc-provider.ts
+++ b/libs/providers/flagd/src/e2e/setup-rpc-provider.ts
@@ -1,21 +1,23 @@
 import assert from 'assert';
 import { OpenFeature } from '@openfeature/server-sdk';
 import { FlagdProvider } from '../lib/flagd-provider';
-
-const FLAGD_NAME = 'flagd Provider';
-const E2E_CLIENT_NAME = 'e2e';
-const UNSTABLE_CLIENT_NAME = 'unstable';
+import { E2E_CLIENT_NAME, FLAGD_NAME, UNSTABLE_CLIENT_NAME, UNAVAILABLE_CLIENT_NAME } from './constants';
 
 // register the flagd provider before the tests.
 console.log('Setting flagd provider...');
 OpenFeature.setProvider(E2E_CLIENT_NAME, new FlagdProvider({ cache: 'disabled' }));
 OpenFeature.setProvider(UNSTABLE_CLIENT_NAME, new FlagdProvider({ cache: 'disabled', port: 8014 }));
+OpenFeature.setProvider(UNAVAILABLE_CLIENT_NAME, new FlagdProvider({ cache: 'disabled', port: 8015 }));
 assert(
   OpenFeature.getProviderMetadata(E2E_CLIENT_NAME).name === FLAGD_NAME,
-  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.providerMetadata.name}`),
+  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.getProviderMetadata(E2E_CLIENT_NAME).name}`),
 );
 assert(
   OpenFeature.getProviderMetadata(UNSTABLE_CLIENT_NAME).name === FLAGD_NAME,
-  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.providerMetadata.name}`),
+  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.getProviderMetadata(UNSTABLE_CLIENT_NAME).name}`),
+);
+assert(
+  OpenFeature.getProviderMetadata(UNAVAILABLE_CLIENT_NAME).name === FLAGD_NAME,
+  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.getProviderMetadata(UNAVAILABLE_CLIENT_NAME).name}`),
 );
 console.log('flagd provider configured!');

--- a/libs/providers/flagd/src/e2e/setup-rpc-provider.ts
+++ b/libs/providers/flagd/src/e2e/setup-rpc-provider.ts
@@ -10,14 +10,26 @@ OpenFeature.setProvider(UNSTABLE_CLIENT_NAME, new FlagdProvider({ cache: 'disabl
 OpenFeature.setProvider(UNAVAILABLE_CLIENT_NAME, new FlagdProvider({ cache: 'disabled', port: 8015 }));
 assert(
   OpenFeature.getProviderMetadata(E2E_CLIENT_NAME).name === FLAGD_NAME,
-  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.getProviderMetadata(E2E_CLIENT_NAME).name}`),
+  new Error(
+    `Expected ${FLAGD_NAME} provider to be configured, instead got: ${
+      OpenFeature.getProviderMetadata(E2E_CLIENT_NAME).name
+    }`,
+  ),
 );
 assert(
   OpenFeature.getProviderMetadata(UNSTABLE_CLIENT_NAME).name === FLAGD_NAME,
-  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.getProviderMetadata(UNSTABLE_CLIENT_NAME).name}`),
+  new Error(
+    `Expected ${FLAGD_NAME} provider to be configured, instead got: ${
+      OpenFeature.getProviderMetadata(UNSTABLE_CLIENT_NAME).name
+    }`,
+  ),
 );
 assert(
   OpenFeature.getProviderMetadata(UNAVAILABLE_CLIENT_NAME).name === FLAGD_NAME,
-  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.getProviderMetadata(UNAVAILABLE_CLIENT_NAME).name}`),
+  new Error(
+    `Expected ${FLAGD_NAME} provider to be configured, instead got: ${
+      OpenFeature.getProviderMetadata(UNAVAILABLE_CLIENT_NAME).name
+    }`,
+  ),
 );
 console.log('flagd provider configured!');

--- a/libs/providers/flagd/src/e2e/step-definitions/evaluation.spec.ts
+++ b/libs/providers/flagd/src/e2e/step-definitions/evaluation.spec.ts
@@ -9,12 +9,13 @@ import {
   StandardResolutionReasons,
 } from '@openfeature/server-sdk';
 import { defineFeature, loadFeature } from 'jest-cucumber';
+import { E2E_CLIENT_NAME } from '../constants';
 
 // load the feature file.
 const feature = loadFeature('features/evaluation.feature');
 
 // get a client (flagd provider registered in setup)
-const client = OpenFeature.getClient('e2e');
+const client = OpenFeature.getClient(E2E_CLIENT_NAME);
 
 const givenAnOpenfeatureClientIsRegistered = (
   given: (stepMatcher: string, stepDefinitionCallback: () => void) => void,

--- a/libs/providers/flagd/src/e2e/step-definitions/flagd-json-evaluator.spec.ts
+++ b/libs/providers/flagd/src/e2e/step-definitions/flagd-json-evaluator.spec.ts
@@ -129,12 +129,12 @@ defineFeature(feature, (test) => {
     let defaultValue: number;
 
     aFlagProviderIsSet(given);
-    
+
     when(/^an integer flag with key "(.*)" is evaluated with default value (.*)$/, (key, defaultVal) => {
       flagKey = key;
       defaultValue = parseInt(defaultVal);
     });
-    
+
     then(/^the returned value should be (.*)$/, async (expectedValue) => {
       const value = await client.getNumberValue(flagKey, defaultValue);
       expect(value).toEqual(parseInt(expectedValue));

--- a/libs/providers/flagd/src/e2e/step-definitions/flagd-json-evaluator.spec.ts
+++ b/libs/providers/flagd/src/e2e/step-definitions/flagd-json-evaluator.spec.ts
@@ -1,12 +1,13 @@
-import { EvaluationContext, OpenFeature, ProviderEvents } from '@openfeature/server-sdk';
+import { EvaluationContext, EvaluationDetails, OpenFeature, ProviderEvents } from '@openfeature/server-sdk';
 import { defineFeature, loadFeature } from 'jest-cucumber';
 import { StepsDefinitionCallbackFunction } from 'jest-cucumber/dist/src/feature-definition-creation';
+import { E2E_CLIENT_NAME } from '../constants';
 
 // load the feature file.
 const feature = loadFeature('features/flagd-json-evaluator.feature');
 
 // get a client (flagd provider registered in setup)
-const client = OpenFeature.getClient('e2e');
+const client = OpenFeature.getClient(E2E_CLIENT_NAME);
 
 const aFlagProviderIsSet = (given: (stepMatcher: string, stepDefinitionCallback: () => void) => void) => {
   given('a flagd provider is set', () => undefined);
@@ -56,10 +57,12 @@ defineFeature(feature, (test) => {
       defaultValue = defaultVal;
     });
     and(
-      /^a context containing a nested property with outer key "(.*)" and inner key "(.*)", with value "(.*)"$/,
+      /^a context containing a nested property with outer key "(.*)" and inner key "(.*)", with value (.*)$/,
       (outerKey: string, innerKey: string, value: string) => {
+        // we have to support string and non-string params in this test (we test invalid context value 3)
+        const valueNoQuotes = value.replaceAll('"', '');
         evaluationContext[outerKey] = {
-          [innerKey]: value,
+          [innerKey]: parseInt(valueNoQuotes) || valueNoQuotes,
         };
       },
     );
@@ -71,7 +74,70 @@ defineFeature(feature, (test) => {
 
   test('Substring operators', evaluateStringFlagWithContext);
 
-  test('Semantic version operator numeric comparision', evaluateStringFlagWithContext);
+  test('Semantic version operator numeric comparison', evaluateStringFlagWithContext);
 
-  test('Semantic version operator semantic comparision', evaluateStringFlagWithContext);
+  test('Semantic version operator semantic comparison', evaluateStringFlagWithContext);
+
+  test('Time-based operations', ({ given, when, and, then }) => {
+    let flagKey: string;
+    let defaultValue: number;
+    const evaluationContext: EvaluationContext = {};
+
+    aFlagProviderIsSet(given);
+
+    when(/^an integer flag with key "(.*)" is evaluated with default value (\d+)$/, (key, defaultVal) => {
+      flagKey = key;
+      defaultValue = defaultVal;
+    });
+
+    and(/^a context containing a key "(.*)", with value (.*)$/, (key, value) => {
+      evaluationContext[key] = value;
+    });
+    then(/^the returned value should be (.*)$/, async (expectedValue) => {
+      const value = await client.getNumberValue(flagKey, defaultValue, evaluationContext);
+      expect(value).toEqual(parseInt(expectedValue));
+    });
+  });
+
+  test('Targeting by targeting key', ({ given, when, and, then }) => {
+    let flagKey: string;
+    let defaultValue: string;
+    let details: EvaluationDetails<string>;
+
+    aFlagProviderIsSet(given);
+
+    when(/^a string flag with key "(.*)" is evaluated with default value "(.*)"$/, (key, defaultVal) => {
+      flagKey = key;
+      defaultValue = defaultVal;
+    });
+
+    and(/^a context containing a targeting key with value "(.*)"$/, async (targetingKeyValue) => {
+      details = await client.getStringDetails(flagKey, defaultValue, { targetingKey: targetingKeyValue });
+    });
+
+    then(/^the returned value should be "(.*)"$/, (expectedValue) => {
+      expect(details.value).toEqual(expectedValue);
+    });
+
+    then(/^the returned reason should be "(.*)"$/, (expectedReason) => {
+      expect(details.reason).toEqual(expectedReason);
+    });
+  });
+
+  test('Errors and edge cases', ({ given, when, then }) => {
+    let flagKey: string;
+    let defaultValue: number;
+
+    aFlagProviderIsSet(given);
+    
+    when(/^an integer flag with key "(.*)" is evaluated with default value (.*)$/, (key, defaultVal) => {
+      flagKey = key;
+      defaultValue = parseInt(defaultVal);
+    });
+    
+    then(/^the returned value should be (.*)$/, async (expectedValue) => {
+      const value = await client.getNumberValue(flagKey, defaultValue);
+      expect(value).toEqual(parseInt(expectedValue));
+    });
+  });
 });

--- a/libs/providers/flagd/src/e2e/step-definitions/flagd-reconnect.unstable.spec.ts
+++ b/libs/providers/flagd/src/e2e/step-definitions/flagd-reconnect.unstable.spec.ts
@@ -54,13 +54,13 @@ defineFeature(feature, (test) => {
     given('flagd is unavailable', async () => {
       // handled in setup
     });
-    
+
     when('a flagd provider is set and initialization is awaited', () => {
       OpenFeature.getClient(UNAVAILABLE_CLIENT_NAME).addHandler(ProviderEvents.Error, () => {
         errorHandlerRun++;
       });
     });
-    
+
     then('an error should be indicated within the configured deadline', () => {
       expect(errorHandlerRun).toBeGreaterThan(0);
     });

--- a/libs/providers/flagd/src/e2e/step-definitions/flagd-reconnect.unstable.spec.ts
+++ b/libs/providers/flagd/src/e2e/step-definitions/flagd-reconnect.unstable.spec.ts
@@ -1,5 +1,6 @@
 import { OpenFeature, ProviderEvents } from '@openfeature/server-sdk';
 import { defineFeature, loadFeature } from 'jest-cucumber';
+import { UNAVAILABLE_CLIENT_NAME, UNSTABLE_CLIENT_NAME } from '../constants';
 
 jest.setTimeout(30000);
 
@@ -7,7 +8,7 @@ jest.setTimeout(30000);
 const feature = loadFeature('features/flagd-reconnect.feature');
 
 // get a client (flagd provider registered in setup)
-const client = OpenFeature.getClient('unstable');
+const client = OpenFeature.getClient(UNSTABLE_CLIENT_NAME);
 
 defineFeature(feature, (test) => {
   let readyRunCount = 0;
@@ -44,6 +45,24 @@ defineFeature(feature, (test) => {
     and('when the connection is reestablished the PROVIDER_READY handler must run again', async () => {
       await new Promise((resolve) => setTimeout(resolve, 10000));
       expect(readyRunCount).toBeGreaterThan(1);
+    });
+  });
+
+  test('Provider unavailable', ({ given, when, then }) => {
+    let errorHandlerRun = 0;
+
+    given('flagd is unavailable', async () => {
+      // handled in setup
+    });
+    
+    when('a flagd provider is set and initialization is awaited', () => {
+      OpenFeature.getClient(UNAVAILABLE_CLIENT_NAME).addHandler(ProviderEvents.Error, () => {
+        errorHandlerRun++;
+      });
+    });
+    
+    then('an error should be indicated within the configured deadline', () => {
+      expect(errorHandlerRun).toBeGreaterThan(0);
     });
   });
 });

--- a/libs/providers/flagd/src/e2e/step-definitions/flagd.spec.ts
+++ b/libs/providers/flagd/src/e2e/step-definitions/flagd.spec.ts
@@ -1,11 +1,12 @@
-import { OpenFeature, ProviderEvents, EventDetails } from '@openfeature/server-sdk';
+import { OpenFeature, ProviderEvents } from '@openfeature/server-sdk';
 import { defineFeature, loadFeature } from 'jest-cucumber';
+import { E2E_CLIENT_NAME } from '../constants';
 
 // load the feature file.
 const feature = loadFeature('features/flagd.feature');
 
 // get a client (flagd provider registered in setup)
-const client = OpenFeature.getClient('e2e');
+const client = OpenFeature.getClient(E2E_CLIENT_NAME);
 
 const aFlagProviderIsSet = (given: (stepMatcher: string, stepDefinitionCallback: () => void) => void) => {
   given('a flagd provider is set', () => undefined);

--- a/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
@@ -74,7 +74,7 @@ export class GrpcFetch implements DataFetch {
       this._syncStream = this._syncClient.syncFlags(this._request);
       this._syncStream.on('data', (data: SyncFlagsResponse) => {
         this._logger?.debug(`Received sync payload`);
-  
+
         try {
           const changes = dataCallback(data.flagConfiguration);
           if (this._initialized && changes.length > 0) {
@@ -83,7 +83,7 @@ export class GrpcFetch implements DataFetch {
         } catch (err) {
           this._logger?.debug('Error processing sync payload: ', (err as Error)?.message ?? 'unknown error');
         }
-  
+
         if (resolveConnect) {
           resolveConnect();
         } else if (!this._isConnected) {
@@ -93,13 +93,27 @@ export class GrpcFetch implements DataFetch {
         }
         this._isConnected = true;
       });
-  
+
       this._syncStream.on('error', (err: ServiceError | undefined) => {
-        this.handleError(err as Error, dataCallback, reconnectCallback, changedCallback, disconnectCallback, rejectConnect);
+        this.handleError(
+          err as Error,
+          dataCallback,
+          reconnectCallback,
+          changedCallback,
+          disconnectCallback,
+          rejectConnect,
+        );
       });
     } catch (err) {
-      this.handleError(err as Error, dataCallback, reconnectCallback, changedCallback, disconnectCallback, rejectConnect);
-    } 
+      this.handleError(
+        err as Error,
+        dataCallback,
+        reconnectCallback,
+        changedCallback,
+        disconnectCallback,
+        rejectConnect,
+      );
+    }
   }
 
   private handleError(

--- a/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
@@ -225,4 +225,12 @@ describe('flagd-core common flag definitions', () => {
     expect(resolved.reason).toBe(StandardResolutionReasons.STATIC);
     expect(resolved.variant).toBe('false');
   });
+
+  it('should throw with invalid targeting rules', () => {
+    const core = new FlagdCore();
+    const flagCfg = `{"flags":{"isEnabled":{"state":"ENABLED","variants":{"true":true,"false":false},"defaultVariant":"false","targeting":{"invalid": ["this is not valid targeting"]}}}}`;
+    core.setConfigurations(flagCfg);
+
+    expect(() => core.resolveBooleanEvaluation('isEnabled', false, {}, console)).toThrow();
+  });
 });

--- a/libs/shared/flagd-core/src/lib/flagd-core.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.ts
@@ -137,7 +137,7 @@ export class FlagdCore implements Storage {
   resolve<T extends FlagValue>(
     type: FlagValueType,
     flagKey: string,
-    defaultValue: T,
+    _: T,
     evalCtx: EvaluationContext = {},
     logger?: Logger,
   ): ResolutionDetails<T> {
@@ -165,8 +165,7 @@ export class FlagdCore implements Storage {
       try {
         targetingResolution = this._targeting.applyTargeting(flagKey, flag.targeting, evalCtx);
       } catch (e) {
-        logger.error(`Error evaluating targeting rule for flag ${flagKey}, falling back to default`, e);
-        targetingResolution = null;
+        throw new GeneralError(`Error evaluating targeting rule for flag ${flagKey}: ${(e as Error)?.message}`);
       }
 
       // Return default variant if targeting resolution is null or undefined


### PR DESCRIPTION
* fixes an unhandled error if sync source not available at startup
* throws on invalid targeting rules as per flagd spec
* adds additional e2e tests

---

Implements the latest e2e tests, including those added [here](https://github.com/open-feature/flagd-testbed/pull/85). Here we decided that invalid targeting should throw, which required a small change in core.

I also found a [bug](https://github.com/open-feature/js-sdk-contrib/pull/767/files#r1488560278) on the in-process provider where there's an unhandled exception in startup.