### PR TITLE
feat(go-feature-flag): Support exporter metadata in web and server providers

### DIFF
--- a/libs/providers/go-feature-flag-web/src/lib/controller/goff-api.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/controller/goff-api.ts
@@ -1,4 +1,4 @@
-import { DataCollectorRequest, FeatureEvent, GoFeatureFlagWebProviderOptions } from '../model';
+import { DataCollectorRequest, ExporterMetadataValue, FeatureEvent, GoFeatureFlagWebProviderOptions } from '../model';
 import { CollectorError } from '../errors/collector-error';
 
 export class GoffApiController {
@@ -15,7 +15,7 @@ export class GoffApiController {
     this.options = options;
   }
 
-  async collectData(events: FeatureEvent<any>[], dataCollectorMetadata: Record<string, string>) {
+  async collectData(events: FeatureEvent<any>[], dataCollectorMetadata: Record<string, ExporterMetadataValue>) {
     if (events?.length === 0) {
       return;
     }

--- a/libs/providers/go-feature-flag-web/src/lib/data-collector-hook.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/data-collector-hook.ts
@@ -1,5 +1,5 @@
 import { EvaluationDetails, FlagValue, Hook, HookContext, Logger } from '@openfeature/web-sdk';
-import { FeatureEvent, GoFeatureFlagWebProviderOptions } from './model';
+import { ExporterMetadataValue, FeatureEvent, GoFeatureFlagWebProviderOptions } from './model';
 import { copy } from 'copy-anything';
 import { CollectorError } from './errors/collector-error';
 import { GoffApiController } from './controller/goff-api';
@@ -15,9 +15,7 @@ export class GoFeatureFlagDataCollectorHook implements Hook {
   // dataFlushInterval interval time (in millisecond) we use to call the relay proxy to collect data.
   private readonly dataFlushInterval: number;
   // dataCollectorMetadata are the metadata used when calling the data collector endpoint
-  private readonly dataCollectorMetadata: Record<string, string> = {
-    provider: 'open-feature-js-sdk',
-  };
+  private readonly dataCollectorMetadata: Record<string, ExporterMetadataValue>;
   private readonly goffApiController: GoffApiController;
   // logger is the Open Feature logger to use
   private logger?: Logger;
@@ -26,6 +24,11 @@ export class GoFeatureFlagDataCollectorHook implements Hook {
     this.dataFlushInterval = options.dataFlushInterval || 1000 * 60;
     this.logger = logger;
     this.goffApiController = new GoffApiController(options);
+    this.dataCollectorMetadata = {
+      provider: 'web',
+      openfeature: true,
+      ...options.exporterMetadata,
+    };
   }
 
   init() {

--- a/libs/providers/go-feature-flag-web/src/lib/model.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/model.ts
@@ -43,7 +43,7 @@ export interface GoFeatureFlagWebProviderOptions {
   // Default: 100 ms
   retryInitialDelay?: number;
 
-  // multiplier of retryInitialDelay after each failure
+  // retryDelayMultiplier (optional) multiplier of retryInitialDelay after each failure
   // (example: 1st connection retry will be after 100ms, second after 200ms, third after 400ms ...)
   // Default: 2
   retryDelayMultiplier?: number;
@@ -58,9 +58,19 @@ export interface GoFeatureFlagWebProviderOptions {
   // default: 1 minute
   dataFlushInterval?: number;
 
-  // disableDataCollection set to true if you don't want to collect the usage of flags retrieved in the cache.
+  // disableDataCollection (optional) set to true if you don't want to collect the usage of flags retrieved in the cache.
   disableDataCollection?: boolean;
+
+  // exporterMetadata (optional) exporter metadata is a set of key-value that will be added to the metadata when calling the
+  // exporter API. All those information will be added to the event produce by the exporter.
+  //
+  // ‼️Important: If you are using a GO Feature Flag relay proxy before version v1.41.0, the information
+  // of this field will not be added to your feature events.
+  exporterMetadata?: Record<string, ExporterMetadataValue>;
 }
+
+// ExporterMetadataValue is the type of the value that can be used in the exporterMetadata
+export type ExporterMetadataValue = string | number | boolean;
 
 /**
  * FlagState is the object used to get the value return by GO Feature Flag.
@@ -97,7 +107,7 @@ export interface GOFeatureFlagWebsocketResponse {
 
 export interface DataCollectorRequest<T> {
   events: FeatureEvent<T>[];
-  meta: Record<string, string>;
+  meta: Record<string, ExporterMetadataValue>;
 }
 
 export interface FeatureEvent<T> {

--- a/libs/providers/go-feature-flag/src/lib/controller/goff-api.ts
+++ b/libs/providers/go-feature-flag/src/lib/controller/goff-api.ts
@@ -2,6 +2,7 @@ import {
   ConfigurationChange,
   DataCollectorRequest,
   DataCollectorResponse,
+  ExporterMetadataValue,
   FeatureEvent,
   GoFeatureFlagProviderOptions,
   GoFeatureFlagProxyRequest,
@@ -146,7 +147,7 @@ export class GoffApiController {
     };
   }
 
-  async collectData(events: FeatureEvent<any>[], dataCollectorMetadata: Record<string, string>) {
+  async collectData(events: FeatureEvent<any>[], dataCollectorMetadata: Record<string, ExporterMetadataValue>) {
     if (events?.length === 0) {
       return;
     }

--- a/libs/providers/go-feature-flag/src/lib/data-collector-hook.ts
+++ b/libs/providers/go-feature-flag/src/lib/data-collector-hook.ts
@@ -6,7 +6,7 @@ import {
   Logger,
   StandardResolutionReasons,
 } from '@openfeature/server-sdk';
-import { DataCollectorHookOptions, FeatureEvent } from './model';
+import { DataCollectorHookOptions, ExporterMetadataValue, FeatureEvent } from './model';
 import { copy } from 'copy-anything';
 import { CollectorError } from './errors/collector-error';
 import { GoffApiController } from './controller/goff-api';
@@ -24,9 +24,7 @@ export class GoFeatureFlagDataCollectorHook implements Hook {
   // dataFlushInterval interval time (in millisecond) we use to call the relay proxy to collect data.
   private readonly dataFlushInterval: number;
   // dataCollectorMetadata are the metadata used when calling the data collector endpoint
-  private readonly dataCollectorMetadata: Record<string, string> = {
-    provider: 'open-feature-js-sdk',
-  };
+  private readonly dataCollectorMetadata: Record<string, ExporterMetadataValue>;
   private readonly goffApiController: GoffApiController;
   // logger is the Open Feature logger to use
   private logger?: Logger;
@@ -36,6 +34,11 @@ export class GoFeatureFlagDataCollectorHook implements Hook {
     this.logger = logger;
     this.goffApiController = goffApiController;
     this.collectUnCachedEvaluation = options.collectUnCachedEvaluation;
+    this.dataCollectorMetadata = {
+      provider: 'js',
+      openfeature: true,
+      ...options.exporterMetadata,
+    };
   }
 
   init() {

--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
@@ -38,7 +38,11 @@ export class GoFeatureFlagProvider implements Provider {
   constructor(options: GoFeatureFlagProviderOptions, logger?: Logger) {
     this._goffApiController = new GoffApiController(options);
     this._dataCollectorHook = new GoFeatureFlagDataCollectorHook(
-      { dataFlushInterval: options.dataFlushInterval },
+      {
+        dataFlushInterval: options.dataFlushInterval,
+        collectUnCachedEvaluation: false,
+        exporterMetadata: options.exporterMetadata,
+      },
       this._goffApiController,
       logger,
     );

--- a/libs/providers/go-feature-flag/src/lib/model.ts
+++ b/libs/providers/go-feature-flag/src/lib/model.ts
@@ -72,14 +72,24 @@ export interface GoFeatureFlagProviderOptions {
   // If a negative number is provided, the provider will not poll.
   // Default: 30000
   pollInterval?: number; // in milliseconds
+
+  // exporterMetadata (optional) exporter metadata is a set of key-value that will be added to the metadata when calling the
+  // exporter API. All those information will be added to the event produce by the exporter.
+  //
+  // ‼️Important: If you are using a GO Feature Flag relay proxy before version v1.41.0, the information
+  // of this field will not be added to your feature events.
+  exporterMetadata?: Record<string, ExporterMetadataValue>;
 }
+
+// ExporterMetadataValue is the type of the value that can be used in the exporterMetadata
+export type ExporterMetadataValue = string | number | boolean;
 
 // GOFeatureFlagResolutionReasons allows to extends resolution reasons
 export declare enum GOFeatureFlagResolutionReasons {}
 
 export interface DataCollectorRequest<T> {
   events: FeatureEvent<T>[];
-  meta: Record<string, string>;
+  meta: Record<string, ExporterMetadataValue>;
 }
 
 export interface FeatureEvent<T> {
@@ -107,6 +117,13 @@ export interface DataCollectorHookOptions {
 
   // collectUnCachedEvent (optional) set to true if you want to send all events not only the cached evaluations.
   collectUnCachedEvaluation?: boolean;
+
+  // exporterMetadata (optional) exporter metadata is a set of key-value that will be added to the metadata when calling the
+  // exporter API. All those information will be added to the event produce by the exporter.
+  //
+  // ‼️Important: If you are using a GO Feature Flag relay proxy before version v1.41.0, the information
+  // of this field will not be added to your feature events.
+  exporterMetadata?: Record<string, ExporterMetadataValue>;
 }
 
 export enum ConfigurationChange {


### PR DESCRIPTION
## This PR
Supporting new functionality of GO Feature Flag called `ExporterMetadata` in the web and server providers.
Check https://github.com/thomaspoignant/go-feature-flag/issues/2936 for more information.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes https://github.com/thomaspoignant/go-feature-flag/issues/2939, https://github.com/thomaspoignant/go-feature-flag/issues/2940
