### PR TITLE
feat(flipt-web): update types to match flipt-client-js

### DIFF
--- a/libs/providers/flipt-web/src/index.ts
+++ b/libs/providers/flipt-web/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/flipt-web-provider';
+export * from './lib/models';

--- a/libs/providers/flipt-web/src/lib/models.ts
+++ b/libs/providers/flipt-web/src/lib/models.ts
@@ -1,7 +1,13 @@
 export interface FliptWebProviderOptions {
   url?: string;
   authentication?: FliptWebProviderAuthentication;
-  fetcher?: () => Promise<Response>;
+  fetcher?: FliptFetcher;
+}
+
+export type FliptFetcher = (args?: FliptFetcherOptions) => Promise<Response>;
+
+export interface FliptFetcherOptions {
+  etag?: string;
 }
 
 export interface FliptClientTokenAuthentication {


### PR DESCRIPTION
## This PR

Updates the types of the `flipt-web` provider to match the [types of the flipt client](https://github.com/flipt-io/flipt-client-sdks/blob/main/flipt-client-js/src/core/types.ts#L50-L62).

Also the types are now exported from the package.

No functional changes.
