### PR TITLE
fix(flagsmith): boolean defaults and flag state evaluation fixes

### DIFF
--- a/libs/providers/flagsmith-client/README.md
+++ b/libs/providers/flagsmith-client/README.md
@@ -88,11 +88,11 @@ following [OpenFeature events](https://openfeature.dev/specification/types#provi
 
 ## Building
 
-Run `nx package providers-flagsmith` to build the library.
+Run `nx package providers-flagsmith-client` to build the library.
 
 ## Running unit tests
 
-Run `nx test providers-flagsmith` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx test providers-flagsmith-client` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## Examples
 

--- a/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.spec.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.spec.ts
@@ -270,10 +270,16 @@ describe('FlagsmithProvider', () => {
       expect(details.value).toEqual(0);
       expect(details.reason).toEqual('ERROR');
     });
-    it('should use defaults for flags that do not exist', async () => {
+    it('should use defaults for number flags that do not exist', async () => {
       await OpenFeature.setProviderAndWait(provider);
       const details = client.getNumberDetails('dont exist', 0);
       expect(details.value).toEqual(0);
+      expect(details.reason).toEqual('DEFAULT');
+    });
+    it('should use defaults for boolean flags that do not exist', async () => {
+      await OpenFeature.setProviderAndWait(provider);
+      const details = client.getBooleanDetails('dont exist', false);
+      expect(details.value).toEqual(false);
       expect(details.reason).toEqual('DEFAULT');
     });
   });

--- a/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.spec.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.spec.ts
@@ -133,8 +133,8 @@ describe('FlagsmithProvider', () => {
             ...defaultState.flags,
             [exampleBooleanFlag.feature.name]: {
               id: exampleBooleanFlag.feature.id,
-              enabled: false,
-              value: exampleBooleanFlag.feature_state_value,
+              enabled: exampleBooleanFlag.enabled,
+              value: false,
             },
           },
         }),
@@ -202,8 +202,8 @@ describe('FlagsmithProvider', () => {
             ...defaultState.flags,
             [exampleBooleanFlag.feature.name]: {
               id: exampleBooleanFlag.feature.id,
-              enabled: false,
-              value: exampleBooleanFlag.feature_state_value,
+              enabled: exampleBooleanFlag.enabled,
+              value: false,
             },
           },
         }),
@@ -222,9 +222,9 @@ describe('FlagsmithProvider', () => {
     const client = OpenFeature.getClient();
     const config = defaultConfig();
     const provider = new FlagsmithClientProvider({ ...config });
-    it('should resolve booleans to the enabled state', async () => {
+    it('should resolve boolean values', async () => {
       await OpenFeature.setProviderAndWait(provider);
-      const details = client.getBooleanDetails(exampleBooleanFlagName, false);
+      const details = client.getBooleanDetails(exampleBooleanFlagName, true);
       expect(details.value).toEqual(true);
       expect(details.reason).toEqual('STATIC');
     });

--- a/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.ts
@@ -90,8 +90,8 @@ export class FlagsmithClientProvider implements Provider {
     return this.initialize(newContext);
   }
 
-  resolveBooleanEvaluation(flagKey: string) {
-    return this.evaluate<boolean>(flagKey, 'boolean', false);
+  resolveBooleanEvaluation(flagKey: string, defaultValue: boolean) {
+    return this.evaluate<boolean>(flagKey, 'boolean', defaultValue);
   }
 
   resolveStringEvaluation(flagKey: string, defaultValue: string) {

--- a/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.ts
@@ -122,10 +122,7 @@ export class FlagsmithClientProvider implements Provider {
    * @private
    */
   private evaluate<T extends FlagValue>(flagKey: string, type: FlagType, defaultValue: T) {
-    const value = typeFactory(
-      type === 'boolean' ? this._client.hasFeature(flagKey) : this._client.getValue(flagKey),
-      type,
-    );
+    const value = typeFactory(this._client.getValue(flagKey), type);
     if (typeof value !== 'undefined' && typeof value !== type) {
       throw new TypeMismatchError(`flag key ${flagKey} is not of type ${type}`);
     }

--- a/libs/providers/flagsmith-client/src/lib/flagsmith.mocks.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith.mocks.ts
@@ -33,7 +33,7 @@ export const defaultConfig: () => IInitConfig = () => ({
 });
 export const exampleBooleanFlagName = 'example_boolean_flag';
 export const exampleBooleanFlag = {
-  feature_state_value: null,
+  feature_state_value: true,
   enabled: true,
   feature: {
     id: 1,


### PR DESCRIPTION
## This PR
Hey team, I wrote a more detailed issue (#1025) but here is a summary:
>The Flagsmith provider doesn't take into account falsey default values in boolean flags, and it is currently using a fixed truthy value in the code, and the evaluation for these boolean values was based off their existance/enablement, and not their actual value, preventing us from using overrides that change the value, not the enabled status.

This PR includes:
- The fix in `resolveBooleanEvaluation` to allow boolean flags to use a specified default value;
- The fix in `evaluate` to ensure boolean flags don't have a special scenario and also consume it's value instead of checking for the existance of the flag;
- Test scenarios that now validate the state value of boolean flags instead of their enablement;
- Additional test scenarios to ensure default values specified outside of constructor default values are also applied and used;

### Related Issues
Fixes #1025 

### Notes
- I took the liberty to make an adjustment to the readme since the suggested contribution command in the flagsmith provider's README wasn't it's actual project name;
- I noticed the provider was written by one of Flagsmith's Founders (@kyle-ssg) and there was a mention in #836 regarding the behavior for boolean flags using the enablement status so there may be additional context they may have regarding Flagsmith's expected behavior, but upon using their platform it seemed counterintuitive in this scenario.

### Follow-up Tasks
- I haven't identified any follow up tasks, but feel free to flag any you may see.

### How to test
- The test scenarios were adjusted to cover the changes, but you may also experiment with the reproducible example, that has the local changes alongside it: https://github.com/uriell/openfeature-flagsmith-boolean-issues