### PR TITLE
docs: fix README.md for flipt-web provider

### DIFF
--- a/libs/providers/flipt-web/README.md
+++ b/libs/providers/flipt-web/README.md
@@ -20,7 +20,7 @@ npm install @openfeature/web-sdk @openfeature/flipt-web-provider
 To initialize the OpenFeature client with Flipt, you can use the following code snippet:
 
 ```ts
-import { FliptWebProvider } from '@openfeature/flipt-web';
+import { FliptWebProvider } from '@openfeature/flipt-web-provider';
 
 const provider = new FliptWebProvider('namespace-of-choice', { url: 'http://your.upstream.flipt.host' });
 await OpenFeature.setProviderAndWait(provider);


### PR DESCRIPTION
## This PR
- Adds missing `-provider` suffix in the import statement for `FliptWebProvider` in the documentation

### Notes
This change ensures consistency with the actual package name and prevents potential confusion for users trying to import the package.