### PR TITLE
chore: add 1.13.0 as a valid grpc-js peer version

### DIFF
--- a/libs/providers/flagd/package.json
+++ b/libs/providers/flagd/package.json
@@ -7,7 +7,7 @@
     "current-version": "echo $npm_package_version"
   },
   "peerDependencies": {
-    "@grpc/grpc-js": "~1.8.0 || ~1.9.0 || ~1.10.0 || ~1.11.0 || ~1.12.0",
+    "@grpc/grpc-js": "~1.8.0 || ~1.9.0 || ~1.10.0 || ~1.11.0 || ~1.12.0 || ~1.13.0",
     "@openfeature/server-sdk": "^1.17.0"
   },
   "dependencies": {


### PR DESCRIPTION
Address a lint issue: https://github.com/open-feature/js-sdk-contrib/actions/runs/13907544265/job/38914010257?pr=1221