### PR TITLE
feat(ofrep): adding error details for 401, 403 and 429

### DIFF
--- a/libs/shared/ofrep-core/src/lib/api/errors.ts
+++ b/libs/shared/ofrep-core/src/lib/api/errors.ts
@@ -32,6 +32,7 @@ export class OFREPApiUnauthorizedError extends OFREPApiError {
     super(undefined, response, message, options);
     Object.setPrototypeOf(this, OFREPApiUnauthorizedError.prototype);
     this.name = OFREPApiUnauthorizedError.name;
+    this.message = message ?? 'OFREP request failed: unauthorized';
   }
 }
 
@@ -40,6 +41,7 @@ export class OFREPForbiddenError extends OFREPApiError {
     super(undefined, response, message, options);
     Object.setPrototypeOf(this, OFREPForbiddenError.prototype);
     this.name = OFREPForbiddenError.name;
+    this.message = message ?? 'OFREP request failed: forbidden';
   }
 }
 

--- a/libs/shared/ofrep-core/src/lib/api/ofrep-api.ts
+++ b/libs/shared/ofrep-core/src/lib/api/ofrep-api.ts
@@ -84,15 +84,15 @@ export class OFREPApi {
     }
 
     if (response.status === 401) {
-      throw new OFREPApiUnauthorizedError(response, 'OFREP request failed: unauthorized');
+      throw new OFREPApiUnauthorizedError(response);
     }
 
     if (response.status === 403) {
-      throw new OFREPForbiddenError(response, 'OFREP request failed: forbidden');
+      throw new OFREPForbiddenError(response);
     }
 
     if (response.status === 429) {
-      throw new OFREPApiTooManyRequestsError(response, 'OFREP request failed: too many requests');
+      throw new OFREPApiTooManyRequestsError(response);
     }
 
     if (response.status === 200 && !this.isJsonMime(response)) {

--- a/libs/shared/ofrep-core/src/lib/api/ofrep-api.ts
+++ b/libs/shared/ofrep-core/src/lib/api/ofrep-api.ts
@@ -84,15 +84,15 @@ export class OFREPApi {
     }
 
     if (response.status === 401) {
-      throw new OFREPApiUnauthorizedError(response);
+      throw new OFREPApiUnauthorizedError(response, 'OFREP request failed: unauthorized');
     }
 
     if (response.status === 403) {
-      throw new OFREPForbiddenError(response);
+      throw new OFREPForbiddenError(response, 'OFREP request failed: forbidden');
     }
 
     if (response.status === 429) {
-      throw new OFREPApiTooManyRequestsError(response);
+      throw new OFREPApiTooManyRequestsError(response, 'OFREP request failed: too many requests');
     }
 
     if (response.status === 200 && !this.isJsonMime(response)) {


### PR DESCRIPTION
## This PR
Current implementation does not include any error details when failing in 401, 403 or 429.
