### PR TITLE
chore: lock configcat dep

### DIFF
--- a/libs/providers/config-cat/src/lib/config-cat-provider.spec.ts
+++ b/libs/providers/config-cat/src/lib/config-cat-provider.spec.ts
@@ -17,6 +17,7 @@ describe('ConfigCatProvider', () => {
   const targetingKey = 'abc';
 
   let provider: ConfigCatProvider;
+  // TODO: this type (and maybe the emitter itself?) is removed in later versions, it may not be sustainable to test with this
   let configCatEmitter: IEventEmitter<HookEvents>;
 
   const values = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@swc/helpers": "0.5.7",
         "ajv": "^8.12.0",
         "axios": "1.6.8",
-        "configcat-js-ssr": "^8.3.0",
+        "configcat-js-ssr": "8.3.0",
         "copy-anything": "^3.0.5",
         "imurmurhash": "^0.1.4",
         "json-logic-engine": "1.3.2",
@@ -6426,21 +6426,21 @@
         "source-map": "^0.6.1"
       }
     },
-    "node_modules/configcat-js-ssr": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/configcat-js-ssr/-/configcat-js-ssr-8.4.0.tgz",
-      "integrity": "sha512-l8jFTI2KX1c4wY+qgBmO28xn3mBkXoqMxuLGPkwp+nNMdEXdvGoSGbEKkeNBD/40PKKg59Yn5dNUuRuKg/QdoA==",
+    "node_modules/configcat-common": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-9.2.0.tgz",
+      "integrity": "sha512-IPnC+jF947ajb0tKZGhu7nMqJlP+RhQKer7drfygW7G/J2RVV0GVvr2rBGNoAPn38Glf8TOZHsDmXmlCQkMl7g==",
       "dependencies": {
-        "axios": "^1.6.2",
-        "configcat-common": "9.3.0",
         "tslib": "^2.4.1"
       }
     },
-    "node_modules/configcat-js-ssr/node_modules/configcat-common": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-9.3.0.tgz",
-      "integrity": "sha512-WgpCanLPsT0ig4eLEo2BCZvo0sqtGIkRREnxNAX3Hubw0FzyQ7JUbiliw7ZlBNgda5jaO2nvcs3man+PDdfyLQ==",
+    "node_modules/configcat-js-ssr": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/configcat-js-ssr/-/configcat-js-ssr-8.3.0.tgz",
+      "integrity": "sha512-cmSNOz4syzLBdO7fK03SWPwXVJIlN2CxJjF8S5l2DDwDz+Nbv9QrllWaseRK1I78H6N7AjEalu2WeEI2VdbEKA==",
       "dependencies": {
+        "axios": "^1.6.2",
+        "configcat-common": "9.2.0",
         "tslib": "^2.4.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@swc/helpers": "0.5.7",
     "ajv": "^8.12.0",
     "axios": "1.6.8",
-    "configcat-js-ssr": "^8.3.0",
+    "configcat-js-ssr": "8.3.0",
     "copy-anything": "^3.0.5",
     "imurmurhash": "^0.1.4",
     "json-logic-engine": "1.3.2",


### PR DESCRIPTION
A [recent change](https://github.com/open-feature/js-sdk-contrib/pull/825) updated this configcat dep, which brought in a breaking change to out testing (noted in-line).

This PR locks the dep to the point-version so prevent test regressions.

We should probably find a better long-term solution.