### PR TITLE
feat(ofrep): parse Retry-After header in OFREPApiTooManyRequestsError

### DIFF
--- a/libs/shared/ofrep-core/README.md
+++ b/libs/shared/ofrep-core/README.md
@@ -1,0 +1,4 @@
+# ofrep-core
+
+The core implementation of OFREP core providers.
+This package is intended to be used by the concrete OFREP provider implementations for API access, error handling, ... 

--- a/libs/shared/ofrep-core/src/lib/api/ofrep-api.spec.ts
+++ b/libs/shared/ofrep-core/src/lib/api/ofrep-api.spec.ts
@@ -62,8 +62,8 @@ describe('OFREPApi', () => {
     });
 
     it('parse numeric Retry-After header correctly on 429 response', async () => {
-      jest.useFakeTimers({})
-      jest.setSystemTime(new Date('2018-01-27'))
+      jest.useFakeTimers({});
+      jest.setSystemTime(new Date('2018-01-27'));
 
       try {
         await api.postEvaluateFlags('my-flag', { context: { errors: { 429: true } } });
@@ -73,32 +73,32 @@ describe('OFREPApi', () => {
         }
 
         expect(error.retryAfterSeconds).toEqual(2000);
-        expect(error.retryAfterDate).toEqual(new Date("2018-01-27T00:33:20.000Z"));
+        expect(error.retryAfterDate).toEqual(new Date('2018-01-27T00:33:20.000Z'));
       }
     });
 
     it('parse date Retry-After header correctly on 429 response', async () => {
-      jest.useFakeTimers({})
-      jest.setSystemTime(new Date('2018-01-27'))
+      jest.useFakeTimers({});
+      jest.setSystemTime(new Date('2018-01-27'));
 
       try {
-        await api.postEvaluateFlags('my-flag', { context: { errors: { 429: "Sat, 27 Jan 2018 07:28:00 GMT" } } });
+        await api.postEvaluateFlags('my-flag', { context: { errors: { 429: 'Sat, 27 Jan 2018 07:28:00 GMT' } } });
       } catch (error) {
         if (!(error instanceof OFREPApiTooManyRequestsError)) {
           throw new Error('Expected OFREPApiTooManyRequestsError');
         }
 
         expect(error.retryAfterSeconds).toEqual(null);
-        expect(error.retryAfterDate).toEqual(new Date("2018-01-27T07:28:00.000Z"));
+        expect(error.retryAfterDate).toEqual(new Date('2018-01-27T07:28:00.000Z'));
       }
     });
 
     it('ignore Retry-After header if it is not valid on 429 response', async () => {
-      jest.useFakeTimers({})
-      jest.setSystemTime(new Date('2018-01-27'))
+      jest.useFakeTimers({});
+      jest.setSystemTime(new Date('2018-01-27'));
 
       try {
-        await api.postEvaluateFlags('my-flag', { context: { errors: { 429: "abcdefg" } } });
+        await api.postEvaluateFlags('my-flag', { context: { errors: { 429: 'abcdefg' } } });
       } catch (error) {
         if (!(error instanceof OFREPApiTooManyRequestsError)) {
           throw new Error('Expected OFREPApiTooManyRequestsError');

--- a/libs/shared/ofrep-core/src/lib/api/ofrep-api.spec.ts
+++ b/libs/shared/ofrep-core/src/lib/api/ofrep-api.spec.ts
@@ -24,7 +24,10 @@ describe('OFREPApi', () => {
   beforeEach(() => {
     api = new OFREPApi('https://localhost:8080');
   });
-  afterEach(() => server.resetHandlers());
+  afterEach(() => {
+    jest.useRealTimers();
+    server.resetHandlers();
+  });
   afterAll(() => server.close());
 
   describe('postEvaluateFlags should', () => {
@@ -56,6 +59,54 @@ describe('OFREPApi', () => {
       await expect(() => api.postEvaluateFlags('my-flag', { context: { errors: { 429: true } } })).rejects.toThrow(
         OFREPApiTooManyRequestsError,
       );
+    });
+
+    it('parse numeric Retry-After header correctly on 429 response', async () => {
+      jest.useFakeTimers({})
+      jest.setSystemTime(new Date('2018-01-27'))
+
+      try {
+        await api.postEvaluateFlags('my-flag', { context: { errors: { 429: true } } });
+      } catch (error) {
+        if (!(error instanceof OFREPApiTooManyRequestsError)) {
+          throw new Error('Expected OFREPApiTooManyRequestsError');
+        }
+
+        expect(error.retryAfterSeconds).toEqual(2000);
+        expect(error.retryAfterDate).toEqual(new Date("2018-01-27T00:33:20.000Z"));
+      }
+    });
+
+    it('parse date Retry-After header correctly on 429 response', async () => {
+      jest.useFakeTimers({})
+      jest.setSystemTime(new Date('2018-01-27'))
+
+      try {
+        await api.postEvaluateFlags('my-flag', { context: { errors: { 429: "Sat, 27 Jan 2018 07:28:00 GMT" } } });
+      } catch (error) {
+        if (!(error instanceof OFREPApiTooManyRequestsError)) {
+          throw new Error('Expected OFREPApiTooManyRequestsError');
+        }
+
+        expect(error.retryAfterSeconds).toEqual(null);
+        expect(error.retryAfterDate).toEqual(new Date("2018-01-27T07:28:00.000Z"));
+      }
+    });
+
+    it('ignore Retry-After header if it is not valid on 429 response', async () => {
+      jest.useFakeTimers({})
+      jest.setSystemTime(new Date('2018-01-27'))
+
+      try {
+        await api.postEvaluateFlags('my-flag', { context: { errors: { 429: "abcdefg" } } });
+      } catch (error) {
+        if (!(error instanceof OFREPApiTooManyRequestsError)) {
+          throw new Error('Expected OFREPApiTooManyRequestsError');
+        }
+
+        expect(error.retryAfterSeconds).toEqual(null);
+        expect(error.retryAfterDate).toEqual(null);
+      }
     });
 
     it('send empty request body if context is not given', async () => {

--- a/libs/shared/ofrep-core/src/test/handlers.ts
+++ b/libs/shared/ofrep-core/src/test/handlers.ts
@@ -41,7 +41,7 @@ export const handlers = [
         throw HttpResponse.text(undefined, { status: 429, headers: { 'Retry-After': '2000' } });
       }
 
-      if (typeof errors?.['429'] === "string") {
+      if (typeof errors?.['429'] === 'string') {
         throw HttpResponse.text(undefined, { status: 429, headers: { 'Retry-After': errors?.['429'] } });
       }
 

--- a/libs/shared/ofrep-core/src/test/handlers.ts
+++ b/libs/shared/ofrep-core/src/test/handlers.ts
@@ -37,8 +37,12 @@ export const handlers = [
         throw HttpResponse.text(undefined, { status: 403 });
       }
 
-      if (errors?.['429']) {
+      if (errors?.['429'] === true) {
         throw HttpResponse.text(undefined, { status: 429, headers: { 'Retry-After': '2000' } });
+      }
+
+      if (typeof errors?.['429'] === "string") {
+        throw HttpResponse.text(undefined, { status: 429, headers: { 'Retry-After': errors?.['429'] } });
       }
 
       if (errors?.['parseError']) {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Implements parsing the retry after header in the `OFREPApiTooManyRequestsError ` as client and server provider need that information.
It can replace the current implementation in the web-provider. https://github.com/open-feature/js-sdk-contrib/pull/776#discussion_r1550601232


