### PR TITLE
fix(go-feature-flag-web): avoid infinite loop in waitWebsocketFinalSt…

### DIFF
--- a/libs/providers/go-feature-flag-web/src/lib/go-feature-flag-web-provider.spec.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/go-feature-flag-web-provider.spec.ts
@@ -606,4 +606,22 @@ describe('GoFeatureFlagWebProvider', () => {
       await OpenFeature.close();
     });
   });
+  describe('waitWebsocketFinalStatus', () => {
+    it('should resolve when WebSocket is open', async () => {
+      const provider = new GoFeatureFlagWebProvider({ endpoint: 'http://localhost:1031' });
+      const websocket = new WebSocket(websocketEndpoint);
+
+      const promise = provider.waitWebsocketFinalStatus(websocket);
+      await websocketMockServer.connected;
+
+      await expect(promise).resolves.toBeUndefined();
+    });
+  });
+});
+it('should reject after maximum retries', async () => {
+  const provider = new GoFeatureFlagWebProvider({ endpoint: 'http://localhost:1031', maxRetries: 1 });
+  const websocket = new WebSocket('ws://localhost:1031/ws/v1/flag/change');
+  await expect(provider.waitWebsocketFinalStatus(websocket)).rejects.toThrow(
+    'Maximum retries reached while waiting for websocket connection',
+  );
 });

--- a/libs/providers/go-feature-flag-web/src/lib/go-feature-flag-web-provider.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/go-feature-flag-web-provider.ts
@@ -133,11 +133,16 @@ export class GoFeatureFlagWebProvider implements Provider {
    * @param socket - the websocket you are waiting for
    */
   waitWebsocketFinalStatus(socket: WebSocket): Promise<void> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
+      let retries = 0;
       const checkConnection = () => {
         if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CLOSED) {
           return resolve();
         }
+        if (retries >= this._maxRetries) {
+          return reject(new Error('Maximum retries reached while waiting for websocket connection'));
+        }
+        retries++;
         // Wait 5 milliseconds before checking again
         setTimeout(checkConnection, 5);
       };


### PR DESCRIPTION
## This PR
This PR fixes the issue https://github.com/thomaspoignant/go-feature-flag/issues/2753 for the web provider when we had an infinite loop when trying to connect with the websocket and an invalid API key.

### Related Issues

Fixes https://github.com/thomaspoignant/go-feature-flag/issues/2753