### PR TITLE
build(renovate): Utilize default OpenFeature Renovate configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,7 @@
 [submodule "libs/shared/flagd-core/test-harness"]
 	path = libs/shared/flagd-core/test-harness
 	url = https://github.com/open-feature/flagd-testbed
+	branch = v0.5.13
 [submodule "libs/shared/flagd-core/spec"]
 	path = libs/shared/flagd-core/spec
 	url = https://github.com/open-feature/spec

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
-  "semanticCommits": "enabled",
-  "labels": [
-    "renovate"
-  ],
+  "extends": ["github>open-feature/community-tooling"],
   "packageRules": [
     {
       "matchPackagePatterns": ["^@nx/", "nx"],


### PR DESCRIPTION
We do have a default OpenFeature Renovate configuration within our community-tooling repository. (https://github.com/open-feature/community-tooling/blob/main/renovate.json)

To reduce maintenance efforts, we should stick to the general one as a basis.
