### PR TITLE
fix(generator): update generated path  `project.json`, `jest.config.ts`, `.eslintrc.json`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
       - run: git branch --track main origin/main || true
 
       - run: if ! npx nx format:check ; then echo "Format check failed. Please run 'npx nx format:write'."; fi
-      - run: npx nx affected --target=lint --parallel=3
-      - run: npx nx affected --target=test --parallel=3 --ci --code-coverage
-      - run: npx nx affected --target=build --parallel=3
+      - run: npx nx affected --target=lint --parallel=3 --exclude=js-sdk-contrib
+      - run: npx nx affected --target=test --parallel=3 --ci --code-coverage --exclude=js-sdk-contrib
+      - run: npx nx affected --target=build --parallel=3 --exclude=js-sdk-contrib
 
   e2e:
       runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "scripts": {
     "generate-hook": "nx generate open-feature hook",
     "generate-provider": "nx generate open-feature provider",
-    "test": "nx run-many --all --target=test --skip-nx-cache",
-    "e2e": "nx run-many --all --target=e2e --skip-nx-cache --output-style=stream --parallel=false",
-    "lint": "nx run-many --all --target=lint --skip-nx-cache",
-    "lint:fix": "nx run-many --all --target=lint --skip-nx-cache --fix",
-    "package": "npx nx run-many --all --target=package",
-    "publish": "npx nx run-many --all --target=publish"
+    "test": "nx run-many --all --target=test --skip-nx-cache --exclude=js-sdk-contrib",
+    "e2e": "nx run-many --all --target=e2e --skip-nx-cache --output-style=stream --parallel=false --exclude=js-sdk-contrib",
+    "lint": "nx run-many --all --target=lint --skip-nx-cache --exclude=js-sdk-contrib",
+    "lint:fix": "nx run-many --all --target=lint --skip-nx-cache --fix --exclude=js-sdk-contrib",
+    "package": "npx nx run-many --all --target=package --exclude=js-sdk-contrib",
+    "publish": "npx nx run-many --all --target=publish --exclude=js-sdk-contrib"
   },
   "private": true,
   "dependencies": {
@@ -92,6 +92,7 @@
     "ts-jest": "29.2.5",
     "ts-node": "10.9.2",
     "typescript": "5.7.3",
-    "undici": "^5.0.0"
+    "undici": "^5.0.0",
+    "verdaccio": "^5.0.4"
   }
 }

--- a/project.json
+++ b/project.json
@@ -1,0 +1,14 @@
+{
+  "name": "js-sdk-contrib",
+  "$schema": "node_modules/nx/schemas/project-schema.json",
+  "targets": {
+    "local-registry": {
+      "executor": "@nx/js:verdaccio",
+      "options": {
+        "port": 4873,
+        "config": ".verdaccio/config.yml",
+        "storage": "tmp/local-registry/storage"
+      }
+    }
+  }
+}

--- a/tools/workspace-plugin/src/generators/open-feature/index.ts
+++ b/tools/workspace-plugin/src/generators/open-feature/index.ts
@@ -68,7 +68,7 @@ export default async function (tree: Tree, schema: SchemaOptions) {
   updateTsConfig(tree, projectRoot);
   updateEslintrc(tree, projectRoot);
   updateJestConfig(tree, projectRoot);
-  updateProjectJson(tree,projectRoot)
+  updateProjectJson(tree, projectRoot);
   updatePackage(tree, projectRoot, schema);
   updateReleasePleaseConfig(tree, projectRoot);
   updateReleasePleaseManifest(tree, projectRoot);
@@ -201,7 +201,7 @@ function updateTsConfig(tree: Tree, projectRoot: string) {
   });
 }
 
-function updateEslintrc(tree : Tree, projectRoot: string){
+function updateEslintrc(tree: Tree, projectRoot: string) {
   // Update .eslintrc.json root location
   updateJson(tree, joinPathFragments(projectRoot, '.eslintrc.json'), (json) => {
     json.extends = `../../${json.extends}`;
@@ -209,28 +209,27 @@ function updateEslintrc(tree : Tree, projectRoot: string){
   });
 }
 
-function updateJestConfig(tree : Tree, projectRoot: string){
-
-  const configPath = joinPathFragments(projectRoot, 'jest.config.ts')
+function updateJestConfig(tree: Tree, projectRoot: string) {
+  const configPath = joinPathFragments(projectRoot, 'jest.config.ts');
 
   // Update jest.preset.js path
   let contents = tree.read(configPath)!.toString();
-  const replaceJestPresetPath = contents.replace('../jest.preset.js', '../../../jest.preset.js')
-  tree.write(configPath, replaceJestPresetPath)
+  const replaceJestPresetPath = contents.replace('../jest.preset.js', '../../../jest.preset.js');
+  tree.write(configPath, replaceJestPresetPath);
 
   // Update coverage path
-  contents = tree.read(configPath)!.toString()
-  const replaceCoveragePath = contents.replace('../coverage/providers', `../../../coverage/${projectRoot}`)
-  tree.write(configPath, replaceCoveragePath)
- }
+  contents = tree.read(configPath)!.toString();
+  const replaceCoveragePath = contents.replace('../coverage/providers', `../../../coverage/${projectRoot}`);
+  tree.write(configPath, replaceCoveragePath);
+}
 
- function updateProjectJson(tree : Tree, projectRoot : string){
+function updateProjectJson(tree: Tree, projectRoot: string) {
   // Update jest.config.ts location
-  updateJson(tree,  joinPathFragments(projectRoot, 'project.json'), (json)=>{
-    json.targets.test.options.jestConfig  = "{projectRoot}/jest.config.ts"
-    return json
-  })
- }
+  updateJson(tree, joinPathFragments(projectRoot, 'project.json'), (json) => {
+    json.targets.test.options.jestConfig = '{projectRoot}/jest.config.ts';
+    return json;
+  });
+}
 
 function updateReleasePleaseConfig(tree: Tree, projectRoot: string) {
   updateJson(tree, 'release-please-config.json', (json) => {

--- a/tools/workspace-plugin/src/generators/open-feature/index.ts
+++ b/tools/workspace-plugin/src/generators/open-feature/index.ts
@@ -42,6 +42,7 @@ export default async function (tree: Tree, schema: SchemaOptions) {
   });
 
   // move the files to the right location in the tree
+  console.log(tree, directory, projectRoot);
   moveFilesToNewDirectory(tree, directory, projectRoot);
 
   // delete the auto-generated files
@@ -65,6 +66,9 @@ export default async function (tree: Tree, schema: SchemaOptions) {
 
   updateProject(tree, projectRoot, name);
   updateTsConfig(tree, projectRoot);
+  updateEslintrc(tree, projectRoot);
+  updateJestConfig(tree, projectRoot);
+  updateProjectJson(tree,projectRoot)
   updatePackage(tree, projectRoot, schema);
   updateReleasePleaseConfig(tree, projectRoot);
   updateReleasePleaseManifest(tree, projectRoot);
@@ -196,6 +200,37 @@ function updateTsConfig(tree: Tree, projectRoot: string) {
     return json;
   });
 }
+
+function updateEslintrc(tree : Tree, projectRoot: string){
+  // Update .eslintrc.json root location
+  updateJson(tree, joinPathFragments(projectRoot, '.eslintrc.json'), (json) => {
+    json.extends = `../../${json.extends}`;
+    return json;
+  });
+}
+
+function updateJestConfig(tree : Tree, projectRoot: string){
+
+  const configPath = joinPathFragments(projectRoot, 'jest.config.ts')
+
+  // Update jest.preset.js path
+  let contents = tree.read(configPath)!.toString();
+  const replaceJestPresetPath = contents.replace('../jest.preset.js', '../../../jest.preset.js')
+  tree.write(configPath, replaceJestPresetPath)
+
+  // Update coverage path
+  contents = tree.read(configPath)!.toString()
+  const replaceCoveragePath = contents.replace('../coverage/providers', `../../../coverage/${projectRoot}`)
+  tree.write(configPath, replaceCoveragePath)
+ }
+
+ function updateProjectJson(tree : Tree, projectRoot : string){
+  // Update jest.config.ts location
+  updateJson(tree,  joinPathFragments(projectRoot, 'project.json'), (json)=>{
+    json.targets.test.options.jestConfig  = "{projectRoot}/jest.config.ts"
+    return json
+  })
+ }
 
 function updateReleasePleaseConfig(tree: Tree, projectRoot: string) {
   updateJson(tree, 'release-please-config.json', (json) => {

--- a/tools/workspace-plugin/src/generators/open-feature/index.ts
+++ b/tools/workspace-plugin/src/generators/open-feature/index.ts
@@ -42,7 +42,6 @@ export default async function (tree: Tree, schema: SchemaOptions) {
   });
 
   // move the files to the right location in the tree
-  console.log(tree, directory, projectRoot);
   moveFilesToNewDirectory(tree, directory, projectRoot);
 
   // delete the auto-generated files


### PR DESCRIPTION
## This PR

This PR fix wrong path generation in freshly created provider after `npm run generate-provider` command


### Related Issues

Running `test` and `lint` commands on a freshly generated provider ( by using `npm run generate-provider`) throws errors  which makes harder starting contribution on the project

Steps to reproduce: 

- Run `npm run generate-provider` and create a new `example` provider
- Launch `npx nx run example:lint` and you will get ` NX   Failed to load config "../.eslintrc.json" to extend from.` error
- Launch `npx nx run example:test` and you will get  ` NX   Can't find a root directory while resolving a config file path.` error

### How to test

Repeat all steps and you will be able to run lint and test command on a freshly created provider

