### PR TITLE
fix!: Allow ConfigCat provider to be used in server applications

### DIFF
--- a/libs/providers/config-cat/README.md
+++ b/libs/providers/config-cat/README.md
@@ -14,20 +14,21 @@ The OpenFeature SDK is required as peer dependency.
 
 The minimum required version of `@openfeature/server-sdk` currently is `1.6.0`.
 
-The minimum required version of `configcat-js` currently is `8.0.0`.
+The minimum required version of `configcat-js-ssr` currently is `7.1.2`.
 
 ```
-$ npm install @openfeature/server-sdk configcat-js
+$ npm install @openfeature/server-sdk configcat-js-ssr
 ```
 
 ## Usage
 
-The ConfigCat provider uses the [ConfigCat Javascript SDK](https://configcat.com/docs/sdk-reference/js/).
+The ConfigCat provider uses the [ConfigCat JavaScript (SSR) SDK](https://configcat.com/docs/sdk-reference/js-ssr/).
+This means that the provider can be used in both server (e.g. Node.js) and client (browser) applications.
 
 It can either be created by passing the ConfigCat SDK options to ```ConfigCatProvider.create``` or
 the ```ConfigCatProvider``` constructor.
 
-The available options can be found in the [ConfigCat Javascript SDK docs](https://configcat.com/docs/sdk-reference/js/).
+The available options can be found in the [ConfigCat JavaScript (SSR) SDK](https://configcat.com/docs/sdk-reference/js-ssr/).
 
 ### Example using the default configuration
 
@@ -53,7 +54,7 @@ OpenFeature.setProvider(provider);
 ## Evaluation Context
 
 ConfigCat only supports string values in its "evaluation
-context", [there known as user](https://configcat.com/docs/advanced/user-object/).
+context", [there known as User Object](https://configcat.com/docs/advanced/user-object/).
 
 This means that every value is converted to a string. This is trivial for numbers and booleans. Objects and arrays are
 converted to JSON strings that can be interpreted in ConfigCat.

--- a/libs/providers/config-cat/package.json
+++ b/libs/providers/config-cat/package.json
@@ -7,6 +7,6 @@
   },
   "peerDependencies": {
     "@openfeature/server-sdk": "^1.8.0",
-    "configcat-js": "^8.0.0 || ^9.0.0"
+    "configcat-js-ssr": ">=7.1.2"
   }
 }

--- a/libs/providers/config-cat/src/lib/config-cat-provider.spec.ts
+++ b/libs/providers/config-cat/src/lib/config-cat-provider.spec.ts
@@ -9,7 +9,7 @@ import {
   LogLevel,
   OverrideBehaviour,
   PollingMode,
-} from 'configcat-js';
+} from 'configcat-js-ssr';
 
 import { IEventEmitter } from 'configcat-common/lib/EventEmitter';
 

--- a/libs/providers/config-cat/src/lib/config-cat-provider.ts
+++ b/libs/providers/config-cat/src/lib/config-cat-provider.ts
@@ -12,7 +12,7 @@ import {
   StandardResolutionReasons,
   TypeMismatchError,
 } from '@openfeature/server-sdk';
-import { getClient, IConfig, IConfigCatClient, IEvaluationDetails, SettingValue } from 'configcat-js';
+import { getClient, IConfig, IConfigCatClient, IEvaluationDetails, SettingValue } from 'configcat-js-ssr';
 import { transformContext } from './context-transformer';
 
 export class ConfigCatProvider implements Provider {

--- a/libs/providers/config-cat/src/lib/config-cat-provider.ts
+++ b/libs/providers/config-cat/src/lib/config-cat-provider.ts
@@ -99,7 +99,7 @@ export class ConfigCatProvider implements Provider {
     const { value, ...evaluationData } = await this._client.getValueDetailsAsync<SettingValue>(
       flagKey,
       undefined,
-      transformContext(context),
+      context.targetingKey != null ? transformContext(context) : undefined,
     );
 
     const validatedValue = validateFlagType('boolean', value);
@@ -121,7 +121,7 @@ export class ConfigCatProvider implements Provider {
     const { value, ...evaluationData } = await this._client.getValueDetailsAsync<SettingValue>(
       flagKey,
       undefined,
-      transformContext(context),
+      context.targetingKey != null ? transformContext(context) : undefined,
     );
 
     const validatedValue = validateFlagType('string', value);
@@ -143,7 +143,7 @@ export class ConfigCatProvider implements Provider {
     const { value, ...evaluationData } = await this._client.getValueDetailsAsync<SettingValue>(
       flagKey,
       undefined,
-      transformContext(context),
+      context.targetingKey != null ? transformContext(context) : undefined,
     );
 
     const validatedValue = validateFlagType('number', value);
@@ -165,7 +165,7 @@ export class ConfigCatProvider implements Provider {
     const { value, ...evaluationData } = await this._client.getValueDetailsAsync(
       flagKey,
       undefined,
-      transformContext(context),
+      context.targetingKey != null ? transformContext(context) : undefined,
     );
 
     if (typeof value === 'undefined') {

--- a/libs/providers/config-cat/src/lib/context-transformer.ts
+++ b/libs/providers/config-cat/src/lib/context-transformer.ts
@@ -1,5 +1,5 @@
 import { EvaluationContext, EvaluationContextValue, TargetingKeyMissingError } from '@openfeature/server-sdk';
-import { User as ConfigCatUser } from 'configcat-js';
+import { User as ConfigCatUser } from 'configcat-js-ssr';
 
 function contextValueToString(contextValue: EvaluationContextValue): string | undefined {
   if (typeof contextValue === 'string') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@swc/helpers": "0.5.3",
         "ajv": "^8.12.0",
         "axios": "1.6.7",
-        "configcat-js": "^9.0.0",
+        "configcat-js-ssr": "^8.3.0",
         "copy-anything": "^3.0.5",
         "imurmurhash": "^0.1.4",
         "json-logic-engine": "1.3.1",
@@ -6363,11 +6363,12 @@
         "tslib": "^2.4.1"
       }
     },
-    "node_modules/configcat-js": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/configcat-js/-/configcat-js-9.4.0.tgz",
-      "integrity": "sha512-yI/Ixc7Cs8z7B4GxcmRozq7iBrhl3Ab2zmrxy1SdQigcyEPkqWbwillfqmOo32SLl8F0QXQblyC55ALxjM5YdA==",
+    "node_modules/configcat-js-ssr": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/configcat-js-ssr/-/configcat-js-ssr-8.3.0.tgz",
+      "integrity": "sha512-cmSNOz4syzLBdO7fK03SWPwXVJIlN2CxJjF8S5l2DDwDz+Nbv9QrllWaseRK1I78H6N7AjEalu2WeEI2VdbEKA==",
       "dependencies": {
+        "axios": "^1.6.2",
         "configcat-common": "9.2.0",
         "tslib": "^2.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@swc/helpers": "0.5.3",
     "ajv": "^8.12.0",
     "axios": "1.6.7",
-    "configcat-js": "^9.0.0",
+    "configcat-js-ssr": "^8.3.0",
     "copy-anything": "^3.0.5",
     "imurmurhash": "^0.1.4",
     "json-logic-engine": "1.3.1",


### PR DESCRIPTION
## This PR

The `conficat-js` package that the ConfigCat provider is based on is for browser applications only as it uses `XMLHttpRequest` under the hood. However, the provider might be used in server applications (like it was attempted in a Node.js application [here](https://www.linkedin.com/video/event/urn:li:ugcPost:7173464062830239744), at around 2:00:00).

For multiplatform scenarios, ConfigCat provides [the `conficat-js-ssr` package](https://configcat.com/docs/sdk-reference/js-ssr/) (that uses Axios under the hood). This provider should use that instead of `conficat-js` to provide a more extensive support for various JS platforms.

This PR also fixes another serious shortcoming of the provider: currently it cannot evaluate feature flags without setting `targetingKey` in the evaluation context. Simple feature flags may not use targeting at all, so requiring a `targetingKey` to evaluate them is obviously not correct.

### Related Issues

n/a

### Notes

n/a

### Follow-up Tasks

n/a

### How to test

n/a

