### PR TITLE
feat: Accept timeout for LD waitForInitialization

### DIFF
--- a/libs/providers/launchdarkly-client/src/lib/launchdarkly-client-provider.spec.ts
+++ b/libs/providers/launchdarkly-client/src/lib/launchdarkly-client-provider.spec.ts
@@ -80,6 +80,17 @@ describe('LaunchDarklyClientProvider', () => {
       expect(initialize).toHaveBeenCalledTimes(1);
       /* when not set in open feauture LD sdk initialize should be called with the anonymous context*/
       expect(initialize).toHaveBeenCalledWith(envKey, { anonymous: true }, { logger });
+      expect(ldClientMock.waitForInitialization).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should call Ld waitForInitialization with correct arguments', async () => {
+      const provider = new LaunchDarklyClientProvider(envKey, { logger, initializationTimeout: 5 });
+      await provider.initialize();
+      expect(initialize).toHaveBeenCalledTimes(1);
+      /* when not set in open feauture LD sdk initialize should be called with the anonymous context*/
+      expect(initialize).toHaveBeenCalledWith(envKey, { anonymous: true }, { logger });
+      expect(ldClientMock.waitForInitialization).toHaveBeenCalledTimes(1);
+      expect(ldClientMock.waitForInitialization).toHaveBeenCalledWith(5);
     });
 
     it('should set the status to READY if initialization succeeds', async () => {

--- a/libs/providers/launchdarkly-client/src/lib/launchdarkly-client-provider.ts
+++ b/libs/providers/launchdarkly-client/src/lib/launchdarkly-client-provider.ts
@@ -42,6 +42,7 @@ export class LaunchDarklyClientProvider implements Provider {
 
   private readonly ldOptions: LDOptions | undefined;
   private readonly logger: Logger;
+  private readonly initializationTimeout?: number;
   private _client?: LDClient;
 
   public events = new OpenFeatureEventEmitter();
@@ -62,13 +63,14 @@ export class LaunchDarklyClientProvider implements Provider {
 
   constructor(
     private readonly envKey: string,
-    { logger, ...ldOptions }: LaunchDarklyProviderOptions,
+    { logger, initializationTimeout, ...ldOptions }: LaunchDarklyProviderOptions,
   ) {
     if (logger) {
       this.logger = logger;
     } else {
       this.logger = basicLogger({ level: 'info' });
     }
+    this.initializationTimeout = initializationTimeout;
     this.ldOptions = { ...ldOptions, logger: this.logger };
   }
 
@@ -92,7 +94,7 @@ export class LaunchDarklyClientProvider implements Provider {
     }
 
     try {
-      await this._client.waitForInitialization();
+      await this._client.waitForInitialization(this.initializationTimeout);
       this.status = ProviderStatus.READY;
     } catch {
       this.status = ProviderStatus.ERROR;

--- a/libs/providers/launchdarkly-client/src/lib/launchdarkly-provider-options.ts
+++ b/libs/providers/launchdarkly-client/src/lib/launchdarkly-provider-options.ts
@@ -36,4 +36,16 @@ export interface LaunchDarklyProviderOptions extends LDOptions {
    * disclaimer: this logger instance will be used by the launch-darkly sdk
    */
   logger?: LDLogger | Logger;
+
+  /**
+   * Configures the amount of time, in seconds, to wait for initialization when
+   * connecting to the LaunchDarkly service.
+   *
+   * Using a large timeout is not recommended as network delays may cause your
+   * application to wait a long time before continuing execution.
+   *
+   * See the launchdarkly-js-client-sdk docs for more details:
+   * {@link https://launchdarkly.github.io/js-client-sdk/interfaces/LDClient.html#waitForInitialization}
+   */
+  initializationTimeout?: number;
 }


### PR DESCRIPTION
Add a new option to the LaunchDarkly provider constructor, `initializationTimeout`, which lets users optionally configure the timeout used in the LDClient `waitForInitialization` method. This timeout is critical because it otherwise would cause the LDClient to hang indefinitely in cases where the network connection cannot be established.