### PR TITLE
chore: migrate from bufbuild to connectrpc

### DIFF
--- a/libs/providers/flagd-web/src/lib/flagd-web-provider.spec.ts
+++ b/libs/providers/flagd-web/src/lib/flagd-web-provider.spec.ts
@@ -1,4 +1,4 @@
-import { CallbackClient, Code, ConnectError, PromiseClient } from '@bufbuild/connect';
+import { CallbackClient, Code, ConnectError, PromiseClient } from '@connectrpc/connect';
 import { Struct } from '@bufbuild/protobuf';
 import {
   Client,

--- a/libs/providers/flagd-web/src/lib/flagd-web-provider.ts
+++ b/libs/providers/flagd-web/src/lib/flagd-web-provider.ts
@@ -1,5 +1,5 @@
-import { CallbackClient, createCallbackClient, createPromiseClient, PromiseClient } from '@bufbuild/connect';
-import { createConnectTransport } from '@bufbuild/connect-web';
+import { CallbackClient, createCallbackClient, createPromiseClient, PromiseClient } from '@connectrpc/connect';
+import { createConnectTransport } from '@connectrpc/connect-web';
 import { Struct } from '@bufbuild/protobuf';
 import {
   EvaluationContext,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/connect-web": "^0.13.0",
         "@bufbuild/protobuf": "^1.2.0",
+        "@connectrpc/connect": "^1.4.0",
+        "@connectrpc/connect-web": "^1.4.0",
         "@flipt-io/flipt": "^1.0.0",
         "@flipt-io/flipt-client-browser": "^0.0.17",
         "@grpc/grpc-js": "^1.9.13",
@@ -2049,27 +2050,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@bufbuild/connect": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/connect/-/connect-0.13.0.tgz",
-      "integrity": "sha512-eZSMbVLyUFtXiZNORgCEvv580xKZeYQdMOWj2i/nxOcpXQcrEzTMTA7SZzWv4k4gveWCOSRoWmYDeOhfWXJv0g==",
-      "deprecated": "Connect has moved to its own org @connectrpc and has a stable v1. Run `npx @connectrpc/connect-migrate@latest` to update. See https://github.com/connectrpc/connect-es/releases/tag/v0.13.1 for details.",
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^1.2.1"
-      }
-    },
-    "node_modules/@bufbuild/connect-web": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/connect-web/-/connect-web-0.13.0.tgz",
-      "integrity": "sha512-Ys9VFDWYktD9yFQSLOlkpsD42LonDNMCysLCfjXFuxlupYuf4f7qg0zkT5bESyTfqk4xtRDSSGR3xygaj/ONIQ==",
-      "deprecated": "Connect has moved to its own org @connectrpc and has a stable v1. Run `npx @connectrpc/connect-migrate@latest` to update. See https://github.com/connectrpc/connect-es/releases/tag/v0.13.1 for details.",
-      "dependencies": {
-        "@bufbuild/connect": "0.13.0"
-      },
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^1.2.1"
-      }
-    },
     "node_modules/@bufbuild/protobuf": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.8.0.tgz",
@@ -2107,6 +2087,23 @@
       },
       "engines": {
         "node": ">=0.1.95"
+      }
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.4.0.tgz",
+      "integrity": "sha512-vZeOkKaAjyV4+RH3+rJZIfDFJAfr+7fyYr6sLDKbYX3uuTVszhFe9/YKf5DNqrDb5cKdKVlYkGn6DTDqMitAnA==",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.4.0.tgz",
+      "integrity": "sha512-13aO4psFbbm7rdOFGV0De2Za64DY/acMspgloDlcOKzLPPs0yZkhp1OOzAQeiAIr7BM/VOHIA3p8mF0inxCYTA==",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2",
+        "@connectrpc/connect": "1.4.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   },
   "private": true,
   "dependencies": {
-    "@bufbuild/connect-web": "^0.13.0",
     "@bufbuild/protobuf": "^1.2.0",
+    "@connectrpc/connect": "^1.4.0",
+    "@connectrpc/connect-web": "^1.4.0",
     "@flipt-io/flipt": "^1.0.0",
     "@flipt-io/flipt-client-browser": "^0.0.17",
     "@grpc/grpc-js": "^1.9.13",


### PR DESCRIPTION
## This PR

- migrate from bufbuild to connectrpc

### Notes

Buf migrated to a dedicated `@connectrpc` org and updated their published packages according.

See the warning on the old package: https://www.npmjs.com/package/@bufbuild/connect-web