### PR TITLE
fix: using GrowthBook renderer interface to trigger ConfigurationChanged events instead of patching specific methods

### DIFF
--- a/libs/providers/growthbook-client/src/lib/growthbook-client-provider.ts
+++ b/libs/providers/growthbook-client/src/lib/growthbook-client-provider.ts
@@ -47,13 +47,9 @@ export class GrowthbookClientProvider implements Provider {
 
     await this.client.init(this._initOptions);
 
-    // Monkey-patch the setPayload function to fire an event
-    const setPayload = this._client.setPayload.bind(this._client);
-
-    this._client.setPayload = async (...args) => {
-      await setPayload(...args);
+    this._client.setRenderer(() => {
       this.events.emit(ProviderEvents.ConfigurationChanged);
-    };
+    });
   }
 
   async onClose(): Promise<void> {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Using GrowthBook default renderer listener to trigger ConfigurationChanged events: https://github.com/growthbook/growthbook/blob/adbf2d7a577b4b2856fb5e2d153a375ec15ea11b/packages/sdk-js/src/GrowthBook.ts#L215

### Related Issues

GrowthBook SSE are not triggering rerenders, so realtime flag updates are not happening.

### Notes

### Follow-up Tasks

### How to test

