### PR TITLE
fix(config-cat): remove event emitter type import from config-cat

### DIFF
--- a/libs/providers/config-cat/src/lib/config-cat-provider.spec.ts
+++ b/libs/providers/config-cat/src/lib/config-cat-provider.spec.ts
@@ -10,15 +10,13 @@ import {
   OverrideBehaviour,
   PollingMode,
 } from 'configcat-js-ssr';
-
-import { IEventEmitter } from 'configcat-common/lib/EventEmitter';
+import { EventEmitter } from 'events';
 
 describe('ConfigCatProvider', () => {
   const targetingKey = 'abc';
 
   let provider: ConfigCatProvider;
-  // TODO: this type (and maybe the emitter itself?) is removed in later versions, it may not be sustainable to test with this
-  let configCatEmitter: IEventEmitter<HookEvents>;
+  let configCatEmitter: EventEmitter<HookEvents>;
 
   const values = {
     booleanFalse: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@swc/helpers": "0.5.7",
         "ajv": "^8.12.0",
         "axios": "1.6.8",
-        "configcat-js-ssr": "8.3.0",
+        "configcat-js-ssr": "^8.3.0",
         "copy-anything": "^3.0.5",
         "imurmurhash": "^0.1.4",
         "json-logic-engine": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@swc/helpers": "0.5.7",
     "ajv": "^8.12.0",
     "axios": "1.6.8",
-    "configcat-js-ssr": "8.3.0",
+    "configcat-js-ssr": "^8.3.0",
     "copy-anything": "^3.0.5",
     "imurmurhash": "^0.1.4",
     "json-logic-engine": "1.3.2",


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Removes the `IEventEmitter` import from configcat-common.
This reduces the risk of breaking the tests because of the removal of this type (export).

It tackles the same problem as #827. 

As there is currently no option to access the internal event emitter or provide it directly, the assumption getting the event emitter from the private options can not be removed.
https://github.com/open-feature/js-sdk-contrib/compare/fix/config-cat/remove-event-emitter-dep?expand=1#diff-ebd6f4363558237806382ec9b364f56831b69ad259c090f1981a4d56a7bb0bcdL43