### PR TITLE
fix: Removed incorrect string case format from the options.authentica…

### DIFF
--- a/libs/providers/flipt-web/src/lib/flipt-web-provider.ts
+++ b/libs/providers/flipt-web/src/lib/flipt-web-provider.ts
@@ -47,19 +47,11 @@ export class FliptWebProvider implements Provider {
   }
 
   async initializeClient() {
-    let authentication = {};
-
-    if (this._options?.authentication && 'clientToken' in this._options.authentication) {
-      authentication = { client_token: this._options.authentication.clientToken };
-    } else if (this._options?.authentication && 'jwtToken' in this._options.authentication) {
-      authentication = { jwt_token: this._options.authentication.jwtToken };
-    }
-
     try {
       this._client = await FliptEvaluationClient.init(this._namespace || 'default', {
         url: this._options?.url || 'http://localhost:8080',
         fetcher: this._options?.fetcher,
-        authentication,
+        authentication: this._options?.authentication,
       });
     } catch (e) {
       throw new ProviderFatalError(getErrorMessage(e));


### PR DESCRIPTION
## This PR
Solves a problem with authentication using **flipt-web-provider**: FliptEvaluationClient using  needs to receive options.authentication in camel case, not snake case.

Removed entire if statement from line 92 to line 104. This change will not affect functionality after switching to camelCase, as it will correctly format the auth. 

### Related Issues

Fixes #1208

### How to test
Initialize the provider, and check if the web request has the Auth header:

```js
  const provider = new FliptWebProvider(
    "NAMESPACE",
    {
      url: "URL",
      authentication: {
        clientToken: "123RANDOM_TOKEN321",
      },
    }
  );

  await OpenFeature.setProviderAndWait(provider);
```

