### PR TITLE
fix(go-feature-flag-web): Set API Key in headers

### DIFF
--- a/libs/providers/go-feature-flag-web/src/lib/go-feature-flag-web-provider.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/go-feature-flag-web-provider.ts
@@ -270,19 +270,13 @@ export class GoFeatureFlagWebProvider implements Provider {
       : endpointURL.pathname + '/' + path;
 
     const request: GoFeatureFlagAllFlagRequest = { evaluationContext: transformContext(context) };
-    const headers = new Headers({
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    });
-    if (this._apiKey) {
-      headers.set('Authorization', `Bearer ${this._apiKey}`);
-    }
-
     const init: RequestInit = {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
+        // we had the authorization header only if we have an API Key
+        ...(this._apiKey ? { Authorization: `Bearer ${this._apiKey}` } : {}),
       },
       body: JSON.stringify(request),
     };


### PR DESCRIPTION
## This PR
We had an issue when adding the `apiKey` as `Authorization` header.
This PR is fixing the problem and adding a test to avoid it in the future.

### Related Issues
Fixes #1029
