### PR TITLE
chore: add "type" import enforcement lint rule and apply

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,14 @@
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
       "rules": {
+        "@typescript-eslint/consistent-type-imports": [
+          "error",
+          {
+            "disallowTypeAnnotations": true,
+            "fixStyle": "separate-type-imports",
+            "prefer": "type-imports"
+          }
+        ],
         "@nx/enforce-module-boundaries": [
           "error",
           {

--- a/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.spec.ts
+++ b/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.spec.ts
@@ -1,6 +1,8 @@
-import { BeforeHookContext, EvaluationDetails, HookContext, StandardResolutionReasons } from '@openfeature/server-sdk';
+import type { BeforeHookContext, EvaluationDetails, HookContext } from '@openfeature/server-sdk';
+import { StandardResolutionReasons } from '@openfeature/server-sdk';
 import opentelemetry from '@opentelemetry/api';
-import { DataPoint, MeterProvider, MetricReader, ScopeMetrics } from '@opentelemetry/sdk-metrics';
+import type { DataPoint, ScopeMetrics } from '@opentelemetry/sdk-metrics';
+import { MeterProvider, MetricReader } from '@opentelemetry/sdk-metrics';
 import {
   ACTIVE_COUNT_NAME,
   ERROR_TOTAL_NAME,
@@ -12,7 +14,7 @@ import {
   VARIANT_ATTR,
 } from '../conventions';
 import { MetricsHook } from './metrics-hook';
-import { AttributeMapper } from '../otel-hook';
+import type { AttributeMapper } from '../otel-hook';
 
 // no-op "in-memory" reader
 class InMemoryMetricReader extends MetricReader {

--- a/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.ts
+++ b/libs/hooks/open-telemetry/src/lib/metrics/metrics-hook.ts
@@ -1,19 +1,18 @@
+import type { BeforeHookContext, Logger } from '@openfeature/server-sdk';
 import {
-  BeforeHookContext,
-  Logger,
   StandardResolutionReasons,
   type EvaluationDetails,
   type FlagValue,
   type Hook,
   type HookContext,
 } from '@openfeature/server-sdk';
-import { Attributes, Counter, UpDownCounter, ValueType, metrics } from '@opentelemetry/api';
+import type { Attributes, Counter, UpDownCounter } from '@opentelemetry/api';
+import { ValueType, metrics } from '@opentelemetry/api';
+import type { EvaluationAttributes, ExceptionAttributes } from '../conventions';
 import {
   ACTIVE_COUNT_NAME,
   ERROR_TOTAL_NAME,
   EXCEPTION_ATTR,
-  EvaluationAttributes,
-  ExceptionAttributes,
   KEY_ATTR,
   PROVIDER_NAME_ATTR,
   REASON_ATTR,
@@ -21,7 +20,8 @@ import {
   SUCCESS_TOTAL_NAME,
   VARIANT_ATTR,
 } from '../conventions';
-import { OpenTelemetryHook, OpenTelemetryHookOptions } from '../otel-hook';
+import type { OpenTelemetryHookOptions } from '../otel-hook';
+import { OpenTelemetryHook } from '../otel-hook';
 
 type ErrorEvaluationAttributes = EvaluationAttributes & ExceptionAttributes;
 

--- a/libs/hooks/open-telemetry/src/lib/otel-hook.ts
+++ b/libs/hooks/open-telemetry/src/lib/otel-hook.ts
@@ -1,5 +1,5 @@
-import { FlagMetadata, Logger } from '@openfeature/server-sdk';
-import { Attributes } from '@opentelemetry/api';
+import type { FlagMetadata, Logger } from '@openfeature/server-sdk';
+import type { Attributes } from '@opentelemetry/api';
 
 export type AttributeMapper = (flagMetadata: FlagMetadata) => Attributes;
 

--- a/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.spec.ts
+++ b/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.spec.ts
@@ -1,4 +1,4 @@
-import { EvaluationDetails, HookContext } from '@openfeature/server-sdk';
+import type { EvaluationDetails, HookContext } from '@openfeature/server-sdk';
 
 const addEvent = jest.fn();
 const recordException = jest.fn();

--- a/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.ts
+++ b/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.ts
@@ -1,7 +1,8 @@
-import { Hook, HookContext, EvaluationDetails, FlagValue, Logger } from '@openfeature/server-sdk';
+import type { Hook, HookContext, EvaluationDetails, FlagValue, Logger } from '@openfeature/server-sdk';
 import { trace } from '@opentelemetry/api';
 import { FEATURE_FLAG, KEY_ATTR, PROVIDER_NAME_ATTR, VARIANT_ATTR } from '../conventions';
-import { OpenTelemetryHook, OpenTelemetryHookOptions } from '../otel-hook';
+import type { OpenTelemetryHookOptions } from '../otel-hook';
+import { OpenTelemetryHook } from '../otel-hook';
 
 export type TracingHookOptions = OpenTelemetryHookOptions;
 

--- a/libs/providers/aws-ssm/src/integration/integration.spec.ts
+++ b/libs/providers/aws-ssm/src/integration/integration.spec.ts
@@ -1,6 +1,7 @@
 import { OpenFeature } from '@openfeature/server-sdk';
 import { AwsSsmProvider } from '../lib/aws-ssm-provider';
-import { GetParameterCommand, GetParameterCommandOutput, SSMClient } from '@aws-sdk/client-ssm';
+import type { GetParameterCommandOutput } from '@aws-sdk/client-ssm';
+import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
 import { mockClient } from 'aws-sdk-client-mock';
 
 const ssmMock = mockClient(SSMClient);

--- a/libs/providers/aws-ssm/src/lib/aws-ssm-provider.spec.ts
+++ b/libs/providers/aws-ssm/src/lib/aws-ssm-provider.spec.ts
@@ -1,4 +1,4 @@
-import { SSMClientConfig } from '@aws-sdk/client-ssm';
+import type { SSMClientConfig } from '@aws-sdk/client-ssm';
 import { AwsSsmProvider } from './aws-ssm-provider';
 import { ErrorCode, StandardResolutionReasons } from '@openfeature/core';
 

--- a/libs/providers/aws-ssm/src/lib/aws-ssm-provider.ts
+++ b/libs/providers/aws-ssm/src/lib/aws-ssm-provider.ts
@@ -1,13 +1,7 @@
-import {
-  EvaluationContext,
-  Provider,
-  JsonValue,
-  ResolutionDetails,
-  StandardResolutionReasons,
-  ErrorCode,
-} from '@openfeature/server-sdk';
+import type { EvaluationContext, Provider, JsonValue, ResolutionDetails } from '@openfeature/server-sdk';
+import { StandardResolutionReasons, ErrorCode } from '@openfeature/server-sdk';
 import { InternalServerError } from '@aws-sdk/client-ssm';
-import { AwsSsmProviderConfig } from './types';
+import type { AwsSsmProviderConfig } from './types';
 import { SSMService } from './ssm-service';
 import { Cache } from './cache';
 

--- a/libs/providers/aws-ssm/src/lib/cache.ts
+++ b/libs/providers/aws-ssm/src/lib/cache.ts
@@ -1,5 +1,5 @@
-import { ResolutionDetails } from '@openfeature/core';
-import { LRUCacheConfig } from './types';
+import type { ResolutionDetails } from '@openfeature/core';
+import type { LRUCacheConfig } from './types';
 import { LRUCache } from 'lru-cache';
 
 export class Cache {

--- a/libs/providers/aws-ssm/src/lib/ssm-service.ts
+++ b/libs/providers/aws-ssm/src/lib/ssm-service.ts
@@ -1,19 +1,8 @@
-import {
-  GetParameterCommand,
-  SSMClient,
-  SSMClientConfig,
-  GetParameterCommandInput,
-  DescribeParametersCommand,
-} from '@aws-sdk/client-ssm';
-import { ResponseMetadata } from '@smithy/types';
-import {
-  FlagNotFoundError,
-  TypeMismatchError,
-  JsonValue,
-  ParseError,
-  ResolutionDetails,
-  StandardResolutionReasons,
-} from '@openfeature/core';
+import type { SSMClientConfig, GetParameterCommandInput } from '@aws-sdk/client-ssm';
+import { GetParameterCommand, SSMClient, DescribeParametersCommand } from '@aws-sdk/client-ssm';
+import type { ResponseMetadata } from '@smithy/types';
+import type { JsonValue, ResolutionDetails } from '@openfeature/core';
+import { FlagNotFoundError, TypeMismatchError, ParseError, StandardResolutionReasons } from '@openfeature/core';
 
 export class SSMService {
   client: SSMClient;

--- a/libs/providers/aws-ssm/src/lib/types.ts
+++ b/libs/providers/aws-ssm/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { SSMClientConfig } from '@aws-sdk/client-ssm';
+import type { SSMClientConfig } from '@aws-sdk/client-ssm';
 
 export type AwsSsmProviderConfig = {
   ssmClientConfig: SSMClientConfig;

--- a/libs/providers/config-cat-web/src/lib/config-cat-web-provider.spec.ts
+++ b/libs/providers/config-cat-web/src/lib/config-cat-web-provider.spec.ts
@@ -1,14 +1,7 @@
 import { ConfigCatWebProvider } from './config-cat-web-provider';
-import {
-  createConsoleLogger,
-  createFlagOverridesFromMap,
-  HookEvents,
-  IConfigCatCache,
-  ISettingUnion,
-  LogLevel,
-  OverrideBehaviour,
-} from 'configcat-js-ssr';
-import { EventEmitter } from 'events';
+import type { HookEvents, IConfigCatCache, ISettingUnion } from 'configcat-js-ssr';
+import { createConsoleLogger, createFlagOverridesFromMap, LogLevel, OverrideBehaviour } from 'configcat-js-ssr';
+import type { EventEmitter } from 'events';
 import { ProviderEvents, ParseError, FlagNotFoundError, TypeMismatchError } from '@openfeature/web-sdk';
 
 describe('ConfigCatWebProvider', () => {

--- a/libs/providers/config-cat-web/src/lib/config-cat-web-provider.ts
+++ b/libs/providers/config-cat-web/src/lib/config-cat-web-provider.ts
@@ -1,32 +1,15 @@
+import type { EvaluationContext, JsonValue, Paradigm, Provider, ResolutionDetails } from '@openfeature/web-sdk';
 import {
-  EvaluationContext,
-  JsonValue,
   OpenFeatureEventEmitter,
-  Paradigm,
   ParseError,
-  Provider,
   ProviderEvents,
   ProviderNotReadyError,
-  ResolutionDetails,
   TypeMismatchError,
 } from '@openfeature/web-sdk';
-import {
-  isType,
-  parseError,
-  PrimitiveType,
-  PrimitiveTypeName,
-  toResolutionDetails,
-  transformContext,
-} from '@openfeature/config-cat-core';
-import {
-  ClientCacheState,
-  getClient,
-  IConfig,
-  IConfigCatClient,
-  OptionsForPollingMode,
-  PollingMode,
-  SettingValue,
-} from 'configcat-js-ssr';
+import type { PrimitiveType, PrimitiveTypeName } from '@openfeature/config-cat-core';
+import { isType, parseError, toResolutionDetails, transformContext } from '@openfeature/config-cat-core';
+import type { IConfig, IConfigCatClient, OptionsForPollingMode, SettingValue } from 'configcat-js-ssr';
+import { ClientCacheState, getClient, PollingMode } from 'configcat-js-ssr';
 
 export class ConfigCatWebProvider implements Provider {
   public readonly events = new OpenFeatureEventEmitter();

--- a/libs/providers/config-cat/src/lib/config-cat-provider.spec.ts
+++ b/libs/providers/config-cat/src/lib/config-cat-provider.spec.ts
@@ -1,16 +1,14 @@
 import { ConfigCatProvider } from './config-cat-provider';
 import { ProviderEvents, ParseError, FlagNotFoundError, TypeMismatchError } from '@openfeature/web-sdk';
+import type { HookEvents, IConfigCatCache, ISettingUnion } from 'configcat-js-ssr';
 import {
   createConsoleLogger,
   createFlagOverridesFromMap,
-  HookEvents,
-  IConfigCatCache,
-  ISettingUnion,
   LogLevel,
   OverrideBehaviour,
   PollingMode,
 } from 'configcat-js-ssr';
-import { EventEmitter } from 'events';
+import type { EventEmitter } from 'events';
 
 describe('ConfigCatProvider', () => {
   const targetingKey = 'abc';

--- a/libs/providers/config-cat/src/lib/config-cat-provider.ts
+++ b/libs/providers/config-cat/src/lib/config-cat-provider.ts
@@ -1,25 +1,17 @@
+import type { EvaluationContext, JsonValue, Provider, ResolutionDetails, Paradigm } from '@openfeature/server-sdk';
 import {
-  EvaluationContext,
-  JsonValue,
   OpenFeatureEventEmitter,
-  Provider,
   ProviderEvents,
-  ResolutionDetails,
-  Paradigm,
   ProviderNotReadyError,
   TypeMismatchError,
   ParseError,
 } from '@openfeature/server-sdk';
-import {
-  isType,
-  parseError,
-  PrimitiveType,
-  PrimitiveTypeName,
-  toResolutionDetails,
-  transformContext,
-} from '@openfeature/config-cat-core';
-import { ClientCacheState, PollingMode, SettingValue } from 'configcat-common';
-import { IConfigCatClient, getClient, IConfig, OptionsForPollingMode } from 'configcat-node';
+import type { PrimitiveType, PrimitiveTypeName } from '@openfeature/config-cat-core';
+import { isType, parseError, toResolutionDetails, transformContext } from '@openfeature/config-cat-core';
+import type { SettingValue } from 'configcat-common';
+import { ClientCacheState, PollingMode } from 'configcat-common';
+import type { IConfigCatClient, IConfig, OptionsForPollingMode } from 'configcat-node';
+import { getClient } from 'configcat-node';
 
 export class ConfigCatProvider implements Provider {
   public readonly events = new OpenFeatureEventEmitter();

--- a/libs/providers/env-var/src/lib/env-var-provider.ts
+++ b/libs/providers/env-var/src/lib/env-var-provider.ts
@@ -1,11 +1,5 @@
-import {
-  FlagNotFoundError,
-  JsonValue,
-  ParseError,
-  Provider,
-  ResolutionDetails,
-  StandardResolutionReasons,
-} from '@openfeature/server-sdk';
+import type { JsonValue, Provider, ResolutionDetails } from '@openfeature/server-sdk';
+import { FlagNotFoundError, ParseError, StandardResolutionReasons } from '@openfeature/server-sdk';
 import { constantCase } from './constant-case';
 
 export type Config = {

--- a/libs/providers/flagd-web/src/e2e/step-definitions/flag.ts
+++ b/libs/providers/flagd-web/src/e2e/step-definitions/flag.ts
@@ -1,12 +1,6 @@
-import { StepDefinitions } from 'jest-cucumber';
-import {
-  EvaluationDetails,
-  FlagValue,
-  JsonObject,
-  OpenFeature,
-  ProviderEvents,
-  StandardResolutionReasons,
-} from '@openfeature/web-sdk';
+import type { StepDefinitions } from 'jest-cucumber';
+import type { EvaluationDetails, FlagValue, JsonObject } from '@openfeature/web-sdk';
+import { OpenFeature, ProviderEvents, StandardResolutionReasons } from '@openfeature/web-sdk';
 import { E2E_CLIENT_NAME } from '@openfeature/flagd-core';
 
 export const flagStepDefinitions: StepDefinitions = ({ given, and, when, then }) => {

--- a/libs/providers/flagd-web/src/e2e/tests/provider.spec.ts
+++ b/libs/providers/flagd-web/src/e2e/tests/provider.spec.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import { OpenFeature } from '@openfeature/web-sdk';
-import { GenericContainer, StartedTestContainer } from 'testcontainers';
+import type { StartedTestContainer } from 'testcontainers';
+import { GenericContainer } from 'testcontainers';
 import { FlagdWebProvider } from '../../lib/flagd-web-provider';
 import { autoBindSteps, loadFeature } from 'jest-cucumber';
 import { FLAGD_NAME, GHERKIN_EVALUATION_FEATURE } from '../constants';

--- a/libs/providers/flagd-web/src/lib/flagd-web-provider.spec.ts
+++ b/libs/providers/flagd-web/src/lib/flagd-web-provider.spec.ts
@@ -1,16 +1,11 @@
-import { CallbackClient, Code, ConnectError, PromiseClient } from '@connectrpc/connect';
+import type { CallbackClient, ConnectError, PromiseClient } from '@connectrpc/connect';
+import { Code } from '@connectrpc/connect';
 import { Struct } from '@bufbuild/protobuf';
-import {
-  Client,
-  ErrorCode,
-  JsonValue,
-  OpenFeature,
-  ProviderEvents,
-  StandardResolutionReasons,
-} from '@openfeature/web-sdk';
+import type { Client, JsonValue } from '@openfeature/web-sdk';
+import { ErrorCode, OpenFeature, ProviderEvents, StandardResolutionReasons } from '@openfeature/web-sdk';
 import fetchMock from 'jest-fetch-mock';
-import { Service } from '../proto/ts/flagd/evaluation/v1/evaluation_connect';
-import { AnyFlag, EventStreamResponse, ResolveAllResponse } from '../proto/ts/flagd/evaluation/v1/evaluation_pb';
+import type { Service } from '../proto/ts/flagd/evaluation/v1/evaluation_connect';
+import type { AnyFlag, EventStreamResponse, ResolveAllResponse } from '../proto/ts/flagd/evaluation/v1/evaluation_pb';
 import { FlagdWebProvider } from './flagd-web-provider';
 
 const EVENT_CONFIGURATION_CHANGE = 'configuration_change';

--- a/libs/providers/flagd-web/src/lib/flagd-web-provider.ts
+++ b/libs/providers/flagd-web/src/lib/flagd-web-provider.ts
@@ -1,23 +1,27 @@
-import { CallbackClient, createCallbackClient, createPromiseClient, PromiseClient } from '@connectrpc/connect';
+import type { CallbackClient, PromiseClient } from '@connectrpc/connect';
+import { createCallbackClient, createPromiseClient } from '@connectrpc/connect';
 import { createConnectTransport } from '@connectrpc/connect-web';
 import { Struct } from '@bufbuild/protobuf';
-import {
+import type {
   EvaluationContext,
-  FlagNotFoundError,
   FlagValue,
   JsonValue,
   Logger,
+  Provider,
+  ResolutionDetails,
+} from '@openfeature/web-sdk';
+import {
+  FlagNotFoundError,
   OpenFeature,
   OpenFeatureEventEmitter,
-  Provider,
   ProviderEvents,
-  ResolutionDetails,
   StandardResolutionReasons,
   TypeMismatchError,
 } from '@openfeature/web-sdk';
 import { Service } from '../proto/ts/flagd/evaluation/v1/evaluation_connect';
-import { AnyFlag } from '../proto/ts/flagd/evaluation/v1/evaluation_pb';
-import { FlagdProviderOptions, getOptions } from './options';
+import type { AnyFlag } from '../proto/ts/flagd/evaluation/v1/evaluation_pb';
+import type { FlagdProviderOptions } from './options';
+import { getOptions } from './options';
 
 export const ERROR_DISABLED = 'DISABLED';
 

--- a/libs/providers/flagd/src/e2e/step-definitions/flag.ts
+++ b/libs/providers/flagd/src/e2e/step-definitions/flag.ts
@@ -1,13 +1,6 @@
-import { StepDefinitions } from 'jest-cucumber';
-import {
-  EvaluationContext,
-  EvaluationDetails,
-  FlagValue,
-  JsonObject,
-  OpenFeature,
-  ProviderEvents,
-  StandardResolutionReasons,
-} from '@openfeature/server-sdk';
+import type { StepDefinitions } from 'jest-cucumber';
+import type { EvaluationContext, EvaluationDetails, FlagValue, JsonObject } from '@openfeature/server-sdk';
+import { OpenFeature, ProviderEvents, StandardResolutionReasons } from '@openfeature/server-sdk';
 import { E2E_CLIENT_NAME } from '@openfeature/flagd-core';
 
 export const flagStepDefinitions: StepDefinitions = ({ given, and, when, then }) => {

--- a/libs/providers/flagd/src/e2e/step-definitions/reconnect.ts
+++ b/libs/providers/flagd/src/e2e/step-definitions/reconnect.ts
@@ -1,4 +1,4 @@
-import { StepDefinitions } from 'jest-cucumber';
+import type { StepDefinitions } from 'jest-cucumber';
 import { OpenFeature, ProviderEvents } from '@openfeature/server-sdk';
 import { UNAVAILABLE_CLIENT_NAME, UNSTABLE_CLIENT_NAME } from '../constants';
 

--- a/libs/providers/flagd/src/e2e/tests/in-process-reconnect.spec.ts
+++ b/libs/providers/flagd/src/e2e/tests/in-process-reconnect.spec.ts
@@ -1,7 +1,8 @@
 import assert from 'assert';
 import { OpenFeature } from '@openfeature/server-sdk';
 import { FlagdProvider } from '../../lib/flagd-provider';
-import { GenericContainer, StartedTestContainer } from 'testcontainers';
+import type { StartedTestContainer } from 'testcontainers';
+import { GenericContainer } from 'testcontainers';
 import { autoBindSteps, loadFeature } from 'jest-cucumber';
 import {
   FLAGD_NAME,

--- a/libs/providers/flagd/src/e2e/tests/in-process.spec.ts
+++ b/libs/providers/flagd/src/e2e/tests/in-process.spec.ts
@@ -1,7 +1,8 @@
 import assert from 'assert';
 import { OpenFeature } from '@openfeature/server-sdk';
 import { FlagdProvider } from '../../lib/flagd-provider';
-import { GenericContainer, StartedTestContainer } from 'testcontainers';
+import type { StartedTestContainer } from 'testcontainers';
+import { GenericContainer } from 'testcontainers';
 import { autoBindSteps, loadFeature } from 'jest-cucumber';
 import {
   FLAGD_NAME,

--- a/libs/providers/flagd/src/e2e/tests/rpc-reconnect.spec.ts
+++ b/libs/providers/flagd/src/e2e/tests/rpc-reconnect.spec.ts
@@ -1,7 +1,8 @@
 import assert from 'assert';
 import { OpenFeature } from '@openfeature/server-sdk';
 import { FlagdProvider } from '../../lib/flagd-provider';
-import { GenericContainer, StartedTestContainer } from 'testcontainers';
+import type { StartedTestContainer } from 'testcontainers';
+import { GenericContainer } from 'testcontainers';
 import { autoBindSteps, loadFeature } from 'jest-cucumber';
 import {
   FLAGD_NAME,

--- a/libs/providers/flagd/src/e2e/tests/rpc.spec.ts
+++ b/libs/providers/flagd/src/e2e/tests/rpc.spec.ts
@@ -1,7 +1,8 @@
 import assert from 'assert';
 import { OpenFeature } from '@openfeature/server-sdk';
 import { FlagdProvider } from '../../lib/flagd-provider';
-import { GenericContainer, StartedTestContainer } from 'testcontainers';
+import type { StartedTestContainer } from 'testcontainers';
+import { GenericContainer } from 'testcontainers';
 import { autoBindSteps, loadFeature } from 'jest-cucumber';
 import {
   FLAGD_NAME,

--- a/libs/providers/flagd/src/lib/configuration.spec.ts
+++ b/libs/providers/flagd/src/lib/configuration.spec.ts
@@ -1,4 +1,5 @@
-import { Config, FlagdProviderOptions, getConfig } from './configuration';
+import type { Config, FlagdProviderOptions } from './configuration';
+import { getConfig } from './configuration';
 import { DEFAULT_MAX_CACHE_SIZE } from './constants';
 
 describe('Configuration', () => {

--- a/libs/providers/flagd/src/lib/flagd-provider.spec.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.spec.ts
@@ -1,16 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ServiceError, status } from '@grpc/grpc-js';
-import {
-  Client,
-  ErrorCode,
-  EvaluationContext,
-  FlagMetadata,
-  OpenFeature,
-  ProviderEvents,
-  StandardResolutionReasons,
-} from '@openfeature/server-sdk';
+import type { ServiceError } from '@grpc/grpc-js';
+import { status } from '@grpc/grpc-js';
+import type { Client, EvaluationContext, FlagMetadata } from '@openfeature/server-sdk';
+import { ErrorCode, OpenFeature, ProviderEvents, StandardResolutionReasons } from '@openfeature/server-sdk';
 import type { UnaryCall } from '@protobuf-ts/runtime-rpc';
-import {
+import type {
   EventStreamResponse,
   ResolveBooleanRequest,
   ResolveBooleanResponse,
@@ -22,10 +16,11 @@ import {
   ResolveObjectResponse,
   ResolveStringRequest,
   ResolveStringResponse,
-  ServiceClient,
 } from '../proto/ts/flagd/evaluation/v1/evaluation';
+import { ServiceClient } from '../proto/ts/flagd/evaluation/v1/evaluation';
 import { FlagdProvider } from './flagd-provider';
-import { FlagChangeMessage, GRPCService } from './service/grpc/grpc-service';
+import type { FlagChangeMessage } from './service/grpc/grpc-service';
+import { GRPCService } from './service/grpc/grpc-service';
 import { ConnectivityState } from '@grpc/grpc-js/build/src/connectivity-state';
 import { EVENT_CONFIGURATION_CHANGE, EVENT_PROVIDER_READY } from './constants';
 

--- a/libs/providers/flagd/src/lib/flagd-provider.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.ts
@@ -1,15 +1,9 @@
-import {
-  EvaluationContext,
-  JsonValue,
-  Logger,
-  OpenFeatureEventEmitter,
-  Provider,
-  ProviderEvents,
-  ResolutionDetails,
-} from '@openfeature/server-sdk';
-import { FlagdProviderOptions, getConfig } from './configuration';
+import type { EvaluationContext, JsonValue, Logger, Provider, ResolutionDetails } from '@openfeature/server-sdk';
+import { OpenFeatureEventEmitter, ProviderEvents } from '@openfeature/server-sdk';
+import type { FlagdProviderOptions } from './configuration';
+import { getConfig } from './configuration';
 import { GRPCService } from './service/grpc/grpc-service';
-import { Service } from './service/service';
+import type { Service } from './service/service';
 import { InProcessService } from './service/in-process/in-process-service';
 
 export class FlagdProvider implements Provider {

--- a/libs/providers/flagd/src/lib/service/common/grpc-util.ts
+++ b/libs/providers/flagd/src/lib/service/common/grpc-util.ts
@@ -1,4 +1,4 @@
-import { ClientReadableStream } from '@grpc/grpc-js';
+import type { ClientReadableStream } from '@grpc/grpc-js';
 
 export const closeStreamIfDefined = (stream: ClientReadableStream<unknown> | undefined) => {
   /**

--- a/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
+++ b/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
@@ -1,20 +1,17 @@
-import { ClientReadableStream, ClientUnaryCall, ServiceError, credentials, status, ClientOptions } from '@grpc/grpc-js';
+import type { ClientReadableStream, ClientUnaryCall, ServiceError, ClientOptions } from '@grpc/grpc-js';
+import { credentials, status } from '@grpc/grpc-js';
 import { ConnectivityState } from '@grpc/grpc-js/build/src/connectivity-state';
+import type { EvaluationContext, FlagValue, JsonValue, Logger, ResolutionDetails } from '@openfeature/server-sdk';
 import {
-  EvaluationContext,
   FlagNotFoundError,
-  FlagValue,
   GeneralError,
-  JsonValue,
-  Logger,
   ParseError,
-  ResolutionDetails,
   StandardResolutionReasons,
   TypeMismatchError,
 } from '@openfeature/server-sdk';
 import { LRUCache } from 'lru-cache';
 import { promisify } from 'node:util';
-import {
+import type {
   EventStreamResponse,
   ResolveBooleanRequest,
   ResolveBooleanResponse,
@@ -26,12 +23,12 @@ import {
   ResolveObjectResponse,
   ResolveStringRequest,
   ResolveStringResponse,
-  ServiceClient,
 } from '../../../proto/ts/flagd/evaluation/v1/evaluation';
-import { Config } from '../../configuration';
+import { ServiceClient } from '../../../proto/ts/flagd/evaluation/v1/evaluation';
+import type { Config } from '../../configuration';
 import { DEFAULT_MAX_CACHE_SIZE, EVENT_CONFIGURATION_CHANGE, EVENT_PROVIDER_READY } from '../../constants';
 import { FlagdProvider } from '../../flagd-provider';
-import { Service } from '../service';
+import type { Service } from '../service';
 import { closeStreamIfDefined } from '../common';
 
 type AnyResponse =

--- a/libs/providers/flagd/src/lib/service/in-process/file/file-fetch.spec.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/file/file-fetch.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { FileFetch } from './file-fetch';
 import { FlagdCore } from '@openfeature/flagd-core';
-import { Logger } from '@openfeature/server-sdk';
+import type { Logger } from '@openfeature/server-sdk';
 
 jest.mock('fs', () => ({
   ...jest.requireActual('fs'),

--- a/libs/providers/flagd/src/lib/service/in-process/file/file-fetch.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/file/file-fetch.ts
@@ -1,5 +1,6 @@
-import { Logger, OpenFeatureError, GeneralError } from '@openfeature/server-sdk';
-import { DataFetch } from '../data-fetch';
+import type { Logger } from '@openfeature/server-sdk';
+import { OpenFeatureError, GeneralError } from '@openfeature/server-sdk';
+import type { DataFetch } from '../data-fetch';
 import { promises as fsPromises, watchFile, unwatchFile } from 'fs';
 
 const encoding = 'utf8';

--- a/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.spec.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.spec.ts
@@ -1,6 +1,6 @@
 import { GrpcFetch } from './grpc-fetch';
-import { Config } from '../../../configuration';
-import { FlagSyncServiceClient, SyncFlagsResponse } from '../../../../proto/ts/flagd/sync/v1/sync';
+import type { Config } from '../../../configuration';
+import type { FlagSyncServiceClient, SyncFlagsResponse } from '../../../../proto/ts/flagd/sync/v1/sync';
 import { ConnectivityState } from '@grpc/grpc-js/build/src/connectivity-state';
 
 let watchStateCallback: () => void = () => ({});

--- a/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
@@ -1,9 +1,12 @@
-import { ClientReadableStream, ServiceError, credentials, ClientOptions } from '@grpc/grpc-js';
-import { GeneralError, Logger } from '@openfeature/server-sdk';
-import { FlagSyncServiceClient, SyncFlagsRequest, SyncFlagsResponse } from '../../../../proto/ts/flagd/sync/v1/sync';
-import { Config } from '../../../configuration';
+import type { ClientReadableStream, ServiceError, ClientOptions } from '@grpc/grpc-js';
+import { credentials } from '@grpc/grpc-js';
+import type { Logger } from '@openfeature/server-sdk';
+import { GeneralError } from '@openfeature/server-sdk';
+import type { SyncFlagsRequest, SyncFlagsResponse } from '../../../../proto/ts/flagd/sync/v1/sync';
+import { FlagSyncServiceClient } from '../../../../proto/ts/flagd/sync/v1/sync';
+import type { Config } from '../../../configuration';
 import { closeStreamIfDefined } from '../../common';
-import { DataFetch } from '../data-fetch';
+import type { DataFetch } from '../data-fetch';
 
 /**
  * Implements the gRPC sync contract to fetch flag data.

--- a/libs/providers/flagd/src/lib/service/in-process/in-process-service.spec.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/in-process-service.spec.ts
@@ -1,4 +1,4 @@
-import { DataFetch } from './data-fetch';
+import type { DataFetch } from './data-fetch';
 import { InProcessService } from './in-process-service';
 
 describe('In-process-service', () => {

--- a/libs/providers/flagd/src/lib/service/in-process/in-process-service.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/in-process-service.ts
@@ -7,9 +7,9 @@ import type {
   Logger,
   ResolutionDetails,
 } from '@openfeature/server-sdk';
-import { Config } from '../../configuration';
-import { Service } from '../service';
-import { DataFetch } from './data-fetch';
+import type { Config } from '../../configuration';
+import type { Service } from '../service';
+import type { DataFetch } from './data-fetch';
 import { FileFetch } from './file/file-fetch';
 import { GrpcFetch } from './grpc/grpc-fetch';
 

--- a/libs/providers/flagd/src/lib/service/service.ts
+++ b/libs/providers/flagd/src/lib/service/service.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext, JsonValue, Logger, ResolutionDetails } from '@openfeature/server-sdk';
+import type { EvaluationContext, JsonValue, Logger, ResolutionDetails } from '@openfeature/server-sdk';
 
 export interface Service {
   connect(

--- a/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.ts
@@ -1,19 +1,18 @@
-import {
+import type {
   EvaluationContext,
   FlagValue,
   JsonValue,
   Logger,
-  OpenFeatureEventEmitter,
   Provider,
-  ProviderEvents,
   ProviderMetadata,
   ResolutionDetails,
   ResolutionReason,
-  TypeMismatchError,
 } from '@openfeature/web-sdk';
+import { OpenFeatureEventEmitter, ProviderEvents, TypeMismatchError } from '@openfeature/web-sdk';
 import { createFlagsmithInstance } from 'flagsmith';
-import { IFlagsmith, IInitConfig, IState } from 'flagsmith/types';
-import { FlagType, typeFactory } from './type-factory';
+import type { IFlagsmith, IInitConfig, IState } from 'flagsmith/types';
+import type { FlagType } from './type-factory';
+import { typeFactory } from './type-factory';
 
 export class FlagsmithClientProvider implements Provider {
   readonly metadata: ProviderMetadata = {

--- a/libs/providers/flagsmith-client/src/lib/flagsmith.mocks.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith.mocks.ts
@@ -1,4 +1,4 @@
-import { IFlagsmithResponse, IInitConfig } from 'flagsmith/types';
+import type { IFlagsmithResponse, IInitConfig } from 'flagsmith/types';
 type Flatten<T> = T extends unknown[] ? T[number] : T;
 type FeatureResponse = Flatten<IFlagsmithResponse['flags']>;
 type Callback = (err: Error | null, val: string | null) => void;

--- a/libs/providers/flagsmith-client/src/lib/type-factory.ts
+++ b/libs/providers/flagsmith-client/src/lib/type-factory.ts
@@ -1,4 +1,4 @@
-import { FlagValue } from '@openfeature/web-sdk';
+import type { FlagValue } from '@openfeature/web-sdk';
 
 export type FlagType = 'string' | 'number' | 'object' | 'boolean';
 

--- a/libs/providers/flipt-web/src/lib/context-transformer.spec.ts
+++ b/libs/providers/flipt-web/src/lib/context-transformer.spec.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext } from '@openfeature/server-sdk';
+import type { EvaluationContext } from '@openfeature/server-sdk';
 import { transformContext } from './context-transformer';
 
 describe('context-transformer', () => {

--- a/libs/providers/flipt-web/src/lib/context-transformer.ts
+++ b/libs/providers/flipt-web/src/lib/context-transformer.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext } from '@openfeature/web-sdk';
+import type { EvaluationContext } from '@openfeature/web-sdk';
 
 export function transformContext(context: EvaluationContext): Record<string, string> {
   const evalContext: Record<string, string> = {};

--- a/libs/providers/flipt-web/src/lib/flipt-web-provider.ts
+++ b/libs/providers/flipt-web/src/lib/flipt-web-provider.ts
@@ -1,16 +1,8 @@
-import {
-  EvaluationContext,
-  Provider,
-  JsonValue,
-  ResolutionDetails,
-  Logger,
-  StandardResolutionReasons,
-  TypeMismatchError,
-  GeneralError,
-  ProviderFatalError,
-} from '@openfeature/web-sdk';
+import type { EvaluationContext, Provider, JsonValue, ResolutionDetails, Logger } from '@openfeature/web-sdk';
+import { StandardResolutionReasons, TypeMismatchError, GeneralError, ProviderFatalError } from '@openfeature/web-sdk';
 import { FliptClient } from '@flipt-io/flipt-client-js/browser';
-import { EvaluationReason, FliptWebProviderOptions } from './models';
+import type { FliptWebProviderOptions } from './models';
+import { EvaluationReason } from './models';
 import { transformContext } from './context-transformer';
 
 export class FliptWebProvider implements Provider {

--- a/libs/providers/flipt/src/lib/context-transformer.spec.ts
+++ b/libs/providers/flipt/src/lib/context-transformer.spec.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext } from '@openfeature/server-sdk';
+import type { EvaluationContext } from '@openfeature/server-sdk';
 import { transformContext } from './context-transformer';
 
 describe('context-transformer', () => {

--- a/libs/providers/flipt/src/lib/context-transformer.ts
+++ b/libs/providers/flipt/src/lib/context-transformer.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext } from '@openfeature/server-sdk';
+import type { EvaluationContext } from '@openfeature/server-sdk';
 
 export function transformContext(context: EvaluationContext): Record<string, string> {
   const evalContext: Record<string, string> = {};

--- a/libs/providers/flipt/src/lib/flipt-provider.ts
+++ b/libs/providers/flipt/src/lib/flipt-provider.ts
@@ -1,11 +1,14 @@
-import { AuthenticationStrategy, FliptClient } from '@flipt-io/flipt';
-import {
+import type { AuthenticationStrategy } from '@flipt-io/flipt';
+import { FliptClient } from '@flipt-io/flipt';
+import type {
   EvaluationContext,
   Provider,
   JsonValue,
   ResolutionDetails,
-  ProviderStatus,
   ProviderMetadata,
+} from '@openfeature/server-sdk';
+import {
+  ProviderStatus,
   TypeMismatchError,
   ProviderNotReadyError,
   StandardResolutionReasons,

--- a/libs/providers/go-feature-flag-web/src/lib/collector-manager.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/collector-manager.ts
@@ -1,5 +1,5 @@
-import { Logger } from '@openfeature/web-sdk';
-import { ExporterMetadataValue, FeatureEvent, GoFeatureFlagWebProviderOptions, TrackingEvent } from './model';
+import type { Logger } from '@openfeature/web-sdk';
+import type { ExporterMetadataValue, FeatureEvent, GoFeatureFlagWebProviderOptions, TrackingEvent } from './model';
 import { GoffApiController } from './controller/goff-api';
 import { CollectorError } from './errors/collector-error';
 import { copy } from 'copy-anything';

--- a/libs/providers/go-feature-flag-web/src/lib/context-transfomer.spec.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/context-transfomer.spec.ts
@@ -1,6 +1,7 @@
-import { GoFeatureFlagEvaluationContext } from './model';
+import type { GoFeatureFlagEvaluationContext } from './model';
 import { transformContext } from './context-transformer';
-import { TargetingKeyMissingError, EvaluationContext } from '@openfeature/web-sdk';
+import type { EvaluationContext } from '@openfeature/web-sdk';
+import { TargetingKeyMissingError } from '@openfeature/web-sdk';
 
 describe('contextTransformer', () => {
   it('should use the targetingKey as user key', () => {

--- a/libs/providers/go-feature-flag-web/src/lib/context-transformer.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/context-transformer.ts
@@ -1,5 +1,6 @@
-import { GoFeatureFlagEvaluationContext } from './model';
-import { TargetingKeyMissingError, EvaluationContext } from '@openfeature/web-sdk';
+import type { GoFeatureFlagEvaluationContext } from './model';
+import type { EvaluationContext } from '@openfeature/web-sdk';
+import { TargetingKeyMissingError } from '@openfeature/web-sdk';
 
 /**
  * transformContext takes the raw OpenFeature context returns a GoFeatureFlagEvaluationContext.

--- a/libs/providers/go-feature-flag-web/src/lib/controller/goff-api.spec.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/controller/goff-api.spec.ts
@@ -1,6 +1,6 @@
 import fetchMock from 'fetch-mock-jest';
 import { GoffApiController } from './goff-api';
-import { GoFeatureFlagWebProviderOptions } from '../model';
+import type { GoFeatureFlagWebProviderOptions } from '../model';
 
 describe('Collect Data API', () => {
   beforeEach(() => {

--- a/libs/providers/go-feature-flag-web/src/lib/controller/goff-api.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/controller/goff-api.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DataCollectorRequest,
   ExporterMetadataValue,
   FeatureEvent,

--- a/libs/providers/go-feature-flag-web/src/lib/data-collector-hook.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/data-collector-hook.ts
@@ -1,5 +1,5 @@
-import { EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk';
-import { CollectorManager } from './collector-manager';
+import type { EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk';
+import type { CollectorManager } from './collector-manager';
 
 const defaultTargetingKey = 'undefined-targetingKey';
 type Timer = ReturnType<typeof setInterval>;

--- a/libs/providers/go-feature-flag-web/src/lib/go-feature-flag-web-provider.spec.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/go-feature-flag-web-provider.spec.ts
@@ -1,16 +1,9 @@
 import { GoFeatureFlagWebProvider } from './go-feature-flag-web-provider';
-import {
-  ErrorCode,
-  EvaluationContext,
-  EvaluationDetails,
-  JsonValue,
-  OpenFeature,
-  ProviderEvents,
-  StandardResolutionReasons,
-} from '@openfeature/web-sdk';
+import type { EvaluationContext, EvaluationDetails, JsonValue } from '@openfeature/web-sdk';
+import { ErrorCode, OpenFeature, ProviderEvents, StandardResolutionReasons } from '@openfeature/web-sdk';
 import WS from 'jest-websocket-mock';
 import TestLogger from './test-logger';
-import { DataCollectorRequest, GOFeatureFlagWebsocketResponse, TrackingEvent } from './model';
+import type { DataCollectorRequest, GOFeatureFlagWebsocketResponse, TrackingEvent } from './model';
 import fetchMock from 'fetch-mock-jest';
 
 describe('GoFeatureFlagWebProvider', () => {

--- a/libs/providers/go-feature-flag-web/src/lib/go-feature-flag-web-provider.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/go-feature-flag-web-provider.ts
@@ -1,19 +1,21 @@
-import {
+import type {
   EvaluationContext,
-  FlagNotFoundError,
   FlagValue,
   Hook,
   Logger,
-  OpenFeature,
-  OpenFeatureEventEmitter,
   Provider,
-  ProviderEvents,
   ResolutionDetails,
-  StandardResolutionReasons,
   TrackingEventDetails,
-  TypeMismatchError,
 } from '@openfeature/web-sdk';
 import {
+  FlagNotFoundError,
+  OpenFeature,
+  OpenFeatureEventEmitter,
+  ProviderEvents,
+  StandardResolutionReasons,
+  TypeMismatchError,
+} from '@openfeature/web-sdk';
+import type {
   FlagState,
   GoFeatureFlagAllFlagRequest,
   GOFeatureFlagAllFlagsResponse,

--- a/libs/providers/go-feature-flag-web/src/lib/model.ts
+++ b/libs/providers/go-feature-flag-web/src/lib/model.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {
+import type {
   ErrorCode,
   EvaluationContext,
   EvaluationContextValue,

--- a/libs/providers/go-feature-flag/src/lib/context-transfomer.spec.ts
+++ b/libs/providers/go-feature-flag/src/lib/context-transfomer.spec.ts
@@ -1,5 +1,5 @@
-import { EvaluationContext } from '@openfeature/server-sdk';
-import { GOFFEvaluationContext } from './model';
+import type { EvaluationContext } from '@openfeature/server-sdk';
+import type { GOFFEvaluationContext } from './model';
 import { transformContext } from './context-transformer';
 
 describe('contextTransformer', () => {

--- a/libs/providers/go-feature-flag/src/lib/context-transformer.ts
+++ b/libs/providers/go-feature-flag/src/lib/context-transformer.ts
@@ -1,6 +1,6 @@
-import { EvaluationContext } from '@openfeature/server-sdk';
+import type { EvaluationContext } from '@openfeature/server-sdk';
 import { sha1 } from 'object-hash';
-import { GOFFEvaluationContext } from './model';
+import type { GOFFEvaluationContext } from './model';
 
 /**
  * transformContext takes the raw OpenFeature context returns a GoFeatureFlagUser.

--- a/libs/providers/go-feature-flag/src/lib/controller/cache.ts
+++ b/libs/providers/go-feature-flag/src/lib/controller/cache.ts
@@ -1,5 +1,5 @@
-import { GoFeatureFlagProviderOptions, Cache } from '../model';
-import { EvaluationContext, Logger, ResolutionDetails } from '@openfeature/server-sdk';
+import type { GoFeatureFlagProviderOptions, Cache } from '../model';
+import type { EvaluationContext, Logger, ResolutionDetails } from '@openfeature/server-sdk';
 import { LRUCache } from 'lru-cache';
 import hash from 'object-hash';
 

--- a/libs/providers/go-feature-flag/src/lib/controller/goff-api.ts
+++ b/libs/providers/go-feature-flag/src/lib/controller/goff-api.ts
@@ -1,5 +1,4 @@
-import {
-  ConfigurationChange,
+import type {
   DataCollectorRequest,
   DataCollectorResponse,
   ExporterMetadataValue,
@@ -8,15 +7,9 @@ import {
   GoFeatureFlagProxyRequest,
   GoFeatureFlagProxyResponse,
 } from '../model';
-import {
-  ErrorCode,
-  EvaluationContext,
-  FlagNotFoundError,
-  Logger,
-  ResolutionDetails,
-  StandardResolutionReasons,
-  TypeMismatchError,
-} from '@openfeature/server-sdk';
+import { ConfigurationChange } from '../model';
+import type { EvaluationContext, Logger, ResolutionDetails } from '@openfeature/server-sdk';
+import { ErrorCode, FlagNotFoundError, StandardResolutionReasons, TypeMismatchError } from '@openfeature/server-sdk';
 import { transformContext } from '../context-transformer';
 import axios, { isAxiosError } from 'axios';
 import { Unauthorized } from '../errors/unauthorized';

--- a/libs/providers/go-feature-flag/src/lib/data-collector-hook.ts
+++ b/libs/providers/go-feature-flag/src/lib/data-collector-hook.ts
@@ -1,15 +1,9 @@
-import {
-  EvaluationDetails,
-  FlagValue,
-  Hook,
-  HookContext,
-  Logger,
-  StandardResolutionReasons,
-} from '@openfeature/server-sdk';
-import { DataCollectorHookOptions, ExporterMetadataValue, FeatureEvent } from './model';
+import type { EvaluationDetails, FlagValue, Hook, HookContext, Logger } from '@openfeature/server-sdk';
+import { StandardResolutionReasons } from '@openfeature/server-sdk';
+import type { DataCollectorHookOptions, ExporterMetadataValue, FeatureEvent } from './model';
 import { copy } from 'copy-anything';
 import { CollectorError } from './errors/collector-error';
-import { GoffApiController } from './controller/goff-api';
+import type { GoffApiController } from './controller/goff-api';
 
 const defaultTargetingKey = 'undefined-targetingKey';
 type Timer = ReturnType<typeof setInterval>;

--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.spec.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.spec.ts
@@ -1,17 +1,12 @@
 /**
  * @jest-environment node
  */
-import {
-  Client,
-  ErrorCode,
-  OpenFeature,
-  ServerProviderStatus,
-  StandardResolutionReasons,
-} from '@openfeature/server-sdk';
+import type { Client } from '@openfeature/server-sdk';
+import { ErrorCode, OpenFeature, ServerProviderStatus, StandardResolutionReasons } from '@openfeature/server-sdk';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { GoFeatureFlagProvider } from './go-feature-flag-provider';
-import { GoFeatureFlagProxyResponse } from './model';
+import type { GoFeatureFlagProxyResponse } from './model';
 import TestLogger from './test-logger';
 
 describe('GoFeatureFlagProvider', () => {

--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.ts
@@ -1,15 +1,7 @@
-import {
-  EvaluationContext,
-  Hook,
-  JsonValue,
-  Logger,
-  OpenFeatureEventEmitter,
-  Provider,
-  ResolutionDetails,
-  ServerProviderEvents,
-  StandardResolutionReasons,
-} from '@openfeature/server-sdk';
-import { ConfigurationChange, ExporterMetadataValue, GoFeatureFlagProviderOptions } from './model';
+import type { EvaluationContext, Hook, JsonValue, Logger, Provider, ResolutionDetails } from '@openfeature/server-sdk';
+import { OpenFeatureEventEmitter, ServerProviderEvents, StandardResolutionReasons } from '@openfeature/server-sdk';
+import type { ExporterMetadataValue, GoFeatureFlagProviderOptions } from './model';
+import { ConfigurationChange } from './model';
 import { GoFeatureFlagDataCollectorHook } from './data-collector-hook';
 import { GoffApiController } from './controller/goff-api';
 import { CacheController } from './controller/cache';

--- a/libs/providers/go-feature-flag/src/lib/model.ts
+++ b/libs/providers/go-feature-flag/src/lib/model.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, EvaluationContextValue, ResolutionDetails } from '@openfeature/server-sdk';
+import type { ErrorCode, EvaluationContextValue, ResolutionDetails } from '@openfeature/server-sdk';
 
 export interface GOFFEvaluationContext {
   key: string;

--- a/libs/providers/growthbook-client/src/lib/growthbook-client-provider.spec.ts
+++ b/libs/providers/growthbook-client/src/lib/growthbook-client-provider.spec.ts
@@ -1,6 +1,8 @@
-import { Context, GrowthBook, InitOptions } from '@growthbook/growthbook';
+import type { Context, InitOptions } from '@growthbook/growthbook';
+import { GrowthBook } from '@growthbook/growthbook';
 import { GrowthbookClientProvider } from './growthbook-client-provider';
-import { Client, OpenFeature } from '@openfeature/web-sdk';
+import type { Client } from '@openfeature/web-sdk';
+import { OpenFeature } from '@openfeature/web-sdk';
 
 jest.mock('@growthbook/growthbook');
 

--- a/libs/providers/growthbook-client/src/lib/growthbook-client-provider.ts
+++ b/libs/providers/growthbook-client/src/lib/growthbook-client-provider.ts
@@ -1,14 +1,8 @@
-import {
-  EvaluationContext,
-  Provider,
-  JsonValue,
-  ResolutionDetails,
-  GeneralError,
-  OpenFeatureEventEmitter,
-  ProviderEvents,
-} from '@openfeature/web-sdk';
+import type { EvaluationContext, Provider, JsonValue, ResolutionDetails } from '@openfeature/web-sdk';
+import { GeneralError, OpenFeatureEventEmitter, ProviderEvents } from '@openfeature/web-sdk';
 
-import { GrowthBook, InitOptions, Context } from '@growthbook/growthbook';
+import type { InitOptions, Context } from '@growthbook/growthbook';
+import { GrowthBook } from '@growthbook/growthbook';
 import isEmpty from 'lodash.isempty';
 import translateResult from './translate-result';
 

--- a/libs/providers/growthbook-client/src/lib/translate-result.ts
+++ b/libs/providers/growthbook-client/src/lib/translate-result.ts
@@ -1,5 +1,6 @@
-import { FeatureResult } from '@growthbook/growthbook';
-import { ErrorCode, ResolutionDetails, TypeMismatchError } from '@openfeature/web-sdk';
+import type { FeatureResult } from '@growthbook/growthbook';
+import type { ResolutionDetails } from '@openfeature/web-sdk';
+import { ErrorCode, TypeMismatchError } from '@openfeature/web-sdk';
 
 const FEATURE_RESULT_ERRORS = ['unknownFeature', 'cyclicPrerequisite'];
 

--- a/libs/providers/growthbook/src/lib/growthbook-provider.spec.ts
+++ b/libs/providers/growthbook/src/lib/growthbook-provider.spec.ts
@@ -1,6 +1,8 @@
-import { ClientOptions, GrowthBookClient, InitOptions } from '@growthbook/growthbook';
+import type { ClientOptions, InitOptions } from '@growthbook/growthbook';
+import { GrowthBookClient } from '@growthbook/growthbook';
 import { GrowthbookProvider } from './growthbook-provider';
-import { Client, OpenFeature } from '@openfeature/server-sdk';
+import type { Client } from '@openfeature/server-sdk';
+import { OpenFeature } from '@openfeature/server-sdk';
 
 jest.mock('@growthbook/growthbook');
 

--- a/libs/providers/growthbook/src/lib/growthbook-provider.ts
+++ b/libs/providers/growthbook/src/lib/growthbook-provider.ts
@@ -1,13 +1,7 @@
-import { ClientOptions, GrowthBookClient, InitOptions } from '@growthbook/growthbook';
-import {
-  EvaluationContext,
-  Provider,
-  JsonValue,
-  ResolutionDetails,
-  OpenFeatureEventEmitter,
-  GeneralError,
-  ProviderEvents,
-} from '@openfeature/server-sdk';
+import type { ClientOptions, InitOptions } from '@growthbook/growthbook';
+import { GrowthBookClient } from '@growthbook/growthbook';
+import type { EvaluationContext, Provider, JsonValue, ResolutionDetails } from '@openfeature/server-sdk';
+import { OpenFeatureEventEmitter, GeneralError, ProviderEvents } from '@openfeature/server-sdk';
 import translateResult from './translate-result';
 
 export class GrowthbookProvider implements Provider {

--- a/libs/providers/growthbook/src/lib/translate-result.ts
+++ b/libs/providers/growthbook/src/lib/translate-result.ts
@@ -1,5 +1,6 @@
-import { FeatureResult } from '@growthbook/growthbook';
-import { ErrorCode, ResolutionDetails, TypeMismatchError } from '@openfeature/server-sdk';
+import type { FeatureResult } from '@growthbook/growthbook';
+import type { ResolutionDetails } from '@openfeature/server-sdk';
+import { ErrorCode, TypeMismatchError } from '@openfeature/server-sdk';
 
 const FEATURE_RESULT_ERRORS = ['unknownFeature', 'cyclicPrerequisite'];
 

--- a/libs/providers/launchdarkly-client/src/lib/launchdarkly-client-provider.spec.ts
+++ b/libs/providers/launchdarkly-client/src/lib/launchdarkly-client-provider.spec.ts
@@ -1,5 +1,6 @@
 import { LaunchDarklyClientProvider } from './launchdarkly-client-provider';
-import { Client, ErrorCode, OpenFeature } from '@openfeature/web-sdk';
+import type { Client } from '@openfeature/web-sdk';
+import { ErrorCode, OpenFeature } from '@openfeature/web-sdk';
 
 import TestLogger from './test-logger';
 import translateContext from './translate-context';

--- a/libs/providers/launchdarkly-client/src/lib/launchdarkly-client-provider.ts
+++ b/libs/providers/launchdarkly-client/src/lib/launchdarkly-client-provider.ts
@@ -1,24 +1,27 @@
-import {
+import type {
   EvaluationContext,
   Provider,
   JsonValue,
   ResolutionDetails,
-  StandardResolutionReasons,
-  ErrorCode,
   ProviderMetadata,
   Logger,
+  TrackingEventDetails,
+} from '@openfeature/web-sdk';
+import {
+  StandardResolutionReasons,
+  ErrorCode,
   GeneralError,
   OpenFeatureEventEmitter,
   ProviderEvents,
   ProviderStatus,
-  TrackingEventDetails,
 } from '@openfeature/web-sdk';
 
 import isEmpty from 'lodash.isempty';
 
-import { basicLogger, LDClient, initialize, LDOptions, LDFlagChangeset } from 'launchdarkly-js-client-sdk';
+import type { LDClient, LDOptions, LDFlagChangeset } from 'launchdarkly-js-client-sdk';
+import { basicLogger, initialize } from 'launchdarkly-js-client-sdk';
 
-import { LaunchDarklyProviderOptions } from './launchdarkly-provider-options';
+import type { LaunchDarklyProviderOptions } from './launchdarkly-provider-options';
 import translateContext from './translate-context';
 import translateResult from './translate-result';
 

--- a/libs/providers/launchdarkly-client/src/lib/launchdarkly-provider-options.ts
+++ b/libs/providers/launchdarkly-client/src/lib/launchdarkly-provider-options.ts
@@ -14,8 +14,8 @@
 
 //Code based on https://github.com/launchdarkly/openfeature-node-server/blob/main/src/LaunchDarklyProviderOptions.ts
 
-import { LDLogger, LDOptions } from 'launchdarkly-js-client-sdk';
-import { Logger } from '@openfeature/web-sdk';
+import type { LDLogger, LDOptions } from 'launchdarkly-js-client-sdk';
+import type { Logger } from '@openfeature/web-sdk';
 
 /**
  * Options for the {@link LaunchDarklyClientProvider}.

--- a/libs/providers/launchdarkly-client/src/lib/test-logger.ts
+++ b/libs/providers/launchdarkly-client/src/lib/test-logger.ts
@@ -14,7 +14,7 @@
 
 //Code taken from https://github.com/launchdarkly/openfeature-node-server/blob/main/__tests__/TestLogger.ts
 
-import { LDLogger } from 'launchdarkly-js-client-sdk';
+import type { LDLogger } from 'launchdarkly-js-client-sdk';
 
 export default class TestLogger implements LDLogger {
   public logs: string[] = [];

--- a/libs/providers/launchdarkly-client/src/lib/translate-context.ts
+++ b/libs/providers/launchdarkly-client/src/lib/translate-context.ts
@@ -15,8 +15,8 @@
 
 //Code taken from https://github.com/launchdarkly/openfeature-node-server/blob/main/src/translateContext.ts
 
-import { EvaluationContext, EvaluationContextValue } from '@openfeature/web-sdk';
-import { LDContext, LDContextCommon, LDLogger, LDSingleKindContext } from 'launchdarkly-js-client-sdk';
+import type { EvaluationContext, EvaluationContextValue } from '@openfeature/web-sdk';
+import type { LDContext, LDContextCommon, LDLogger, LDSingleKindContext } from 'launchdarkly-js-client-sdk';
 
 const LDContextBuiltIns = {
   name: 'string',

--- a/libs/providers/launchdarkly-client/src/lib/translate-result.ts
+++ b/libs/providers/launchdarkly-client/src/lib/translate-result.ts
@@ -1,5 +1,6 @@
-import { ErrorCode, ResolutionDetails } from '@openfeature/web-sdk';
-import { LDEvaluationDetail } from 'launchdarkly-js-client-sdk';
+import type { ResolutionDetails } from '@openfeature/web-sdk';
+import { ErrorCode } from '@openfeature/web-sdk';
+import type { LDEvaluationDetail } from 'launchdarkly-js-client-sdk';
 
 function translateErrorKind(errorKind?: string): ErrorCode {
   // Error code specification.

--- a/libs/providers/multi-provider-web/src/lib/errors.ts
+++ b/libs/providers/multi-provider-web/src/lib/errors.ts
@@ -1,5 +1,6 @@
-import { ErrorCode, GeneralError, OpenFeatureError } from '@openfeature/web-sdk';
-import { RegisteredProvider } from './types';
+import type { ErrorCode } from '@openfeature/web-sdk';
+import { GeneralError, OpenFeatureError } from '@openfeature/web-sdk';
+import type { RegisteredProvider } from './types';
 
 export class ErrorWithCode extends OpenFeatureError {
   constructor(

--- a/libs/providers/multi-provider-web/src/lib/hook-executor.ts
+++ b/libs/providers/multi-provider-web/src/lib/hook-executor.ts
@@ -1,4 +1,4 @@
-import { EvaluationDetails, FlagValue, Hook, HookContext, HookHints, Logger } from '@openfeature/web-sdk';
+import type { EvaluationDetails, FlagValue, Hook, HookContext, HookHints, Logger } from '@openfeature/web-sdk';
 
 /**
  * Utility for executing a set of hooks of each type. Implementation is largely copied from the main OpenFeature SDK.

--- a/libs/providers/multi-provider-web/src/lib/multi-provider-web.spec.ts
+++ b/libs/providers/multi-provider-web/src/lib/multi-provider-web.spec.ts
@@ -1,18 +1,20 @@
 import { WebMultiProvider } from './multi-provider-web';
-import {
-  DefaultLogger,
-  ErrorCode,
+import type {
   EvaluationContext,
-  FlagNotFoundError,
   FlagValue,
   FlagValueType,
   Hook,
-  InMemoryProvider,
   Logger,
-  OpenFeatureEventEmitter,
   Provider,
   ProviderEmittableEvents,
   ProviderMetadata,
+} from '@openfeature/web-sdk';
+import {
+  DefaultLogger,
+  ErrorCode,
+  FlagNotFoundError,
+  InMemoryProvider,
+  OpenFeatureEventEmitter,
   ClientProviderEvents,
 } from '@openfeature/web-sdk';
 import { FirstMatchStrategy } from './strategies/FirstMatchStrategy';

--- a/libs/providers/multi-provider-web/src/lib/multi-provider-web.ts
+++ b/libs/providers/multi-provider-web/src/lib/multi-provider-web.ts
@@ -1,30 +1,33 @@
-import {
-  DefaultLogger,
+import type {
   EvaluationContext,
   FlagValueType,
-  GeneralError,
   Hook,
   HookContext,
   HookHints,
   JsonValue,
   Logger,
-  OpenFeatureEventEmitter,
   Provider,
   ProviderMetadata,
   BeforeHookContext,
   ResolutionDetails,
   FlagMetadata,
-  ErrorCode,
   EvaluationDetails,
   FlagValue,
   OpenFeatureError,
+} from '@openfeature/web-sdk';
+import {
+  DefaultLogger,
+  GeneralError,
+  OpenFeatureEventEmitter,
+  ErrorCode,
   StandardResolutionReasons,
 } from '@openfeature/web-sdk';
 import { HookExecutor } from './hook-executor';
 import { constructAggregateError, throwAggregateErrorFromPromiseResults } from './errors';
-import { BaseEvaluationStrategy, ProviderResolutionResult, FirstMatchStrategy } from './strategies';
+import type { BaseEvaluationStrategy, ProviderResolutionResult } from './strategies';
+import { FirstMatchStrategy } from './strategies';
 import { StatusTracker } from './status-tracker';
-import { ProviderEntryInput, RegisteredProvider } from './types';
+import type { ProviderEntryInput, RegisteredProvider } from './types';
 
 export class WebMultiProvider implements Provider {
   readonly runsOn = 'client';

--- a/libs/providers/multi-provider-web/src/lib/status-tracker.ts
+++ b/libs/providers/multi-provider-web/src/lib/status-tracker.ts
@@ -1,5 +1,6 @@
-import { EventDetails, OpenFeatureEventEmitter, ProviderEvents, ProviderStatus } from '@openfeature/web-sdk';
-import { RegisteredProvider } from './types';
+import type { EventDetails, OpenFeatureEventEmitter } from '@openfeature/web-sdk';
+import { ProviderEvents, ProviderStatus } from '@openfeature/web-sdk';
+import type { RegisteredProvider } from './types';
 
 /**
  * Tracks each individual provider's status by listening to emitted events

--- a/libs/providers/multi-provider-web/src/lib/strategies/BaseEvaluationStrategy.ts
+++ b/libs/providers/multi-provider-web/src/lib/strategies/BaseEvaluationStrategy.ts
@@ -1,13 +1,13 @@
-import {
+import type {
   ErrorCode,
   EvaluationContext,
   FlagValue,
   FlagValueType,
   OpenFeatureError,
   Provider,
-  ProviderStatus,
   ResolutionDetails,
 } from '@openfeature/web-sdk';
+import { ProviderStatus } from '@openfeature/web-sdk';
 import { ErrorWithCode } from '../errors';
 
 export type StrategyEvaluationContext = {

--- a/libs/providers/multi-provider-web/src/lib/strategies/ComparisonStrategy.ts
+++ b/libs/providers/multi-provider-web/src/lib/strategies/ComparisonStrategy.ts
@@ -1,11 +1,12 @@
-import {
-  BaseEvaluationStrategy,
+import type {
   FinalResult,
   ProviderResolutionResult,
   ProviderResolutionSuccessResult,
   StrategyPerProviderContext,
 } from './BaseEvaluationStrategy';
-import { EvaluationContext, FlagValue, GeneralError, Provider } from '@openfeature/web-sdk';
+import { BaseEvaluationStrategy } from './BaseEvaluationStrategy';
+import type { EvaluationContext, FlagValue, Provider } from '@openfeature/web-sdk';
+import { GeneralError } from '@openfeature/web-sdk';
 
 /**
  * Evaluate all providers and compare the results.

--- a/libs/providers/multi-provider-web/src/lib/strategies/FirstMatchStrategy.ts
+++ b/libs/providers/multi-provider-web/src/lib/strategies/FirstMatchStrategy.ts
@@ -1,10 +1,7 @@
-import {
-  BaseEvaluationStrategy,
-  FinalResult,
-  ProviderResolutionResult,
-  StrategyPerProviderContext,
-} from './BaseEvaluationStrategy';
-import { ErrorCode, EvaluationContext, FlagValue } from '@openfeature/web-sdk';
+import type { FinalResult, ProviderResolutionResult, StrategyPerProviderContext } from './BaseEvaluationStrategy';
+import { BaseEvaluationStrategy } from './BaseEvaluationStrategy';
+import type { EvaluationContext, FlagValue } from '@openfeature/web-sdk';
+import { ErrorCode } from '@openfeature/web-sdk';
 
 /**
  * Return the first result that did not indicate "flag not found".

--- a/libs/providers/multi-provider-web/src/lib/strategies/FirstSuccessfulStrategy.ts
+++ b/libs/providers/multi-provider-web/src/lib/strategies/FirstSuccessfulStrategy.ts
@@ -1,10 +1,6 @@
-import {
-  BaseEvaluationStrategy,
-  FinalResult,
-  ProviderResolutionResult,
-  StrategyPerProviderContext,
-} from './BaseEvaluationStrategy';
-import { EvaluationContext, FlagValue } from '@openfeature/web-sdk';
+import type { FinalResult, ProviderResolutionResult, StrategyPerProviderContext } from './BaseEvaluationStrategy';
+import { BaseEvaluationStrategy } from './BaseEvaluationStrategy';
+import type { EvaluationContext, FlagValue } from '@openfeature/web-sdk';
 
 /**
  * Return the first result that did result in an error

--- a/libs/providers/multi-provider-web/src/lib/types.ts
+++ b/libs/providers/multi-provider-web/src/lib/types.ts
@@ -1,5 +1,5 @@
 // Represents an entry in the constructor's provider array which may or may not have a name set
-import { Provider } from '@openfeature/web-sdk';
+import type { Provider } from '@openfeature/web-sdk';
 
 export type ProviderEntryInput = {
   provider: Provider;

--- a/libs/providers/multi-provider/src/lib/errors.ts
+++ b/libs/providers/multi-provider/src/lib/errors.ts
@@ -1,5 +1,6 @@
-import { ErrorCode, GeneralError, OpenFeatureError } from '@openfeature/server-sdk';
-import { RegisteredProvider } from './types';
+import type { ErrorCode } from '@openfeature/server-sdk';
+import { GeneralError, OpenFeatureError } from '@openfeature/server-sdk';
+import type { RegisteredProvider } from './types';
 
 export class ErrorWithCode extends OpenFeatureError {
   constructor(

--- a/libs/providers/multi-provider/src/lib/hook-executor.ts
+++ b/libs/providers/multi-provider/src/lib/hook-executor.ts
@@ -1,4 +1,4 @@
-import { EvaluationDetails, FlagValue, Hook, HookContext, HookHints, Logger } from '@openfeature/server-sdk';
+import type { EvaluationDetails, FlagValue, Hook, HookContext, HookHints, Logger } from '@openfeature/server-sdk';
 
 /**
  * Utility for executing a set of hooks of each type. Implementation is largely copied from the main OpenFeature SDK.

--- a/libs/providers/multi-provider/src/lib/multi-provider.spec.ts
+++ b/libs/providers/multi-provider/src/lib/multi-provider.spec.ts
@@ -1,18 +1,20 @@
 import { MultiProvider } from './multi-provider';
-import {
-  DefaultLogger,
-  ErrorCode,
+import type {
   EvaluationContext,
-  FlagNotFoundError,
   FlagValue,
   FlagValueType,
   Hook,
-  InMemoryProvider,
   Logger,
-  OpenFeatureEventEmitter,
   Provider,
-  ServerProviderEvents,
   ProviderMetadata,
+} from '@openfeature/server-sdk';
+import {
+  DefaultLogger,
+  ErrorCode,
+  FlagNotFoundError,
+  InMemoryProvider,
+  OpenFeatureEventEmitter,
+  ServerProviderEvents,
 } from '@openfeature/server-sdk';
 import { FirstMatchStrategy } from './strategies/FirstMatchStrategy';
 import { FirstSuccessfulStrategy } from './strategies/FirstSuccessfulStrategy';

--- a/libs/providers/multi-provider/src/lib/multi-provider.ts
+++ b/libs/providers/multi-provider/src/lib/multi-provider.ts
@@ -1,30 +1,33 @@
-import {
+import type {
   BeforeHookContext,
-  DefaultLogger,
-  ErrorCode,
   EvaluationContext,
   EvaluationDetails,
   FlagMetadata,
   FlagValue,
   FlagValueType,
-  GeneralError,
   Hook,
   HookContext,
   HookHints,
   JsonValue,
   Logger,
   OpenFeatureError,
-  OpenFeatureEventEmitter,
   Provider,
   ProviderMetadata,
   ResolutionDetails,
+} from '@openfeature/server-sdk';
+import {
+  DefaultLogger,
+  ErrorCode,
+  GeneralError,
+  OpenFeatureEventEmitter,
   StandardResolutionReasons,
 } from '@openfeature/server-sdk';
 import { constructAggregateError, throwAggregateErrorFromPromiseResults } from './errors';
 import { HookExecutor } from './hook-executor';
 import { StatusTracker } from './status-tracker';
-import { BaseEvaluationStrategy, FirstMatchStrategy, ProviderResolutionResult } from './strategies';
-import { ProviderEntryInput, RegisteredProvider } from './types';
+import type { BaseEvaluationStrategy, ProviderResolutionResult } from './strategies';
+import { FirstMatchStrategy } from './strategies';
+import type { ProviderEntryInput, RegisteredProvider } from './types';
 
 export class MultiProvider implements Provider {
   readonly runsOn = 'server';

--- a/libs/providers/multi-provider/src/lib/status-tracker.ts
+++ b/libs/providers/multi-provider/src/lib/status-tracker.ts
@@ -1,5 +1,6 @@
-import { EventDetails, OpenFeatureEventEmitter, ProviderEvents, ProviderStatus } from '@openfeature/server-sdk';
-import { RegisteredProvider } from './types';
+import type { EventDetails, OpenFeatureEventEmitter } from '@openfeature/server-sdk';
+import { ProviderEvents, ProviderStatus } from '@openfeature/server-sdk';
+import type { RegisteredProvider } from './types';
 
 /**
  * Tracks each individual provider's status by listening to emitted events

--- a/libs/providers/multi-provider/src/lib/strategies/BaseEvaluationStrategy.ts
+++ b/libs/providers/multi-provider/src/lib/strategies/BaseEvaluationStrategy.ts
@@ -1,13 +1,13 @@
-import {
+import type {
   ErrorCode,
   EvaluationContext,
   FlagValue,
   FlagValueType,
   OpenFeatureError,
   Provider,
-  ProviderStatus,
   ResolutionDetails,
 } from '@openfeature/server-sdk';
+import { ProviderStatus } from '@openfeature/server-sdk';
 import { ErrorWithCode } from '../errors';
 
 export type StrategyEvaluationContext = {

--- a/libs/providers/multi-provider/src/lib/strategies/ComparisonStrategy.ts
+++ b/libs/providers/multi-provider/src/lib/strategies/ComparisonStrategy.ts
@@ -1,11 +1,12 @@
-import {
-  BaseEvaluationStrategy,
+import type {
   FinalResult,
   ProviderResolutionResult,
   ProviderResolutionSuccessResult,
   StrategyPerProviderContext,
 } from './BaseEvaluationStrategy';
-import { EvaluationContext, FlagValue, GeneralError, Provider } from '@openfeature/server-sdk';
+import { BaseEvaluationStrategy } from './BaseEvaluationStrategy';
+import type { EvaluationContext, FlagValue, Provider } from '@openfeature/server-sdk';
+import { GeneralError } from '@openfeature/server-sdk';
 
 /**
  * Evaluate all providers in parallel and compare the results.

--- a/libs/providers/multi-provider/src/lib/strategies/FirstMatchStrategy.ts
+++ b/libs/providers/multi-provider/src/lib/strategies/FirstMatchStrategy.ts
@@ -1,10 +1,7 @@
-import {
-  BaseEvaluationStrategy,
-  FinalResult,
-  ProviderResolutionResult,
-  StrategyPerProviderContext,
-} from './BaseEvaluationStrategy';
-import { ErrorCode, EvaluationContext, FlagValue, OpenFeatureError, ResolutionDetails } from '@openfeature/server-sdk';
+import type { FinalResult, ProviderResolutionResult, StrategyPerProviderContext } from './BaseEvaluationStrategy';
+import { BaseEvaluationStrategy } from './BaseEvaluationStrategy';
+import type { EvaluationContext, FlagValue } from '@openfeature/server-sdk';
+import { ErrorCode, OpenFeatureError, ResolutionDetails } from '@openfeature/server-sdk';
 
 /**
  * Return the first result that did not indicate "flag not found".

--- a/libs/providers/multi-provider/src/lib/strategies/FirstSuccessfulStrategy.ts
+++ b/libs/providers/multi-provider/src/lib/strategies/FirstSuccessfulStrategy.ts
@@ -1,10 +1,7 @@
-import {
-  BaseEvaluationStrategy,
-  FinalResult,
-  ProviderResolutionResult,
-  StrategyPerProviderContext,
-} from './BaseEvaluationStrategy';
-import { EvaluationContext, FlagValue, ResolutionDetails } from '@openfeature/server-sdk';
+import type { FinalResult, ProviderResolutionResult, StrategyPerProviderContext } from './BaseEvaluationStrategy';
+import { BaseEvaluationStrategy } from './BaseEvaluationStrategy';
+import type { EvaluationContext, FlagValue } from '@openfeature/server-sdk';
+import { ResolutionDetails } from '@openfeature/server-sdk';
 
 /**
  * Return the first result that did result in an error

--- a/libs/providers/multi-provider/src/lib/types.ts
+++ b/libs/providers/multi-provider/src/lib/types.ts
@@ -1,5 +1,5 @@
 // Represents an entry in the constructor's provider array which may or may not have a name set
-import { Provider } from '@openfeature/server-sdk';
+import type { Provider } from '@openfeature/server-sdk';
 
 export type ProviderEntryInput = {
   provider: Provider;

--- a/libs/providers/ofrep-web/src/lib/model/in-memory-cache.ts
+++ b/libs/providers/ofrep-web/src/lib/model/in-memory-cache.ts
@@ -1,5 +1,5 @@
 import type { FlagMetadata, FlagValue, ResolutionDetails } from '@openfeature/web-sdk';
-import { ResolutionError } from './resolution-error';
+import type { ResolutionError } from './resolution-error';
 
 /**
  * Cache of flag values from bulk evaluation.

--- a/libs/providers/ofrep-web/src/lib/model/ofrep-web-provider-options.ts
+++ b/libs/providers/ofrep-web/src/lib/model/ofrep-web-provider-options.ts
@@ -1,4 +1,4 @@
-import { OFREPProviderBaseOptions } from '@openfeature/ofrep-core';
+import type { OFREPProviderBaseOptions } from '@openfeature/ofrep-core';
 
 export type OFREPWebProviderOptions = OFREPProviderBaseOptions & {
   /**

--- a/libs/providers/ofrep-web/src/lib/model/resolution-error.ts
+++ b/libs/providers/ofrep-web/src/lib/model/resolution-error.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, ResolutionReason } from '@openfeature/web-sdk';
+import type { ErrorCode, ResolutionReason } from '@openfeature/web-sdk';
 
 export type ResolutionError = {
   reason: ResolutionReason;

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
@@ -1,6 +1,5 @@
+import type { EvaluationRequest, EvaluationResponse } from '@openfeature/ofrep-core';
 import {
-  EvaluationRequest,
-  EvaluationResponse,
   OFREPApi,
   OFREPApiFetchError,
   OFREPApiTooManyRequestsError,
@@ -9,25 +8,28 @@ import {
   isEvaluationFailureResponse,
   isEvaluationSuccessResponse,
 } from '@openfeature/ofrep-core';
-import {
-  ClientProviderEvents,
-  ErrorCode,
+import type {
   EvaluationContext,
   FlagValue,
-  GeneralError,
   Hook,
   JsonValue,
   Logger,
+  Provider,
+  ResolutionDetails,
+} from '@openfeature/web-sdk';
+import {
+  ClientProviderEvents,
+  ErrorCode,
+  GeneralError,
   OpenFeatureError,
   OpenFeatureEventEmitter,
-  Provider,
   ProviderFatalError,
-  ResolutionDetails,
   StandardResolutionReasons,
 } from '@openfeature/web-sdk';
-import { BulkEvaluationStatus, EvaluateFlagsResponse } from './model/evaluate-flags-response';
-import { FlagCache, MetadataCache } from './model/in-memory-cache';
-import { OFREPWebProviderOptions } from './model/ofrep-web-provider-options';
+import type { EvaluateFlagsResponse } from './model/evaluate-flags-response';
+import { BulkEvaluationStatus } from './model/evaluate-flags-response';
+import type { FlagCache, MetadataCache } from './model/in-memory-cache';
+import type { OFREPWebProviderOptions } from './model/ofrep-web-provider-options';
 import { isResolutionError } from './model/resolution-error';
 
 const ErrorMessageMap: { [key in ErrorCode]: string } = {

--- a/libs/providers/ofrep/src/lib/ofrep-provider.spec.ts
+++ b/libs/providers/ofrep/src/lib/ofrep-provider.spec.ts
@@ -1,4 +1,5 @@
-import { OFREPProvider, OFREPProviderOptions } from './ofrep-provider';
+import type { OFREPProviderOptions } from './ofrep-provider';
+import { OFREPProvider } from './ofrep-provider';
 import {
   OFREPApiTooManyRequestsError,
   OFREPApiUnauthorizedError,

--- a/libs/providers/ofrep/src/lib/ofrep-provider.ts
+++ b/libs/providers/ofrep/src/lib/ofrep-provider.ts
@@ -1,21 +1,12 @@
+import type { EvaluationFlagValue, OFREPApiEvaluationResult, OFREPProviderBaseOptions } from '@openfeature/ofrep-core';
 import {
-  EvaluationFlagValue,
   OFREPApi,
-  OFREPApiEvaluationResult,
   OFREPApiTooManyRequestsError,
-  OFREPProviderBaseOptions,
   handleEvaluationError,
   toResolutionDetails,
 } from '@openfeature/ofrep-core';
-import {
-  ErrorCode,
-  EvaluationContext,
-  GeneralError,
-  JsonValue,
-  Provider,
-  ResolutionDetails,
-  StandardResolutionReasons,
-} from '@openfeature/server-sdk';
+import type { EvaluationContext, JsonValue, Provider, ResolutionDetails } from '@openfeature/server-sdk';
+import { ErrorCode, GeneralError, StandardResolutionReasons } from '@openfeature/server-sdk';
 
 export type OFREPProviderOptions = OFREPProviderBaseOptions;
 

--- a/libs/providers/unleash-web/src/lib/unleash-web-provider-config.ts
+++ b/libs/providers/unleash-web/src/lib/unleash-web-provider-config.ts
@@ -1,3 +1,3 @@
-import { IConfig } from 'unleash-proxy-client';
+import type { IConfig } from 'unleash-proxy-client';
 
 export type UnleashConfig = IConfig;

--- a/libs/providers/unleash-web/src/lib/unleash-web-provider.ts
+++ b/libs/providers/unleash-web/src/lib/unleash-web-provider.ts
@@ -1,17 +1,13 @@
+import type { EvaluationContext, Provider, Logger, JsonValue, ResolutionDetails } from '@openfeature/web-sdk';
 import {
-  EvaluationContext,
-  Provider,
-  Logger,
-  JsonValue,
   FlagNotFoundError,
   OpenFeatureEventEmitter,
   ProviderEvents,
-  ResolutionDetails,
   ProviderFatalError,
   TypeMismatchError,
 } from '@openfeature/web-sdk';
 import { UnleashClient } from 'unleash-proxy-client';
-import { UnleashConfig } from './unleash-web-provider-config';
+import type { UnleashConfig } from './unleash-web-provider-config';
 
 export class UnleashWebProvider implements Provider {
   metadata = {

--- a/libs/shared/config-cat-core/src/lib/context-transformer.spec.ts
+++ b/libs/shared/config-cat-core/src/lib/context-transformer.spec.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext } from '@openfeature/core';
+import type { EvaluationContext } from '@openfeature/core';
 import { transformContext } from './context-transformer';
 
 describe('context-transformer', () => {

--- a/libs/shared/config-cat-core/src/lib/context-transformer.ts
+++ b/libs/shared/config-cat-core/src/lib/context-transformer.ts
@@ -1,5 +1,5 @@
-import { EvaluationContext, EvaluationContextValue } from '@openfeature/core';
-import { User as ConfigCatUser, UserAttributeValue } from 'configcat-common';
+import type { EvaluationContext, EvaluationContextValue } from '@openfeature/core';
+import type { User as ConfigCatUser, UserAttributeValue } from 'configcat-common';
 
 function toUserAttributeValue(value: EvaluationContextValue): UserAttributeValue {
   if (typeof value === 'string' || typeof value === 'number' || value instanceof Date) {

--- a/libs/shared/config-cat-core/src/lib/result-mapping.ts
+++ b/libs/shared/config-cat-core/src/lib/result-mapping.ts
@@ -1,11 +1,8 @@
-import { IEvaluationDetails } from 'configcat-js-ssr';
+import type { IEvaluationDetails } from 'configcat-js-ssr';
+import type { ResolutionDetails, ResolutionReason, JsonValue, OpenFeatureError } from '@openfeature/core';
 import {
-  ResolutionDetails,
-  ResolutionReason,
   TypeMismatchError,
   StandardResolutionReasons,
-  JsonValue,
-  OpenFeatureError,
   ParseError,
   TargetingKeyMissingError,
   GeneralError,

--- a/libs/shared/flagd-core/src/lib/feature-flag.spec.ts
+++ b/libs/shared/flagd-core/src/lib/feature-flag.spec.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@openfeature/core';
-import { FeatureFlag, Flag } from './feature-flag';
+import type { Flag } from './feature-flag';
+import { FeatureFlag } from './feature-flag';
 
 const logger: Logger = {
   error: jest.fn(),

--- a/libs/shared/flagd-core/src/lib/flagd-core.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.ts
@@ -9,8 +9,9 @@ import type {
   JsonValue,
   FlagMetadata,
 } from '@openfeature/core';
-import { FeatureFlag } from './feature-flag';
-import { MemoryStorage, Storage } from './storage';
+import type { FeatureFlag } from './feature-flag';
+import type { Storage } from './storage';
+import { MemoryStorage } from './storage';
 
 type ResolutionDetailsWithFlagMetadata<T> = Required<Pick<ResolutionDetails<T>, 'flagMetadata'>> & ResolutionDetails<T>;
 

--- a/libs/shared/flagd-core/src/lib/parser.ts
+++ b/libs/shared/flagd-core/src/lib/parser.ts
@@ -3,7 +3,8 @@ import { ParseError } from '@openfeature/core';
 import Ajv from 'ajv';
 import flagsSchema from '../../flagd-schemas/json/flags.json';
 import targetingSchema from '../../flagd-schemas/json/targeting.json';
-import { FeatureFlag, Flag } from './feature-flag';
+import type { Flag } from './feature-flag';
+import { FeatureFlag } from './feature-flag';
 
 type FlagConfig = {
   flags: { [key: string]: Flag };

--- a/libs/shared/flagd-core/src/lib/storage.ts
+++ b/libs/shared/flagd-core/src/lib/storage.ts
@@ -1,5 +1,5 @@
 import type { FlagMetadata, Logger } from '@openfeature/core';
-import { FeatureFlag } from './feature-flag';
+import type { FeatureFlag } from './feature-flag';
 import { parse } from './parser';
 
 /**

--- a/libs/shared/ofrep-core/src/lib/api/ofrep-api.spec.ts
+++ b/libs/shared/ofrep-core/src/lib/api/ofrep-api.spec.ts
@@ -1,7 +1,7 @@
 import { ErrorCode, StandardResolutionReasons } from '@openfeature/core';
 import { server } from '../../test/mock-service-worker';
 import { TEST_FLAG_METADATA, TEST_FLAG_SET_METADATA } from '../../test/test-constants';
-import {
+import type {
   BulkEvaluationFailureResponse,
   BulkEvaluationSuccessResponse,
   EvaluationFailureResponse,

--- a/libs/shared/ofrep-core/src/lib/api/ofrep-api.ts
+++ b/libs/shared/ofrep-core/src/lib/api/ofrep-api.ts
@@ -1,5 +1,6 @@
-import { ErrorCode, FlagMetadata, ResolutionDetails, StandardResolutionReasons } from '@openfeature/core';
-import {
+import type { FlagMetadata, ResolutionDetails } from '@openfeature/core';
+import { ErrorCode, StandardResolutionReasons } from '@openfeature/core';
+import type {
   EvaluationFlagValue,
   EvaluationRequest,
   EvaluationSuccessResponse,
@@ -7,15 +8,18 @@ import {
   OFREPApiBulkEvaluationResult,
   OFREPApiEvaluationResult,
   OFREPEvaluationErrorHttpStatus,
-  OFREPEvaluationErrorHttpStatuses,
   OFREPEvaluationSuccessHttpStatus,
+} from '../model';
+import {
+  OFREPEvaluationErrorHttpStatuses,
   OFREPEvaluationSuccessHttpStatuses,
   isBulkEvaluationFailureResponse,
   isBulkEvaluationSuccessResponse,
   isEvaluationFailureResponse,
   isEvaluationSuccessResponse,
 } from '../model';
-import { OFREPProviderBaseOptions, buildHeaders } from '../provider';
+import type { OFREPProviderBaseOptions } from '../provider';
+import { buildHeaders } from '../provider';
 import {
   OFREPApiFetchError,
   OFREPApiTooManyRequestsError,

--- a/libs/shared/ofrep-core/src/lib/model/bulk-evaluation.ts
+++ b/libs/shared/ofrep-core/src/lib/model/bulk-evaluation.ts
@@ -1,5 +1,5 @@
-import { ErrorCode } from '@openfeature/core';
-import { EvaluationResponse, MetadataResponse } from './evaluation';
+import type { ErrorCode } from '@openfeature/core';
+import type { EvaluationResponse, MetadataResponse } from './evaluation';
 
 export interface BulkEvaluationFailureResponse extends MetadataResponse {
   /**

--- a/libs/shared/ofrep-core/src/lib/model/ofrep-api-result.ts
+++ b/libs/shared/ofrep-core/src/lib/model/ofrep-api-result.ts
@@ -1,5 +1,5 @@
-import { EvaluationFailureResponse, EvaluationSuccessResponse } from './evaluation';
-import { BulkEvaluationFailureResponse, BulkEvaluationSuccessResponse } from './bulk-evaluation';
+import type { EvaluationFailureResponse, EvaluationSuccessResponse } from './evaluation';
+import type { BulkEvaluationFailureResponse, BulkEvaluationSuccessResponse } from './bulk-evaluation';
 
 export interface OFREPApiResult<
   S extends OFREPEvaluationErrorHttpStatus | OFREPEvaluationNotModifiedHttpStatus | OFREPEvaluationSuccessHttpStatus,

--- a/libs/shared/ofrep-core/src/lib/provider/ofrep-provider-options.ts
+++ b/libs/shared/ofrep-core/src/lib/provider/ofrep-provider-options.ts
@@ -1,4 +1,4 @@
-import { FetchAPI } from '../api';
+import type { FetchAPI } from '../api';
 
 export type OFREPProviderBaseOptions = {
   /**

--- a/libs/shared/ofrep-core/src/test/handlers.ts
+++ b/libs/shared/ofrep-core/src/test/handlers.ts
@@ -1,5 +1,6 @@
-import { http, HttpResponse, StrictResponse } from 'msw';
-import { BulkEvaluationResponse, EvaluationFailureResponse, EvaluationRequest, EvaluationResponse } from '../lib';
+import type { StrictResponse } from 'msw';
+import { http, HttpResponse } from 'msw';
+import type { BulkEvaluationResponse, EvaluationFailureResponse, EvaluationRequest, EvaluationResponse } from '../lib';
 import { TEST_FLAG_METADATA, TEST_FLAG_SET_METADATA } from './test-constants';
 import { ErrorCode, StandardResolutionReasons } from '@openfeature/core';
 

--- a/libs/shared/ofrep-core/src/test/test-constants.ts
+++ b/libs/shared/ofrep-core/src/test/test-constants.ts
@@ -1,4 +1,4 @@
-import { FlagMetadata } from '@openfeature/core';
+import type { FlagMetadata } from '@openfeature/core';
 
 export const TEST_FLAG_METADATA: FlagMetadata = {
   booleanKey: true,

--- a/tools/workspace-plugin/src/generators/open-feature/index.ts
+++ b/tools/workspace-plugin/src/generators/open-feature/index.ts
@@ -1,3 +1,4 @@
+import type { Tree } from '@nx/devkit';
 import {
   formatFiles,
   generateFiles,
@@ -5,7 +6,6 @@ import {
   joinPathFragments,
   logger,
   names,
-  Tree,
   updateJson,
   moveFilesToNewDirectory,
 } from '@nx/devkit';


### PR DESCRIPTION
Adds a lint rule which enforces the use of `type` imports for types, and applies the autofix.

No other changes.

Resolves: https://github.com/open-feature/js-sdk-contrib/issues/1210