### PR TITLE
ci: add adams85 from ConfigCat as component owner

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -5,6 +5,10 @@ components:
     - toddbaert
   libs/providers/config-cat:
     - lukas-reining
+    - adams85
+  libs/providers/config-cat-web:
+    - lukas-reining
+    - adams85
   libs/providers/env-var:
     - beeme1mr
     - toddbaert


### PR DESCRIPTION
## This PR
- Adds @adams85 (ConfigCat) to the component owner's list of the ConfigCat providers. The intention behind this is that we (ConfigCat) would like to mark the providers in this repo as the official OpenFeature JS providers for ConfigCat, and we would like to participate in their development and maintenance.

### Notes
I noticed that the `config-cat-web` provider wasn't on the list, so I added it. Please let me know if there was a specific reason not to list it, and I'll remove it from this PR.

