### PR TITLE
feat: Default port to 8015 if in-process resolver is used. #936

### DIFF
--- a/libs/providers/flagd/README.md
+++ b/libs/providers/flagd/README.md
@@ -27,17 +27,23 @@ Options can be defined in the constructor or as environment variables. Construct
 
 ### Available Configuration Options
 
-| Option name                            | Environment variable name      | Type    | Default   | Supported values |
-| -------------------------------------- | ------------------------------ | ------- | --------- | ---------------- |
-| host                                   | FLAGD_HOST                     | string  | localhost |                  |
-| port                                   | FLAGD_PORT                     | number  | 8013      |                  |
-| tls                                    | FLAGD_TLS                      | boolean | false     |                  |
-| socketPath                             | FLAGD_SOCKET_PATH              | string  | -         |                  |
-| resolverType                           | FLAGD_RESOLVER                 | string  | rpc       | rpc, in-process  |
-| offlineFlagSourcePath                  | FLAGD_OFFLINE_FLAG_SOURCE_PATH | string  | -         |                  |
-| selector                               | FLAGD_SOURCE_SELECTOR          | string  | -         |                  |
-| cache                                  | FLAGD_CACHE                    | string  | lru       | lru, disabled    |
-| maxCacheSize                           | FLAGD_MAX_CACHE_SIZE           | int     | 1000      |                  |
+| Option name                            | Environment variable name      | Type    | Default                                                        | Supported values |
+| -------------------------------------- | ------------------------------ | ------- |----------------------------------------------------------------| ---------------- |
+| host                                   | FLAGD_HOST                     | string  | localhost                                                      |                  |
+| port                                   | FLAGD_PORT                     | number  | [resolver specific defaults](#resolver-type-specific-defaults) |                  |
+| tls                                    | FLAGD_TLS                      | boolean | false                                                          |                  |
+| socketPath                             | FLAGD_SOCKET_PATH              | string  | -                                                              |                  |
+| resolverType                           | FLAGD_RESOLVER                 | string  | rpc                                                            | rpc, in-process  |
+| offlineFlagSourcePath                  | FLAGD_OFFLINE_FLAG_SOURCE_PATH | string  | -                                                              |                  |
+| selector                               | FLAGD_SOURCE_SELECTOR          | string  | -                                                              |                  |
+| cache                                  | FLAGD_CACHE                    | string  | lru                                                            | lru, disabled    |
+| maxCacheSize                           | FLAGD_MAX_CACHE_SIZE           | int     | 1000                                                           |                  |
+
+#### Resolver type-specific Defaults
+
+| Option name                            | Environment variable name      |  in-process | rpc  | default |
+| -------------------------------------- | ------------------------------ |-------------|------|---------|
+| port                                   | FLAGD_PORT                     |  8015       | 8013 | 8013    |
 
 Below are examples of usage patterns.
 
@@ -72,7 +78,7 @@ Flag configurations for evaluation are obtained via gRPC protocol using [sync pr
   }))
 ```
 
-In the above example, the provider expects a flag sync service implementation to be available at `localhost:8013` (default host and port).
+In the above example, the provider expects a flag sync service implementation to be available at `localhost:8015` (default host and port).
 
 In-process resolver can also work in an offline mode.
 To enable this mode, you should provide a valid flag configuration file with the option `offlineFlagSourcePath`.

--- a/libs/providers/flagd/src/lib/configuration.spec.ts
+++ b/libs/providers/flagd/src/lib/configuration.spec.ts
@@ -1,4 +1,4 @@
-import { FlagdProviderOptions, getConfig } from './configuration';
+import { Config, FlagdProviderOptions, getConfig } from './configuration';
 import { DEFAULT_MAX_CACHE_SIZE } from './constants';
 
 describe('Configuration', () => {
@@ -76,5 +76,42 @@ describe('Configuration', () => {
   it('should ignore an valid port set as an environment variable', () => {
     process.env['FLAGD_PORT'] = 'invalid number';
     expect(getConfig()).toStrictEqual(expect.objectContaining({ port: 8013 }));
+  });
+
+  describe('port handling', () => {
+    describe('for "in-process" evaluation', () => {
+      const resolverType = 'in-process';
+      const port = 8015;
+      it('should use default in-process port if resolver type is set per envVar and no port is provided', () => {
+        process.env['FLAGD_RESOLVER'] = resolverType;
+        expect(getConfig()).toStrictEqual(expect.objectContaining({ port, resolverType }));
+      });
+      it('should use default in-process port if resolver type is set per options and no port is provided', () => {
+        const options: Partial<Config> = { resolverType };
+        expect(getConfig(options)).toStrictEqual(expect.objectContaining({ port, resolverType }));
+      });
+      it('should use provided port if resolver type is set per options and port', () => {
+        const port = 1111;
+        const options: Partial<Config> = { resolverType, port };
+        expect(getConfig(options)).toStrictEqual(expect.objectContaining({ port, resolverType }));
+      });
+    });
+    describe('for "rpc" evaluation', () => {
+      const resolverType = 'rpc';
+      const port = 8013;
+      it('should use default in-process port if resolver type is set per envVar and no port is provided', () => {
+        process.env['FLAGD_RESOLVER'] = resolverType;
+        expect(getConfig()).toStrictEqual(expect.objectContaining({ port, resolverType }));
+      });
+      it('should use default in-process port if resolver type is set per options and no port is provided', () => {
+        const options: Partial<Config> = { resolverType };
+        expect(getConfig(options)).toStrictEqual(expect.objectContaining({ port, resolverType }));
+      });
+      it('should use provided port if resolver type is set per options and port', () => {
+        const port = 1111;
+        const options: Partial<Config> = { resolverType, port };
+        expect(getConfig(options)).toStrictEqual(expect.objectContaining({ port, resolverType }));
+      });
+    });
   });
 });

--- a/libs/providers/flagd/src/lib/configuration.ts
+++ b/libs/providers/flagd/src/lib/configuration.ts
@@ -72,15 +72,17 @@ export interface Config {
 
 export type FlagdProviderOptions = Partial<Config>;
 
-const DEFAULT_CONFIG: Config = {
+const DEFAULT_CONFIG: Omit<Config, 'port' | 'resolverType'> = {
   host: 'localhost',
-  port: 8013,
   tls: false,
-  resolverType: 'rpc',
   selector: '',
   cache: 'lru',
   maxCacheSize: DEFAULT_MAX_CACHE_SIZE,
 };
+
+const DEFAULT_RPC_CONFIG: Config = { ...DEFAULT_CONFIG, resolverType: 'rpc', port: 8013 };
+
+const DEFAULT_IN_PROCESS_CONFIG: Config = { ...DEFAULT_CONFIG, resolverType: 'in-process', port: 8015 };
 
 enum ENV_VAR {
   FLAGD_HOST = 'FLAGD_HOST',
@@ -125,9 +127,14 @@ const getEnvVarConfig = (): Partial<Config> => ({
 });
 
 export function getConfig(options: FlagdProviderOptions = {}) {
+  const envVarConfig = getEnvVarConfig();
+  const defaultConfig =
+    options.resolverType == 'in-process' || envVarConfig.resolverType == 'in-process'
+      ? DEFAULT_IN_PROCESS_CONFIG
+      : DEFAULT_RPC_CONFIG;
   return {
-    ...DEFAULT_CONFIG,
-    ...getEnvVarConfig(),
+    ...defaultConfig,
+    ...envVarConfig,
     ...options,
   };
 }


### PR DESCRIPTION
closes: #936

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

The flagd provider defaults to RPC mode and the corresponding port (8013) using the [evaluation proto](https://buf.build/open-feature/flagd/docs/main:flagd.evaluation.v1). If the in-process resolver is selected, it operates in in-process mode using the [sync proto](https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1), but still uses port 8013, instead of defaulting to the correct port (8015, for the sync proto).

We improve the configuration by defaulting to port 8015 if the in-process resolver is selected.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #936


