### PR TITLE
feat: Initial GrowthBook OpenFeature provider

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -13,5 +13,6 @@
   "libs/providers/ofrep-web": "0.1.3",
   "libs/providers/flipt": "0.1.0",
   "libs/providers/flagsmith-client": "0.1.2",
-  "libs/providers/flipt-web": "0.1.0"
+  "libs/providers/flipt-web": "0.1.0",
+  "libs/providers/growthbook-client": "0.1.0"
 }

--- a/libs/providers/growthbook-client/.eslintrc.json
+++ b/libs/providers/growthbook-client/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": "error"
+      }
+    }
+  ]
+}

--- a/libs/providers/growthbook-client/README.md
+++ b/libs/providers/growthbook-client/README.md
@@ -1,0 +1,44 @@
+# growthbook-client Provider
+
+## Installation
+
+```
+$ npm install @openfeature/growthbook-client-provider
+```
+
+## Example Setup
+
+```typescript
+import { GrowthBook, Context, InitOptions } from '@growthbook/growthbook';
+import { GrowthbookClientProvider } from '@openfeature/growthbook-client-provider';
+
+/*
+ * Configure your GrowthBook instance with GrowthBook context
+ * @see https://docs.growthbook.io/lib/js#step-1-configure-your-app
+ */
+const gbContext: Context = {
+  apiHost: 'https://cdn.growthbook.io',
+  clientKey: 'sdk-abc123',
+  // Only required if you have feature encryption enabled in GrowthBook
+  decryptionKey: 'key_abc123',
+};
+
+/*
+ * optional init options
+ * @see https://docs.growthbook.io/lib/js#switching-to-init
+ */
+const initOptions: InitOptions = {
+  timeout: 2000,
+  streaming: true,
+};
+
+OpenFeature.setProvider(new GrowthbookClientProvider(gbContext, initOptions));
+```
+
+## Building
+
+Run `nx package providers-growthbook-client` to build the library.
+
+## Running unit tests
+
+Run `nx test providers-growthbook-client` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/providers/growthbook-client/babel.config.json
+++ b/libs/providers/growthbook-client/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": [["minify", { "builtIns": false }]]
+}

--- a/libs/providers/growthbook-client/jest.config.ts
+++ b/libs/providers/growthbook-client/jest.config.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+export default {
+  displayName: 'providers-growthbook-client',
+  preset: '../../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/providers/growthbook-client',
+};

--- a/libs/providers/growthbook-client/package-lock.json
+++ b/libs/providers/growthbook-client/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "@openfeature/growthbook-client-provider",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openfeature/growthbook-client-provider",
+      "version": "0.0.1",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@growthbook/growthbook": "^1.0.0",
+        "@openfeature/web-sdk": "^1.0.0"
+      }
+    },
+    "node_modules/@growthbook/growthbook": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@growthbook/growthbook/-/growthbook-1.0.0.tgz",
+      "integrity": "sha512-qfVhZcubsGjJI8oNjZp5g69N7c+NMxWl3WS05Sa93V6qNjE9Uz2PZqj7Qj+6iTEOZ1ignmEsIBJEKfdlpa9INg==",
+      "peer": true,
+      "dependencies": {
+        "dom-mutator": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@openfeature/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-aNuvOmqrFxAyzLnEa3YINsUu1pskXyEeMu4O9Kyde0+cS7q+Tgh4KKePwAROXkhhU1RQckW931P41xK5osXAWA==",
+      "peer": true
+    },
+    "node_modules/@openfeature/web-sdk": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.0.3.tgz",
+      "integrity": "sha512-WIB2hIUbpIxK2nEdchWCKZyLhwFQzr+DUh+NnN+v13VoLHq1CE96zhLHC7IQpgyQ6+L7//tPqgeb112Kmb8MNA==",
+      "peer": true,
+      "peerDependencies": {
+        "@openfeature/core": "1.1.0"
+      }
+    },
+    "node_modules/dom-mutator": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/dom-mutator/-/dom-mutator-0.6.0.tgz",
+      "integrity": "sha512-iCt9o0aYfXMUkz/43ZOAUFQYotjGB+GNbYJiJdz4TgXkyToXbbRy5S6FbTp72lRBtfpUMwEc1KmpFEU4CZeoNg==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    }
+  }
+}

--- a/libs/providers/growthbook-client/package.json
+++ b/libs/providers/growthbook-client/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openfeature/growthbook-client-provider",
+  "version": "0.1.0",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "main": "./src/index.js",
+  "typings": "./src/index.d.ts",
+  "scripts": {
+    "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi",
+    "current-version": "echo $npm_package_version"
+  },
+  "peerDependencies": {
+    "@growthbook/growthbook": "^1.0.0",
+    "@openfeature/web-sdk": "^1.0.0"
+  }
+}

--- a/libs/providers/growthbook-client/project.json
+++ b/libs/providers/growthbook-client/project.json
@@ -1,0 +1,79 @@
+{
+  "name": "providers-growthbook-client",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/providers/growthbook-client/src",
+  "projectType": "library",
+  "targets": {
+    "publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run publish-if-not-exists",
+        "cwd": "dist/libs/providers/growthbook-client"
+      },
+      "dependsOn": [
+        {
+          "projects": "self",
+          "target": "package"
+        }
+      ]
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/providers/growthbook-client/**/*.ts",
+          "libs/providers/growthbook-client/package.json"
+        ]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/providers/growthbook-client/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "package": {
+      "executor": "@nx/rollup:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "project": "libs/providers/growthbook-client/package.json",
+        "outputPath": "dist/libs/providers/growthbook-client",
+        "entryFile": "libs/providers/growthbook-client/src/index.ts",
+        "tsConfig": "libs/providers/growthbook-client/tsconfig.lib.json",
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "compiler": "tsc",
+        "generateExportsField": true,
+        "umdName": "growthbook-client",
+        "external": "all",
+        "format": ["cjs", "esm"],
+        "assets": [
+          {
+            "glob": "package.json",
+            "input": "./assets",
+            "output": "./src/"
+          },
+          {
+            "glob": "LICENSE",
+            "input": "./",
+            "output": "./"
+          },
+          {
+            "glob": "README.md",
+            "input": "./libs/providers/growthbook-client",
+            "output": "./"
+          }
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/providers/growthbook-client/src/index.ts
+++ b/libs/providers/growthbook-client/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/growthbook-client-provider';

--- a/libs/providers/growthbook-client/src/lib/growthbook-client-provider.spec.ts
+++ b/libs/providers/growthbook-client/src/lib/growthbook-client-provider.spec.ts
@@ -1,0 +1,178 @@
+import { Context, GrowthBook, InitOptions } from '@growthbook/growthbook';
+import { GrowthbookClientProvider } from './growthbook-client-provider';
+import { Client, OpenFeature } from '@openfeature/web-sdk';
+
+jest.mock('@growthbook/growthbook');
+
+const testFlagKey = 'flag-key';
+const growthbookContextMock: Context = {
+  apiHost: 'http://api.growthbook.io',
+  clientKey: 'sdk-test-key',
+  attributes: {
+    id: 1,
+  },
+};
+
+const initOptionsMock: InitOptions = {
+  timeout: 5000,
+};
+
+describe('GrowthbookClientProvider', () => {
+  let gbProvider: GrowthbookClientProvider;
+  let ofClient: Client;
+
+  beforeAll(() => {
+    gbProvider = new GrowthbookClientProvider(growthbookContextMock, initOptionsMock);
+    OpenFeature.setProvider(gbProvider);
+    ofClient = OpenFeature.getClient();
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be and instance of GrowthbookClientProvider', () => {
+    expect(new GrowthbookClientProvider(growthbookContextMock, initOptionsMock)).toBeInstanceOf(
+      GrowthbookClientProvider,
+    );
+  });
+
+  describe('constructor', () => {
+    it('should set the growthbook context & initOptions correctly', () => {
+      const provider = new GrowthbookClientProvider(growthbookContextMock, initOptionsMock);
+
+      expect(provider['context']).toEqual(growthbookContextMock);
+      expect(provider['_initOptions']).toEqual(initOptionsMock);
+    });
+  });
+
+  describe('initialize', () => {
+    const provider = new GrowthbookClientProvider(growthbookContextMock);
+
+    it('should call growthbook initialize function with correct arguments', async () => {
+      const evalContext = { deviceId: 5 };
+      await provider.initialize({ deviceId: 5 });
+
+      expect(provider['_client']?.setAttributes).toHaveBeenCalledWith(evalContext);
+    });
+  });
+
+  describe('resolveBooleanEvaluation', () => {
+    it('handles correct return types for boolean variations', () => {
+      jest.spyOn(GrowthBook.prototype, 'evalFeature').mockImplementation(() => ({
+        value: true,
+        source: 'experiment',
+        on: true,
+        off: false,
+        ruleId: 'test',
+        experimentResult: {
+          value: true,
+          variationId: 1,
+          key: 'treatment',
+          inExperiment: true,
+          hashAttribute: 'id',
+          hashValue: 'abc',
+          featureId: testFlagKey,
+        },
+      }));
+
+      const res = ofClient.getBooleanDetails(testFlagKey, false);
+      expect(res).toEqual({
+        flagKey: testFlagKey,
+        flagMetadata: {},
+        value: true,
+        reason: 'experiment',
+        variant: 'treatment',
+      });
+    });
+  });
+
+  describe('resolveStringEvaluation', () => {
+    it('handles correct return types for string variations', () => {
+      jest.spyOn(GrowthBook.prototype, 'evalFeature').mockImplementation(() => ({
+        value: 'Experiment fearlessly, deliver confidently',
+        source: 'experiment',
+        on: true,
+        off: false,
+        ruleId: 'test',
+        experimentResult: {
+          value: 'Experiment fearlessly, deliver confidently',
+          variationId: 1,
+          key: 'treatment',
+          inExperiment: true,
+          hashAttribute: 'id',
+          hashValue: 'abc',
+          featureId: testFlagKey,
+        },
+      }));
+
+      const res = ofClient.getStringDetails(testFlagKey, '');
+      expect(res).toEqual({
+        flagKey: testFlagKey,
+        flagMetadata: {},
+        value: 'Experiment fearlessly, deliver confidently',
+        reason: 'experiment',
+        variant: 'treatment',
+      });
+    });
+  });
+
+  describe('resolveNumberEvaluation', () => {
+    it('handles correct return types for number variations', () => {
+      jest.spyOn(GrowthBook.prototype, 'evalFeature').mockImplementation(() => ({
+        value: 12345,
+        source: 'experiment',
+        on: true,
+        off: false,
+        ruleId: 'test',
+        experimentResult: {
+          value: 12345,
+          variationId: 1,
+          key: 'treatment',
+          inExperiment: true,
+          hashAttribute: 'id',
+          hashValue: 'abc',
+          featureId: testFlagKey,
+        },
+      }));
+
+      const res = ofClient.getNumberDetails(testFlagKey, 1);
+      expect(res).toEqual({
+        flagKey: testFlagKey,
+        flagMetadata: {},
+        value: 12345,
+        reason: 'experiment',
+        variant: 'treatment',
+      });
+    });
+  });
+
+  describe('resolveObjectEvaluation', () => {
+    it('handles correct return types for object variations', () => {
+      jest.spyOn(GrowthBook.prototype, 'evalFeature').mockImplementation(() => ({
+        value: { test: true },
+        source: 'experiment',
+        on: true,
+        off: false,
+        ruleId: 'test',
+        experimentResult: {
+          value: { test: true },
+          variationId: 1,
+          key: 'treatment',
+          inExperiment: true,
+          hashAttribute: 'id',
+          hashValue: 'abc',
+          featureId: testFlagKey,
+        },
+      }));
+
+      const res = ofClient.getObjectDetails(testFlagKey, {});
+      expect(res).toEqual({
+        flagKey: testFlagKey,
+        flagMetadata: {},
+        value: { test: true },
+        reason: 'experiment',
+        variant: 'treatment',
+      });
+    });
+  });
+});

--- a/libs/providers/growthbook-client/src/lib/growthbook-client-provider.ts
+++ b/libs/providers/growthbook-client/src/lib/growthbook-client-provider.ts
@@ -1,0 +1,90 @@
+import {
+  EvaluationContext,
+  Provider,
+  JsonValue,
+  ResolutionDetails,
+  GeneralError,
+  OpenFeatureEventEmitter,
+  ProviderEvents,
+} from '@openfeature/web-sdk';
+
+import { GrowthBook, InitOptions, Context } from '@growthbook/growthbook';
+import isEmpty from 'lodash.isempty';
+import translateResult from './translate-result';
+
+export class GrowthbookClientProvider implements Provider {
+  metadata = {
+    name: GrowthbookClientProvider.name,
+  };
+
+  readonly runsOn = 'client';
+  private _client?: GrowthBook;
+  private readonly context: Context;
+  private _initOptions?: InitOptions;
+  public readonly events = new OpenFeatureEventEmitter();
+
+  constructor(growthbookContext: Context, initOptions?: InitOptions) {
+    this.context = growthbookContext;
+    this._initOptions = initOptions;
+  }
+
+  private get client(): GrowthBook {
+    if (!this._client) {
+      throw new GeneralError('Provider is not initialized');
+    }
+    return this._client;
+  }
+
+  // the global context is passed to the initialization function
+  async initialize(evalContext?: EvaluationContext): Promise<void> {
+    // Use context to construct the instance to instantiate GrowthBook
+    this._client = new GrowthBook(this.context);
+
+    if (!isEmpty(evalContext)) {
+      // Set attributes from the global provider context
+      await this.client.setAttributes(evalContext);
+    }
+
+    await this.client.init(this._initOptions);
+
+    // Monkey-patch the setPayload function to fire an event
+    const setPayload = this._client.setPayload.bind(this._client);
+
+    this._client.setPayload = async (...args) => {
+      await setPayload(...args);
+      this.events.emit(ProviderEvents.ConfigurationChanged);
+    };
+  }
+
+  async onClose(): Promise<void> {
+    return this.client.destroy();
+  }
+
+  async onContextChange(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void> {
+    await this.client.setAttributes(newContext);
+  }
+
+  resolveBooleanEvaluation(flagKey: string, defaultValue: boolean): ResolutionDetails<boolean> {
+    const res = this.client.evalFeature(flagKey);
+
+    return translateResult(res, defaultValue);
+  }
+
+  resolveStringEvaluation(flagKey: string, defaultValue: string): ResolutionDetails<string> {
+    const res = this.client.evalFeature(flagKey);
+
+    return translateResult(res, defaultValue);
+  }
+
+  resolveNumberEvaluation(flagKey: string, defaultValue: number): ResolutionDetails<number> {
+    const res = this.client.evalFeature(flagKey);
+
+    return translateResult(res, defaultValue);
+  }
+
+  resolveObjectEvaluation<U extends JsonValue>(flagKey: string, defaultValue: U): ResolutionDetails<U> {
+    const res = this.client.evalFeature(flagKey);
+
+    return translateResult(res, defaultValue);
+  }
+}

--- a/libs/providers/growthbook-client/src/lib/translate-result.spec.ts
+++ b/libs/providers/growthbook-client/src/lib/translate-result.spec.ts
@@ -1,0 +1,74 @@
+import { TypeMismatchError } from '@openfeature/core';
+import translateResult from './translate-result';
+
+describe('translateResult', () => {
+  it('does populate the errorCode correctly when there is an error', () => {
+    const translated = translateResult<boolean>(
+      {
+        value: true,
+        source: 'unknownFeature',
+        on: true,
+        off: false,
+        ruleId: 'test',
+        experimentResult: {
+          value: true,
+          variationId: 1,
+          key: 'treatment',
+          inExperiment: true,
+          hashAttribute: 'id',
+          hashValue: 'abc',
+          featureId: 'testFlagKey',
+        },
+      },
+      false,
+    );
+    expect(translated.errorCode).toEqual('FLAG_NOT_FOUND');
+  });
+
+  it('does not populate the errorCode when there is not an error', () => {
+    const translated = translateResult<boolean>(
+      {
+        value: true,
+        source: 'defaultValue',
+        on: true,
+        off: false,
+        ruleId: 'test',
+        experimentResult: {
+          value: true,
+          variationId: 1,
+          key: 'treatment',
+          inExperiment: true,
+          hashAttribute: 'id',
+          hashValue: 'abc',
+          featureId: 'testFlagKey',
+        },
+      },
+      false,
+    );
+    expect(translated.errorCode).toBeUndefined();
+  });
+
+  it('throws an error when result type differs from defaultValue type', () => {
+    expect(() =>
+      translateResult<boolean>(
+        {
+          value: 'test',
+          source: 'defaultValue',
+          on: true,
+          off: false,
+          ruleId: 'test',
+          experimentResult: {
+            value: 'test',
+            variationId: 1,
+            key: 'treatment',
+            inExperiment: true,
+            hashAttribute: 'id',
+            hashValue: 'abc',
+            featureId: 'testFlagKey',
+          },
+        },
+        false,
+      ),
+    ).toThrow(TypeMismatchError);
+  });
+});

--- a/libs/providers/growthbook-client/src/lib/translate-result.ts
+++ b/libs/providers/growthbook-client/src/lib/translate-result.ts
@@ -1,0 +1,33 @@
+import { FeatureResult } from '@growthbook/growthbook';
+import { ErrorCode, ResolutionDetails, TypeMismatchError } from '@openfeature/web-sdk';
+
+const FEATURE_RESULT_ERRORS = ['unknownFeature', 'cyclicPrerequisite'];
+
+function translateError(errorKind?: string): ErrorCode {
+  switch (errorKind) {
+    case 'unknownFeature':
+      return ErrorCode.FLAG_NOT_FOUND;
+    case 'cyclicPrerequisite':
+      return ErrorCode.PARSE_ERROR;
+    default:
+      return ErrorCode.GENERAL;
+  }
+}
+
+export default function translateResult<T>(result: FeatureResult, defaultValue: T): ResolutionDetails<T> {
+  if (result.value !== null && typeof result.value !== typeof defaultValue) {
+    throw new TypeMismatchError(`Expected flag type ${typeof defaultValue} but got ${typeof result.value}`);
+  }
+
+  const resolution: ResolutionDetails<T> = {
+    value: result.value === null ? defaultValue : result.value,
+    reason: result.source,
+    variant: result.experimentResult?.key,
+  };
+
+  if (FEATURE_RESULT_ERRORS.includes(result.source)) {
+    resolution.errorCode = translateError(result.source);
+  }
+
+  return resolution;
+}

--- a/libs/providers/growthbook-client/tsconfig.json
+++ b/libs/providers/growthbook-client/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ES6",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/providers/growthbook-client/tsconfig.lib.json
+++ b/libs/providers/growthbook-client/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/providers/growthbook-client/tsconfig.spec.json
+++ b/libs/providers/growthbook-client/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@connectrpc/connect-web": "^1.4.0",
         "@flipt-io/flipt": "^1.0.0",
         "@flipt-io/flipt-client-browser": "^0.0.17",
+        "@growthbook/growthbook": "^1.0.0",
         "@grpc/grpc-js": "^1.9.13",
         "@openfeature/ofrep-core": "^0.1.4",
         "@opentelemetry/api": "^1.3.0",
@@ -2348,6 +2349,17 @@
       "version": "0.0.17",
       "resolved": "https://registry.npmjs.org/@flipt-io/flipt-client-browser/-/flipt-client-browser-0.0.17.tgz",
       "integrity": "sha512-AJxB1xXrK0r1HP3fKTYwcx1Zqwfj890XgsaO0pC4UGp434QyKZTeI386h9EvOHYrVYaZfpAuODjD0YnCM/dT3Q=="
+    },
+    "node_modules/@growthbook/growthbook": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@growthbook/growthbook/-/growthbook-1.0.0.tgz",
+      "integrity": "sha512-qfVhZcubsGjJI8oNjZp5g69N7c+NMxWl3WS05Sa93V6qNjE9Uz2PZqj7Qj+6iTEOZ1ignmEsIBJEKfdlpa9INg==",
+      "dependencies": {
+        "dom-mutator": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.10.7",
@@ -6836,6 +6848,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-mutator": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/dom-mutator/-/dom-mutator-0.6.0.tgz",
+      "integrity": "sha512-iCt9o0aYfXMUkz/43ZOAUFQYotjGB+GNbYJiJdz4TgXkyToXbbRy5S6FbTp72lRBtfpUMwEc1KmpFEU4CZeoNg==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/dom-serializer": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@connectrpc/connect-web": "^1.4.0",
     "@flipt-io/flipt": "^1.0.0",
     "@flipt-io/flipt-client-browser": "^0.0.17",
+    "@growthbook/growthbook": "^1.0.0",
     "@grpc/grpc-js": "^1.9.13",
     "@openfeature/ofrep-core": "^0.1.4",
     "@opentelemetry/api": "^1.3.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -108,6 +108,13 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "versioning": "default"
+    },
+    "libs/providers/growthbook-client": {
+      "release-type": "node",
+      "prerelease": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "versioning": "default"
     }
   },
   "changelog-sections": [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -27,6 +27,7 @@
       "@openfeature/flipt-web-provider": ["libs/providers/flipt-web/src/index.ts"],
       "@openfeature/go-feature-flag-provider": ["libs/providers/go-feature-flag/src/index.ts"],
       "@openfeature/go-feature-flag-web-provider": ["libs/providers/go-feature-flag-web/src/index.ts"],
+      "@openfeature/growthbook-client-provider": ["libs/providers/growthbook-client/src/index.ts"],
       "@openfeature/hooks-open-telemetry": ["libs/hooks/open-telemetry/src/index.ts"],
       "@openfeature/launchdarkly-client-provider": ["libs/providers/launchdarkly-client/src/index.ts"],
       "@openfeature/ofrep-core": ["libs/shared/ofrep-core/src/index.ts"],


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds a new OpenFeature client provider for the GrowthBook JS SDK

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->

- [x] Update README with GrowthBook provider specific information

### How to test
<!-- if applicable, add testing instructions under this section -->
Integrate OpenFeature into a test web app and set it up with this new GrowthBook provider. Ensure that GrowthBook flag evaluation works as expected using the OpenFeature API

[How to set up OpenFeature on a React app](https://openfeature.dev/docs/reference/technologies/client/web/react)

```
// Pass in gbContext the same way you would if you were instantiating GrowthBook directly
OpenFeature.setProvider(new GrowthbookClientProvider(gbContext))
```
