### PR TITLE
fix(config-cat-web): Update dependency configcat-js-ssr to v8.4.2

### DIFF
--- a/libs/providers/config-cat-web/package-lock.json
+++ b/libs/providers/config-cat-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.1",
       "peerDependencies": {
         "@openfeature/web-sdk": "^1.0.0",
-        "configcat-js-ssr": "^8.4.1"
+        "configcat-js-ssr": "^8.4.2"
       }
     },
     "node_modules/@openfeature/core": {
@@ -34,9 +34,9 @@
       "peer": true
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -66,12 +66,12 @@
       }
     },
     "node_modules/configcat-js-ssr": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/configcat-js-ssr/-/configcat-js-ssr-8.4.1.tgz",
-      "integrity": "sha512-MWYgtaBkWzAbIPy0hA0M1UV1JSqzXhk1m25f1HFbQMoP/ybX/lDrGUiCMyDosPjcV82qjul8MTiDWIIgOfabPw==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/configcat-js-ssr/-/configcat-js-ssr-8.4.2.tgz",
+      "integrity": "sha512-ksn7aV428kVg/XmzHGVLIYn5ds6b8VVpVHPTgmJ2CXcHeXJ+NeoyRWYgO+Zz3HzMxlKW1IMVthZAk62PajlelQ==",
       "peer": true,
       "dependencies": {
-        "axios": "^1.6.8",
+        "axios": "^1.7.4",
         "configcat-common": "9.3.0",
         "tslib": "^2.4.1"
       }

--- a/libs/providers/config-cat-web/package.json
+++ b/libs/providers/config-cat-web/package.json
@@ -7,6 +7,6 @@
   },
   "peerDependencies": {
     "@openfeature/web-sdk": "^1.0.0",
-    "configcat-js-ssr": "^8.4.1"
+    "configcat-js-ssr": "^8.4.2"
   }
 }


### PR DESCRIPTION
## This PR

Yet another [security vulnerability](https://github.com/advisories/GHSA-8hc4-vh64-cxmj) has been discovered in `axios`, so a [new version](https://github.com/configcat/js-ssr-sdk/releases/tag/v8.4.2) of `configcat-js-ssr` was released, referencing the patched version of `axios`.

This PR updates the `configcat-js-ssr` dependency of the `config-cat-web` provider to the new version.
