### PR TITLE
feat: Add interceptors to flagd options.

### DIFF
--- a/libs/providers/flagd-web/src/lib/flagd-web-provider.ts
+++ b/libs/providers/flagd-web/src/lib/flagd-web-provider.ts
@@ -55,6 +55,7 @@ export class FlagdWebProvider implements Provider {
     const { host, port, tls, maxRetries, maxDelay, pathPrefix } = getOptions(options);
     const transport = createConnectTransport({
       baseUrl: `${tls ? 'https' : 'http'}://${host}:${port}/${pathPrefix}`,
+      interceptors: options.interceptors,
     });
     this._promiseClient = promiseClient ? promiseClient : createPromiseClient(Service, transport);
     this._callbackClient = callbackClient ? callbackClient : createCallbackClient(Service, transport);

--- a/libs/providers/flagd-web/src/lib/options.ts
+++ b/libs/providers/flagd-web/src/lib/options.ts
@@ -1,3 +1,5 @@
+import type { Interceptor } from '@connectrpc/connect';
+
 export interface Options {
   /**
    * The domain name or IP address of flagd.
@@ -39,6 +41,11 @@ export interface Options {
    * @default 0
    */
   maxRetries: number;
+
+  /**
+   * Connect interceptors applied to all calls.
+   */
+  interceptors?: Interceptor[];
 }
 
 export type FlagdProviderOptions = Partial<Options> & Pick<Options, 'host'>;


### PR DESCRIPTION
## This PR

This change enables passing interceptors to the flagd-web provider which can be leveraged to add extra headers to outgoing requests.

### Notes
I'm working on bootstrapping a flagd deployment, and I have flagd behind a proxy that requires a session header. I didn't see an existing way to mutate requests.

