### PR TITLE
chore: bump ofrep-core to ^0.1.2

### DIFF
--- a/libs/providers/ofrep-web/package.json
+++ b/libs/providers/ofrep-web/package.json
@@ -12,6 +12,6 @@
   },
   "peerDependencies": {
     "@openfeature/web-sdk": ">=0.4.0",
-    "@openfeature/ofrep-core": "^0.1.0"
+    "@openfeature/ofrep-core": "^0.1.2"
   }
 }

--- a/libs/providers/ofrep/package.json
+++ b/libs/providers/ofrep/package.json
@@ -12,6 +12,6 @@
   },
   "peerDependencies": {
     "@openfeature/server-sdk": "^1.6.0",
-    "@openfeature/ofrep-core": "^0.1.1"
+    "@openfeature/ofrep-core": "^0.1.2"
   }
 }


### PR DESCRIPTION
Bumps OFREP core to ^0.1.2 to fix fetch error in browser.