### PR TITLE
fix: flagsmith project paths

### DIFF
--- a/libs/providers/flagsmith-client/project.json
+++ b/libs/providers/flagsmith-client/project.json
@@ -8,7 +8,7 @@
       "executor": "nx:run-commands",
       "options": {
         "command": "npm run publish-if-not-exists",
-        "cwd": "dist/libs/providers/flagsmith"
+        "cwd": "dist/libs/providers/flagsmith-client"
       },
       "dependsOn": [
         {
@@ -49,7 +49,7 @@
         "buildableProjectDepsInPackageJsonType": "dependencies",
         "compiler": "tsc",
         "generateExportsField": true,
-        "umdName": "flagsmith",
+        "umdName": "flagsmith-client",
         "external": "all",
         "format": ["cjs", "esm"],
         "assets": [
@@ -65,7 +65,7 @@
           },
           {
             "glob": "README.md",
-            "input": "./libs/providers/flagsmith",
+            "input": "./libs/providers/flagsmith-client",
             "output": "./"
           }
         ]


### PR DESCRIPTION
## This PR

https://github.com/open-feature/js-sdk-contrib/actions/runs/8606772734 failed, I believe this is due to the following paths not being updated when the provider was renamed from flagsmith to flagsmith-client. Sorry about that!