### PR TITLE
fix: missing lodash dep (and tooling fix)

### DIFF
--- a/libs/providers/growthbook-client/project.json
+++ b/libs/providers/growthbook-client/project.json
@@ -50,6 +50,7 @@
         "entryFile": "libs/providers/growthbook-client/src/index.ts",
         "tsConfig": "libs/providers/growthbook-client/tsconfig.lib.json",
         "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true,
         "compiler": "tsc",
         "generateExportsField": true,
         "umdName": "growthbook-client",

--- a/tools/workspace-plugin/src/generators/open-feature/index.ts
+++ b/tools/workspace-plugin/src/generators/open-feature/index.ts
@@ -124,6 +124,7 @@ function updateProject(tree: Tree, projectRoot: string, umdName: string) {
         entryFile: `${projectRoot}/src/index.ts`,
         tsConfig: `${projectRoot}/tsconfig.lib.json`,
         buildableProjectDepsInPackageJsonType: 'dependencies',
+        updateBuildableProjectDepsInPackageJson: true,
         compiler: 'tsc',
         generateExportsField: true,
         umdName,


### PR DESCRIPTION
This adds the `updateBuildableProjectDepsInPackageJson` to the growthbook provider, which fixes a bug by allowing NX to automatically generate deps based on usage. It also fixes the root cause of this missing in our template generators.

Fixes: https://github.com/open-feature/js-sdk-contrib/issues/1032

You can see the difference in the bundled output in these screenshots (before/after):

![image](https://github.com/user-attachments/assets/8ff39d57-66b0-4b97-a1eb-e0e56afd0164)
![image](https://github.com/user-attachments/assets/fbbce356-c415-4409-8fa1-0cd680df093c)
