### PR TITLE
fix(gofeatureflag): remove NodeJS.timeout because it fails eslint

### DIFF
--- a/libs/providers/go-feature-flag/src/lib/data-collector-hook.ts
+++ b/libs/providers/go-feature-flag/src/lib/data-collector-hook.ts
@@ -17,7 +17,7 @@ export class GoFeatureFlagDataCollectorHook implements Hook {
   // collectUnCachedEvent (optional) set to true if you want to send all events not only the cached evaluations.
   collectUnCachedEvaluation?: boolean;
   // bgSchedulerId contains the id of the setInterval that is running.
-  private bgScheduler?: NodeJS.Timeout | number;
+  private bgScheduler?: number;
   // dataCollectorBuffer contains all the FeatureEvents that we need to send to the relay-proxy for data collection.
   private dataCollectorBuffer?: FeatureEvent<any>[];
   // dataFlushInterval interval time (in millisecond) we use to call the relay proxy to collect data.

--- a/libs/providers/go-feature-flag/src/lib/data-collector-hook.ts
+++ b/libs/providers/go-feature-flag/src/lib/data-collector-hook.ts
@@ -12,12 +12,13 @@ import { CollectorError } from './errors/collector-error';
 import { GoffApiController } from './controller/goff-api';
 
 const defaultTargetingKey = 'undefined-targetingKey';
+type Timer = ReturnType<typeof setInterval>;
 
 export class GoFeatureFlagDataCollectorHook implements Hook {
   // collectUnCachedEvent (optional) set to true if you want to send all events not only the cached evaluations.
   collectUnCachedEvaluation?: boolean;
   // bgSchedulerId contains the id of the setInterval that is running.
-  private bgScheduler?: number;
+  private bgScheduler?: Timer;
   // dataCollectorBuffer contains all the FeatureEvents that we need to send to the relay-proxy for data collection.
   private dataCollectorBuffer?: FeatureEvent<any>[];
   // dataFlushInterval interval time (in millisecond) we use to call the relay proxy to collect data.


### PR DESCRIPTION
## This PR

The CI in PR #947 had no issue in CI, but it failed during the [release-please job](https://github.com/open-feature/js-sdk-contrib/actions/runs/9675435875/job/26692945884).

I am not sure why those checks are different, I guess we have something different in the CI.
This PR should fix the release please process for the go-feature-flag-provider.

@toddbaert @beeme1mr I am not sure if we have to update the release please file to be sure the right version is released? 