### PR TITLE
fix(flagd): improve targeting key check in fractional operator

### DIFF
--- a/libs/shared/flagd-core/src/lib/targeting/fractional.ts
+++ b/libs/shared/flagd-core/src/lib/targeting/fractional.ts
@@ -29,12 +29,12 @@ export function fractionalFactory(logger: Logger) {
       bucketBy = args[0];
       buckets = args.slice(1, args.length);
     } else {
-      bucketBy = `${flagdProperties[flagKeyPropertyKey]}${context[targetingPropertyKey]}`;
-      if (!bucketBy) {
+      const targetingKey = context[targetingPropertyKey];
+      if (!targetingKey) {
         logger.debug('Missing targetingKey property, cannot perform fractional targeting');
         return null;
       }
-
+      bucketBy = `${flagdProperties[flagKeyPropertyKey]}${targetingKey}`;
       buckets = args;
     }
 

--- a/libs/shared/flagd-core/src/lib/targeting/targeting.spec.ts
+++ b/libs/shared/flagd-core/src/lib/targeting/targeting.spec.ts
@@ -187,6 +187,17 @@ describe('fractional operator', () => {
 
     expect(targeting.applyTargeting('flagA', input, { targetingKey: 'bucketKeyB' })).toBe('blue');
   });
+
+  it('should return null if targeting key is missing', () => {
+    const input = {
+      fractional: [
+        ['red', 1],
+        ['blue', 1],
+      ],
+    };
+
+    expect(targeting.applyTargeting('flagA', input, {})).toBe(null);
+  });
 });
 
 describe('fractional operator should validate', () => {


### PR DESCRIPTION
## This PR

- improve targeting key check in fractional operator

### Notes

The old logic was always truthy. This corrects the behavior and brings it in line with Java.

https://github.com/open-feature/java-sdk-contrib/blob/main/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/targeting/Fractional.java#L43

### How to test

Run the jest test suite. The test added this PR failed before the fix.
