### PR TITLE
feat: support proxy routing via gRPC default_authority

### DIFF
--- a/libs/providers/flagd/README.md
+++ b/libs/providers/flagd/README.md
@@ -96,7 +96,8 @@ This mode is useful for local development, test cases, and for offline applicati
 
 ### Default Authority usage (optional)
 
-This is useful for complex routing or service-discovery usecases that involve a proxy (e.g., Envoy). Please refer to this [link](https://github.com/open-feature/js-sdk-contrib/issues/1187) for more information.
+This is useful for complex routing or service-discovery use cases that involve a proxy (e.g., Envoy).
+Please refer to this [GitHub issue](https://github.com/open-feature/js-sdk-contrib/issues/1187) for more information.
 
 ```ts
   OpenFeature.setProvider(new FlagdProvider({

--- a/libs/providers/flagd/README.md
+++ b/libs/providers/flagd/README.md
@@ -38,6 +38,7 @@ Options can be defined in the constructor or as environment variables. Construct
 | selector                               | FLAGD_SOURCE_SELECTOR          | string  | -                                                              |                  |
 | cache                                  | FLAGD_CACHE                    | string  | lru                                                            | lru, disabled    |
 | maxCacheSize                           | FLAGD_MAX_CACHE_SIZE           | int     | 1000                                                           |                  |
+| defaultAuthority                       | FLAGD_DEFAULT_AUTHORITY        | string  | -                                                              | rpc, in-process  |
 
 #### Resolver type-specific Defaults
 
@@ -92,6 +93,17 @@ To enable this mode, you should provide a valid flag configuration file with the
 
 Offline mode uses `fs.watchFile` and polls every 5 seconds for changes to the file.
 This mode is useful for local development, test cases, and for offline applications.
+
+### Default Authority usage (optional)
+
+This is useful for complex routing or service-discovery usecases that involve a proxy (e.g., Envoy). Please refer to this [link](https://github.com/open-feature/js-sdk-contrib/issues/1187) for more information.
+
+```ts
+  OpenFeature.setProvider(new FlagdProvider({
+      resolverType: 'in-process',
+      defaultAuthority: 'b-target-api.service',
+  }))
+```
 
 ### Supported Events
 

--- a/libs/providers/flagd/src/lib/configuration.spec.ts
+++ b/libs/providers/flagd/src/lib/configuration.spec.ts
@@ -31,6 +31,7 @@ describe('Configuration', () => {
     const resolverType = 'in-process';
     const selector = 'app=weather';
     const offlineFlagSourcePath = '/tmp/flags.json';
+    const defaultAuthority = 'test-authority';
 
     process.env['FLAGD_HOST'] = host;
     process.env['FLAGD_PORT'] = `${port}`;
@@ -41,6 +42,7 @@ describe('Configuration', () => {
     process.env['FLAGD_SOURCE_SELECTOR'] = `${selector}`;
     process.env['FLAGD_RESOLVER'] = `${resolverType}`;
     process.env['FLAGD_OFFLINE_FLAG_SOURCE_PATH'] = offlineFlagSourcePath;
+    process.env['FLAGD_DEFAULT_AUTHORITY'] = defaultAuthority;
 
     expect(getConfig()).toStrictEqual({
       host,
@@ -52,6 +54,7 @@ describe('Configuration', () => {
       resolverType,
       selector,
       offlineFlagSourcePath,
+      defaultAuthority,
     });
   });
 
@@ -64,11 +67,13 @@ describe('Configuration', () => {
       cache: 'lru',
       resolverType: 'rpc',
       selector: '',
+      defaultAuthority: '',
     };
 
     process.env['FLAGD_HOST'] = 'override';
     process.env['FLAGD_PORT'] = '8080';
     process.env['FLAGD_TLS'] = 'false';
+    process.env['FLAGD_DEFAULT_AUTHORITY'] = 'test-authority-override';
 
     expect(getConfig(options)).toStrictEqual(options);
   });

--- a/libs/providers/flagd/src/lib/configuration.ts
+++ b/libs/providers/flagd/src/lib/configuration.ts
@@ -68,6 +68,13 @@ export interface Config {
    * @default 1000
    */
   maxCacheSize?: number;
+
+  /**
+   * The target host (authority) when routing requests through a proxy (e.g. Envoy)
+   *
+   * @default ''
+   */
+  defaultAuthority?: string;
 }
 
 export type FlagdProviderOptions = Partial<Config>;
@@ -94,6 +101,7 @@ enum ENV_VAR {
   FLAGD_SOURCE_SELECTOR = 'FLAGD_SOURCE_SELECTOR',
   FLAGD_RESOLVER = 'FLAGD_RESOLVER',
   FLAGD_OFFLINE_FLAG_SOURCE_PATH = 'FLAGD_OFFLINE_FLAG_SOURCE_PATH',
+  FLAGD_DEFAULT_AUTHORITY = 'FLAGD_DEFAULT_AUTHORITY',
 }
 
 const getEnvVarConfig = (): Partial<Config> => ({
@@ -123,6 +131,9 @@ const getEnvVarConfig = (): Partial<Config> => ({
   }),
   ...(process.env[ENV_VAR.FLAGD_OFFLINE_FLAG_SOURCE_PATH] && {
     offlineFlagSourcePath: process.env[ENV_VAR.FLAGD_OFFLINE_FLAG_SOURCE_PATH],
+  }),
+  ...(process.env[ENV_VAR.FLAGD_DEFAULT_AUTHORITY] && {
+    defaultAuthority: process.env[ENV_VAR.FLAGD_DEFAULT_AUTHORITY],
   }),
 });
 

--- a/libs/providers/flagd/src/lib/configuration.ts
+++ b/libs/providers/flagd/src/lib/configuration.ts
@@ -72,7 +72,6 @@ export interface Config {
   /**
    * The target host (authority) when routing requests through a proxy (e.g. Envoy)
    *
-   * @default ''
    */
   defaultAuthority?: string;
 }

--- a/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
+++ b/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
@@ -1,4 +1,4 @@
-import { ClientReadableStream, ClientUnaryCall, ServiceError, credentials, status } from '@grpc/grpc-js';
+import { ClientReadableStream, ClientUnaryCall, ServiceError, credentials, status, ClientOptions } from '@grpc/grpc-js';
 import { ConnectivityState } from '@grpc/grpc-js/build/src/connectivity-state';
 import {
   EvaluationContext,
@@ -80,12 +80,20 @@ export class GRPCService implements Service {
     client?: ServiceClient,
     private logger?: Logger,
   ) {
-    const { host, port, tls, socketPath } = config;
+    const { host, port, tls, socketPath, defaultAuthority } = config;
+    let clientOptions: ClientOptions | undefined;
+    if (defaultAuthority) {
+      clientOptions = {
+        'grpc.default_authority': defaultAuthority,
+      };
+    }
+
     this._client = client
       ? client
       : new ServiceClient(
           socketPath ? `unix://${socketPath}` : `${host}:${port}`,
           tls ? credentials.createSsl() : credentials.createInsecure(),
+          clientOptions,
         );
 
     if (config.cache === 'lru') {

--- a/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.spec.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.spec.ts
@@ -44,7 +44,7 @@ const serviceMock: FlagSyncServiceClient = {
 } as unknown as FlagSyncServiceClient;
 
 describe('grpc fetch', () => {
-  const cfg: Config = { host: 'localhost', port: 8000, tls: false, socketPath: '' };
+  const cfg: Config = { host: 'localhost', port: 8000, tls: false, socketPath: '', defaultAuthority: 'test-authority' };
 
   afterEach(() => {
     jest.clearAllMocks();

--- a/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
@@ -1,4 +1,4 @@
-import { ClientReadableStream, ServiceError, credentials } from '@grpc/grpc-js';
+import { ClientReadableStream, ServiceError, credentials, ClientOptions } from '@grpc/grpc-js';
 import { GeneralError, Logger } from '@openfeature/server-sdk';
 import { FlagSyncServiceClient, SyncFlagsRequest, SyncFlagsResponse } from '../../../../proto/ts/flagd/sync/v1/sync';
 import { Config } from '../../../configuration';
@@ -27,13 +27,20 @@ export class GrpcFetch implements DataFetch {
   private _isConnected = false;
 
   constructor(config: Config, syncServiceClient?: FlagSyncServiceClient, logger?: Logger) {
-    const { host, port, tls, socketPath, selector } = config;
+    const { host, port, tls, socketPath, selector, defaultAuthority } = config;
+    let clientOptions: ClientOptions | undefined;
+    if (defaultAuthority) {
+      clientOptions = {
+        'grpc.default_authority': defaultAuthority,
+      };
+    }
 
     this._syncClient = syncServiceClient
       ? syncServiceClient
       : new FlagSyncServiceClient(
           socketPath ? `unix://${socketPath}` : `${host}:${port}`,
           tls ? credentials.createSsl() : credentials.createInsecure(),
+          clientOptions,
         );
 
     this._logger = logger;


### PR DESCRIPTION
## This PR
To provide a :authority header to request route to target backend services using default_authority parameter by the JS clients. This enable better integration with service proxies like Envoy, facilitating more flexible and robust gRPC client configurations.

### Related Issues
https://github.com/open-feature/js-sdk-contrib/issues/1187
https://github.com/open-feature/flagd/issues/1532

### How to test
Use defaultAuthority parameter to pass down the target authority when sending a grpc request from client side. 

