### PR TITLE
chore: address linting issue

### DIFF
--- a/libs/shared/ofrep-core/src/lib/api/errors.ts
+++ b/libs/shared/ofrep-core/src/lib/api/errors.ts
@@ -57,7 +57,7 @@ export class OFREPApiTooManyRequestsError extends OFREPApiError {
     this.name = OFREPApiTooManyRequestsError.name;
     this.requestTime = new Date();
     this.message =
-      message ?? this.retryAfterDate
+      (message ?? this.retryAfterDate)
         ? `rate limit exceeded, try again after ${this.retryAfterDate}`
         : `rate limit exceeded, try again later`;
   }


### PR DESCRIPTION
```
nx run ofrep-core:lint
  Linting "ofrep-core"...
  
  /home/runner/work/js-sdk-contrib/js-sdk-contrib/libs/shared/ofrep-core/src/lib/api/errors.ts
    60:7  error  Replace `message·??·this.retryAfterDate` with `(message·??·this.retryAfterDate)`  prettier/prettier
  
  ✖ 1 problem (1 error, 0 warnings)
    1 error and 0 warnings potentially fixable with the `--fix` option.
  
  ✖ 1 problem (1 error, 0 warnings)
    1 error and 0 warnings are potentially fixable with the `--fix` option.
```

https://github.com/open-feature/js-sdk-contrib/actions/runs/13907544265/job/38914010257?pr=1221