### PR TITLE
fix: improper inclusion of test deps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,7 +56,7 @@
             "checkObsoleteDependencies": true,
             "checkVersionMismatches": true,
             "ignoredDependencies": ["jest-cucumber", "jest"],
-            "ignoredFiles": ["**/*.spec.ts", "**/*.spec.js", "**/*.test.ts", "**/*.test.js"]
+            "ignoredFiles": ["**/test/**", "**/spec/**", "**/*.spec.ts", "**/*.spec.js", "**/*.test.ts", "**/*.test.js"]
           }
         ]
       }

--- a/libs/shared/ofrep-core/package.json
+++ b/libs/shared/ofrep-core/package.json
@@ -8,8 +8,5 @@
   },
   "peerDependencies": {
     "@openfeature/core": "^1.6.0"
-  },
-  "dependencies": {
-    "msw": "^2.2.3"
   }
 }


### PR DESCRIPTION
Fixes an issue where our auto dependency inclusion was a bit overactive and includes a mock server (msw) as a real dep.

This was because msw was used for a mock/test server which exists in not in a `.spec` or `.test` file, but in a `test/` dir.

I've updated the dependency analysis rules accordingly and this is no longer flagged to be added.