### PR TITLE
fix(go-feature-flag): Support endpoint paths in data collector goff-api.ts

### DIFF
--- a/libs/providers/go-feature-flag-web/src/lib/controller/goff-api.spec.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/controller/goff-api.spec.ts
@@ -103,6 +103,52 @@ describe('Collect Data API', () => {
     );
   });
 
+  it('should call the API to collect data with endpoint path', async () => {
+    fetchMock.post('https://gofeatureflag.org/examplepath/v1/data/collector', 200);
+    const options: GoFeatureFlagWebProviderOptions = {
+      endpoint: 'https://gofeatureflag.org/examplepath',
+      apiTimeout: 1000,
+    };
+    const goff = new GoffApiController(options);
+    await goff.collectData(
+      [
+        {
+          key: 'flagKey',
+          contextKind: 'user',
+          creationDate: 1733138237486,
+          default: false,
+          kind: 'feature',
+          userKey: 'toto',
+          value: true,
+          variation: 'varA',
+        },
+      ],
+      { provider: 'open-feature-js-sdk' },
+    );
+    expect(fetchMock.lastUrl()).toBe('https://gofeatureflag.org/examplepath/v1/data/collector');
+    expect(fetchMock.lastOptions()?.headers).toEqual({
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    });
+    expect(fetchMock.lastOptions()?.body).toEqual(
+      JSON.stringify({
+        events: [
+          {
+            key: 'flagKey',
+            contextKind: 'user',
+            creationDate: 1733138237486,
+            default: false,
+            kind: 'feature',
+            userKey: 'toto',
+            value: true,
+            variation: 'varA',
+          },
+        ],
+        meta: { provider: 'open-feature-js-sdk' },
+      }),
+    );
+  });
+
   it('should not call the API to collect data if no event provided', async () => {
     fetchMock.post('https://gofeatureflag.org/v1/data/collector', 200);
     const options: GoFeatureFlagWebProviderOptions = {

--- a/libs/providers/go-feature-flag-web/src/lib/controller/goff-api.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/controller/goff-api.ts
@@ -22,7 +22,10 @@ export class GoffApiController {
 
     const request: DataCollectorRequest<boolean> = { events: events, meta: dataCollectorMetadata };
     const endpointURL = new URL(this.endpoint);
-    endpointURL.pathname = 'v1/data/collector';
+    const dataCollectorPath = 'v1/data/collector';
+    endpointURL.pathname = endpointURL.pathname.endsWith('/')
+      ? endpointURL.pathname + dataCollectorPath
+      : endpointURL.pathname + '/' + dataCollectorPath;
 
     try {
       const headers: HeadersInit = {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Behavior: web provider instances with paths in the endpoint will not have paths included in data collector calls
- Change: Match pathname logic in main web provider for data collector: https://github.com/open-feature/js-sdk-contrib/blob/main/libs/providers/go-feature-flag-web/src/lib/go-feature-flag-web-provider.ts#L95

### How to test
<!-- if applicable, add testing instructions under this section -->

- Instantiate web provider with endpoint like `https://some.website/examplepath`
- Check data collector calls go to `https://some.website/examplepath/v1/data/collector`