### PR TITLE
feat(gofeatureflag): added cache option

### DIFF
--- a/libs/providers/go-feature-flag/src/lib/controller/cache.ts
+++ b/libs/providers/go-feature-flag/src/lib/controller/cache.ts
@@ -10,7 +10,7 @@ export class CacheController {
   // logger is the Open Feature logger to use
   private logger?: Logger;
   // cache contains the local cache used in the provider to avoid calling the relay-proxy for every evaluation
-  private readonly cache?: LRUCache<string, ResolutionDetails<any>> | Cache;
+  private readonly cache?: Cache;
   // options for this provider
   private readonly options: GoFeatureFlagProviderOptions;
 

--- a/libs/providers/go-feature-flag/src/lib/controller/cache.ts
+++ b/libs/providers/go-feature-flag/src/lib/controller/cache.ts
@@ -20,7 +20,7 @@ export class CacheController {
     this.logger = logger;
     const cacheSize =
       options.flagCacheSize !== undefined && options.flagCacheSize !== 0 ? options.flagCacheSize : 10000;
-    this.cache = new LRUCache({ maxSize: cacheSize, sizeCalculation: () => 1 });
+    this.cache = options.cache || new LRUCache({ maxSize: cacheSize, sizeCalculation: () => 1 });
   }
 
   get(flagKey: string, evaluationContext: EvaluationContext): ResolutionDetails<any> | undefined {

--- a/libs/providers/go-feature-flag/src/lib/controller/cache.ts
+++ b/libs/providers/go-feature-flag/src/lib/controller/cache.ts
@@ -1,4 +1,4 @@
-import { GoFeatureFlagProviderOptions } from '../model';
+import { GoFeatureFlagProviderOptions, Cache } from '../model';
 import { EvaluationContext, Logger, ResolutionDetails } from '@openfeature/server-sdk';
 import { LRUCache } from 'lru-cache';
 import hash from 'object-hash';
@@ -10,7 +10,7 @@ export class CacheController {
   // logger is the Open Feature logger to use
   private logger?: Logger;
   // cache contains the local cache used in the provider to avoid calling the relay-proxy for every evaluation
-  private readonly cache?: LRUCache<string, ResolutionDetails<any>>;
+  private readonly cache?: LRUCache<string, ResolutionDetails<any>> | Cache;
   // options for this provider
   private readonly options: GoFeatureFlagProviderOptions;
 

--- a/libs/providers/go-feature-flag/src/lib/model.ts
+++ b/libs/providers/go-feature-flag/src/lib/model.ts
@@ -38,7 +38,7 @@ export interface GoFeatureFlagProxyResponse<T> {
  */
 export interface Cache {
   get: (key: string) => ResolutionDetails<any> | undefined;
-  set: (key: string, value: ResolutionDetails<any>, options?: { ttl?: number }) => void;
+  set: (key: string, value: ResolutionDetails<any>, options?: Record<string, any>) => void;
   clear: () => void;
 }
 
@@ -143,4 +143,3 @@ export enum ConfigurationChange {
   FLAG_CONFIGURATION_UPDATED,
   FLAG_CONFIGURATION_NOT_CHANGED,
 }
-

--- a/libs/providers/go-feature-flag/src/lib/model.ts
+++ b/libs/providers/go-feature-flag/src/lib/model.ts
@@ -56,7 +56,7 @@ export interface GoFeatureFlagProviderOptions {
   // Default: null
   apiKey?: string;
 
-  // cache (optional) set to true if you want to use an alternative cache library.
+  // cache (optional) set an alternative cache library.
   cache?: Cache;
 
   // disableCache (optional) set to true if you would like that every flag evaluation goes to the GO Feature Flag directly.

--- a/libs/providers/go-feature-flag/src/lib/model.ts
+++ b/libs/providers/go-feature-flag/src/lib/model.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, EvaluationContextValue } from '@openfeature/server-sdk';
+import { ErrorCode, EvaluationContextValue, ResolutionDetails } from '@openfeature/server-sdk';
 
 export interface GOFFEvaluationContext {
   key: string;
@@ -34,6 +34,15 @@ export interface GoFeatureFlagProxyResponse<T> {
 }
 
 /**
+ * Cache is the interface used to implement an alternative cache for the provider.
+ */
+export interface Cache {
+  get: (key: string) => ResolutionDetails<any> | undefined;
+  set: (key: string, value: ResolutionDetails<any>, options?: { ttl?: number }) => void;
+  clear: () => void;
+}
+
+/**
  * GoFeatureFlagProviderOptions is the object containing all the provider options
  * when initializing the open-feature provider.
  */
@@ -46,6 +55,9 @@ export interface GoFeatureFlagProviderOptions {
   // (This feature is available only if you are using GO Feature Flag relay proxy v1.7.0 or above)
   // Default: null
   apiKey?: string;
+
+  // cache (optional) set to true if you want to use an alternative cache library.
+  cache?: Cache;
 
   // disableCache (optional) set to true if you would like that every flag evaluation goes to the GO Feature Flag directly.
   disableCache?: boolean;
@@ -131,3 +143,4 @@ export enum ConfigurationChange {
   FLAG_CONFIGURATION_UPDATED,
   FLAG_CONFIGURATION_NOT_CHANGED,
 }
+


### PR DESCRIPTION
Resolves #1283

## Description
We want to be able to provide our own caching library when using the Server SDK. Adding the `cache` property to GoFeatureFlagProviderOptions.