### PR TITLE
refactor(`aws-ssm`): improve unit tests readability

### DIFF
--- a/libs/providers/aws-ssm/src/lib/aws-ssm-provider.spec.ts
+++ b/libs/providers/aws-ssm/src/lib/aws-ssm-provider.spec.ts
@@ -2,8 +2,7 @@ import type { SSMClientConfig } from '@aws-sdk/client-ssm';
 import { AwsSsmProvider } from './aws-ssm-provider';
 import { ErrorCode, StandardResolutionReasons } from '@openfeature/core';
 
-describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
-
+describe('aws-ssm-provider.ts - AwsSsmProvider', () => {
   let provider: AwsSsmProvider;
   let getBooleanValueSpy: jest.SpyInstance;
   let getStringValueSpy: jest.SpyInstance;
@@ -34,9 +33,8 @@ describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
     getObjectValueSpy = jest.spyOn(provider.service, 'getObjectValue');
   });
 
-  describe("resolveBooleanEvaluation", () => {
-
-    it("should return cached value when flag is cached", async () => {
+  describe('resolveBooleanEvaluation', () => {
+    it('should return cached value when flag is cached', async () => {
       provider.cache.set('test', {
         value: true,
         reason: StandardResolutionReasons.STATIC,
@@ -50,7 +48,7 @@ describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
       });
     });
 
-    it("should return default value when getBooleanValue rejects", async () => {
+    it('should return default value when getBooleanValue rejects', async () => {
       getBooleanValueSpy.mockRejectedValue(new Error());
 
       const result = await provider.resolveBooleanEvaluation('test-error', false, {});
@@ -63,7 +61,7 @@ describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
       });
     });
 
-    it("should resolve with expected value when getBooleanValue resolves", async () => {
+    it('should resolve with expected value when getBooleanValue resolves', async () => {
       getBooleanValueSpy.mockResolvedValue({
         value: true,
         reason: StandardResolutionReasons.STATIC,
@@ -78,9 +76,8 @@ describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
     });
   });
 
-  describe("resolveStringEvaluation", () => {
-
-    it("should return cached value when flag is cached", async () => {
+  describe('resolveStringEvaluation', () => {
+    it('should return cached value when flag is cached', async () => {
       provider.cache.set('test-string', {
         value: 'somestring',
         reason: StandardResolutionReasons.STATIC,
@@ -94,7 +91,7 @@ describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
       });
     });
 
-    it("should return default value when getStringValue rejects", async () => {
+    it('should return default value when getStringValue rejects', async () => {
       getStringValueSpy.mockRejectedValue(new Error());
 
       const result = await provider.resolveStringEvaluation('test-string-error', 'default', {});
@@ -107,7 +104,7 @@ describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
       });
     });
 
-    it("should resolve with expected value when getStringValue resolves", async () => {
+    it('should resolve with expected value when getStringValue resolves', async () => {
       getStringValueSpy.mockResolvedValue({
         value: 'somestring',
         reason: StandardResolutionReasons.STATIC,
@@ -122,9 +119,8 @@ describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
     });
   });
 
-  describe("resolveNumberEvaluation", () => {
-
-    it("should return cached value when flag is cached", async () => {
+  describe('resolveNumberEvaluation', () => {
+    it('should return cached value when flag is cached', async () => {
       provider.cache.set('test-number', {
         value: 489,
         reason: StandardResolutionReasons.STATIC,
@@ -138,7 +134,7 @@ describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
       });
     });
 
-    it("should return default value when getNumberValue rejects", async () => {
+    it('should return default value when getNumberValue rejects', async () => {
       getNumberValueSpy.mockRejectedValue(new Error());
 
       const result = await provider.resolveNumberEvaluation('test-number-error', -1, {});
@@ -151,7 +147,7 @@ describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
       });
     });
 
-    it("should resolve with expected value when getNumberValue resolves", async () => {
+    it('should resolve with expected value when getNumberValue resolves', async () => {
       getNumberValueSpy.mockResolvedValue({
         value: 489,
         reason: StandardResolutionReasons.STATIC,
@@ -166,9 +162,8 @@ describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
     });
   });
 
-  describe("resolveObjectEvaluation", () => {
-
-    it("should return cached value when flag is cached", async () => {
+  describe('resolveObjectEvaluation', () => {
+    it('should return cached value when flag is cached', async () => {
       provider.cache.set('test-object', {
         value: { default: false },
         reason: StandardResolutionReasons.STATIC,
@@ -182,7 +177,7 @@ describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
       });
     });
 
-    it("should return default value when getObjectValue rejects", async () => {
+    it('should return default value when getObjectValue rejects', async () => {
       getObjectValueSpy.mockRejectedValue(new Error());
 
       const result = await provider.resolveObjectEvaluation('test-object-error', { default: true }, {});
@@ -195,7 +190,7 @@ describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
       });
     });
 
-    it("should resolve with expected value when getObjectValue resolves", async () => {
+    it('should resolve with expected value when getObjectValue resolves', async () => {
       getObjectValueSpy.mockResolvedValue({
         value: { default: true },
         reason: StandardResolutionReasons.STATIC,

--- a/libs/providers/aws-ssm/src/lib/aws-ssm-provider.spec.ts
+++ b/libs/providers/aws-ssm/src/lib/aws-ssm-provider.spec.ts
@@ -2,202 +2,216 @@ import type { SSMClientConfig } from '@aws-sdk/client-ssm';
 import { AwsSsmProvider } from './aws-ssm-provider';
 import { ErrorCode, StandardResolutionReasons } from '@openfeature/core';
 
-const MOCK_SSM_CLIENT_CONFIG: SSMClientConfig = {
-  region: 'us-east-1',
-  credentials: {
-    accessKeyId: 'accessKeyId',
-    secretAccessKey: 'secretAccessKey',
-  },
-};
+describe("aws-ssm-provider.ts - AwsSsmProvider", () => {
 
-const provider: AwsSsmProvider = new AwsSsmProvider({
-  ssmClientConfig: MOCK_SSM_CLIENT_CONFIG,
-  cacheOpts: {
-    enabled: true,
-    ttl: 1000,
-    size: 100,
-  },
-});
+  let provider: AwsSsmProvider;
+  let getBooleanValueSpy: jest.SpyInstance;
+  let getStringValueSpy: jest.SpyInstance;
+  let getNumberValueSpy: jest.SpyInstance;
+  let getObjectValueSpy: jest.SpyInstance;
 
-describe(AwsSsmProvider.name, () => {
-  describe(AwsSsmProvider.prototype.resolveBooleanEvaluation.name, () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
+  const mockSsmClientConfig: SSMClientConfig = {
+    region: 'us-east-1',
+    credentials: {
+      accessKeyId: 'accessKeyId',
+      secretAccessKey: 'secretAccessKey',
+    },
+  };
+
+  beforeAll(() => {
+    provider = new AwsSsmProvider({
+      ssmClientConfig: mockSsmClientConfig,
+      cacheOpts: {
+        enabled: true,
+        ttl: 1000,
+        size: 100,
+      },
     });
-    describe('when flag is cached', () => {
-      afterAll(() => {
-        provider.cache.clear();
+
+    getBooleanValueSpy = jest.spyOn(provider.service, 'getBooleanValue');
+    getStringValueSpy = jest.spyOn(provider.service, 'getStringValue');
+    getNumberValueSpy = jest.spyOn(provider.service, 'getNumberValue');
+    getObjectValueSpy = jest.spyOn(provider.service, 'getObjectValue');
+  });
+
+  describe("resolveBooleanEvaluation", () => {
+
+    it("should return cached value when flag is cached", async () => {
+      provider.cache.set('test', {
+        value: true,
+        reason: StandardResolutionReasons.STATIC,
       });
-      it('should return cached value', async () => {
-        provider.cache.set('test', {
-          value: true,
-          reason: StandardResolutionReasons.STATIC,
-        });
-        await expect(provider.resolveBooleanEvaluation('test', false, {})).resolves.toEqual({
-          value: true,
-          reason: StandardResolutionReasons.CACHED,
-        });
+
+      const result = await provider.resolveBooleanEvaluation('test', false, {});
+
+      expect(result).toEqual({
+        value: true,
+        reason: StandardResolutionReasons.CACHED,
       });
     });
-    describe('when flag is not cached', () => {
-      describe('when getBooleanValue rejects', () => {
-        it('should return default value', async () => {
-          jest.spyOn(provider.service, 'getBooleanValue').mockRejectedValue(new Error());
-          await expect(provider.resolveBooleanEvaluation('test', false, {})).resolves.toEqual({
-            value: false,
-            reason: StandardResolutionReasons.ERROR,
-            errorMessage: 'An unknown error occurred',
-            errorCode: ErrorCode.GENERAL,
-          });
-        });
+
+    it("should return default value when getBooleanValue rejects", async () => {
+      getBooleanValueSpy.mockRejectedValue(new Error());
+
+      const result = await provider.resolveBooleanEvaluation('test-error', false, {});
+
+      expect(result).toEqual({
+        value: false,
+        reason: StandardResolutionReasons.ERROR,
+        errorMessage: 'An unknown error occurred',
+        errorCode: ErrorCode.GENERAL,
       });
-      describe('when getBooleanValue resolves', () => {
-        it('should resolve with expected value', async () => {
-          jest.spyOn(provider.service, 'getBooleanValue').mockResolvedValue({
-            value: true,
-            reason: StandardResolutionReasons.STATIC,
-          });
-          await expect(provider.resolveBooleanEvaluation('test', false, {})).resolves.toEqual({
-            value: true,
-            reason: StandardResolutionReasons.STATIC,
-          });
-        });
+    });
+
+    it("should resolve with expected value when getBooleanValue resolves", async () => {
+      getBooleanValueSpy.mockResolvedValue({
+        value: true,
+        reason: StandardResolutionReasons.STATIC,
+      });
+
+      const result = await provider.resolveBooleanEvaluation('test-success', false, {});
+
+      expect(result).toEqual({
+        value: true,
+        reason: StandardResolutionReasons.STATIC,
       });
     });
   });
-  describe(AwsSsmProvider.prototype.resolveStringEvaluation.name, () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-    describe('when flag is cached', () => {
-      afterAll(() => {
-        provider.cache.clear();
+
+  describe("resolveStringEvaluation", () => {
+
+    it("should return cached value when flag is cached", async () => {
+      provider.cache.set('test-string', {
+        value: 'somestring',
+        reason: StandardResolutionReasons.STATIC,
       });
-      it('should return cached value', async () => {
-        provider.cache.set('test', {
-          value: 'somestring',
-          reason: StandardResolutionReasons.STATIC,
-        });
-        await expect(provider.resolveStringEvaluation('test', 'default', {})).resolves.toEqual({
-          value: 'somestring',
-          reason: StandardResolutionReasons.CACHED,
-        });
+
+      const result = await provider.resolveStringEvaluation('test-string', 'default', {});
+
+      expect(result).toEqual({
+        value: 'somestring',
+        reason: StandardResolutionReasons.CACHED,
       });
     });
-    describe('when flag is not cached', () => {
-      describe('when getStringValue rejects', () => {
-        it('should return default value', async () => {
-          jest.spyOn(provider.service, 'getStringValue').mockRejectedValue(new Error());
-          await expect(provider.resolveStringEvaluation('test', 'default', {})).resolves.toEqual({
-            value: 'default',
-            reason: StandardResolutionReasons.ERROR,
-            errorMessage: 'An unknown error occurred',
-            errorCode: ErrorCode.GENERAL,
-          });
-        });
-      });
-      describe('when getStringValue resolves', () => {
-        it('should resolve with expected value', async () => {
-          jest.spyOn(provider.service, 'getStringValue').mockResolvedValue({
-            value: 'somestring',
-            reason: StandardResolutionReasons.STATIC,
-          });
-          await expect(provider.resolveStringEvaluation('test', 'default', {})).resolves.toEqual({
-            value: 'somestring',
-            reason: StandardResolutionReasons.STATIC,
-          });
-        });
+
+    it("should return default value when getStringValue rejects", async () => {
+      getStringValueSpy.mockRejectedValue(new Error());
+
+      const result = await provider.resolveStringEvaluation('test-string-error', 'default', {});
+
+      expect(result).toEqual({
+        value: 'default',
+        reason: StandardResolutionReasons.ERROR,
+        errorMessage: 'An unknown error occurred',
+        errorCode: ErrorCode.GENERAL,
       });
     });
-  });
-  describe(AwsSsmProvider.prototype.resolveNumberEvaluation.name, () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-    describe('when flag is cached', () => {
-      afterAll(() => {
-        provider.cache.clear();
+
+    it("should resolve with expected value when getStringValue resolves", async () => {
+      getStringValueSpy.mockResolvedValue({
+        value: 'somestring',
+        reason: StandardResolutionReasons.STATIC,
       });
-      it('should return cached value', async () => {
-        provider.cache.set('test', {
-          value: 489,
-          reason: StandardResolutionReasons.STATIC,
-        });
-        await expect(provider.resolveNumberEvaluation('test', -1, {})).resolves.toEqual({
-          value: 489,
-          reason: StandardResolutionReasons.CACHED,
-        });
-      });
-    });
-    describe('when flag is not cached', () => {
-      describe('when getNumberValue rejects', () => {
-        it('should return default value', async () => {
-          jest.spyOn(provider.service, 'getNumberValue').mockRejectedValue(new Error());
-          await expect(provider.resolveNumberEvaluation('test', -1, {})).resolves.toEqual({
-            value: -1,
-            reason: StandardResolutionReasons.ERROR,
-            errorMessage: 'An unknown error occurred',
-            errorCode: ErrorCode.GENERAL,
-          });
-        });
-      });
-      describe('when getNumberValue resolves', () => {
-        it('should resolve with expected value', async () => {
-          jest.spyOn(provider.service, 'getNumberValue').mockResolvedValue({
-            value: 489,
-            reason: StandardResolutionReasons.STATIC,
-          });
-          await expect(provider.resolveNumberEvaluation('test', -1, {})).resolves.toEqual({
-            value: 489,
-            reason: StandardResolutionReasons.STATIC,
-          });
-        });
+
+      const result = await provider.resolveStringEvaluation('test-string-success', 'default', {});
+
+      expect(result).toEqual({
+        value: 'somestring',
+        reason: StandardResolutionReasons.STATIC,
       });
     });
   });
-  describe(AwsSsmProvider.prototype.resolveObjectEvaluation.name, () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-    describe('when flag is cached', () => {
-      afterAll(() => {
-        provider.cache.clear();
+
+  describe("resolveNumberEvaluation", () => {
+
+    it("should return cached value when flag is cached", async () => {
+      provider.cache.set('test-number', {
+        value: 489,
+        reason: StandardResolutionReasons.STATIC,
       });
-      it('should return cached value', async () => {
-        provider.cache.set('test', {
-          value: { default: false },
-          reason: StandardResolutionReasons.STATIC,
-        });
-        await expect(provider.resolveObjectEvaluation('test', { default: true }, {})).resolves.toEqual({
-          value: { default: false },
-          reason: StandardResolutionReasons.CACHED,
-        });
+
+      const result = await provider.resolveNumberEvaluation('test-number', -1, {});
+
+      expect(result).toEqual({
+        value: 489,
+        reason: StandardResolutionReasons.CACHED,
       });
     });
-    describe('when flag is not cached', () => {
-      describe('when getObjectValue rejects', () => {
-        it('should return default value', async () => {
-          jest.spyOn(provider.service, 'getObjectValue').mockRejectedValue(new Error());
-          await expect(provider.resolveObjectEvaluation('test', { default: true }, {})).resolves.toEqual({
-            value: { default: true },
-            reason: StandardResolutionReasons.ERROR,
-            errorMessage: 'An unknown error occurred',
-            errorCode: ErrorCode.GENERAL,
-          });
-        });
-      });
-      describe('when getObjectValue resolves', () => {
-        it('should resolve with expected value', async () => {
-          jest.spyOn(provider.service, 'getObjectValue').mockResolvedValue({
-            value: { default: true },
-            reason: StandardResolutionReasons.STATIC,
-          });
-          await expect(provider.resolveObjectEvaluation('test', -1, {})).resolves.toEqual({
-            value: { default: true },
-            reason: StandardResolutionReasons.STATIC,
-          });
-        });
+
+    it("should return default value when getNumberValue rejects", async () => {
+      getNumberValueSpy.mockRejectedValue(new Error());
+
+      const result = await provider.resolveNumberEvaluation('test-number-error', -1, {});
+
+      expect(result).toEqual({
+        value: -1,
+        reason: StandardResolutionReasons.ERROR,
+        errorMessage: 'An unknown error occurred',
+        errorCode: ErrorCode.GENERAL,
       });
     });
+
+    it("should resolve with expected value when getNumberValue resolves", async () => {
+      getNumberValueSpy.mockResolvedValue({
+        value: 489,
+        reason: StandardResolutionReasons.STATIC,
+      });
+
+      const result = await provider.resolveNumberEvaluation('test-number-success', -1, {});
+
+      expect(result).toEqual({
+        value: 489,
+        reason: StandardResolutionReasons.STATIC,
+      });
+    });
+  });
+
+  describe("resolveObjectEvaluation", () => {
+
+    it("should return cached value when flag is cached", async () => {
+      provider.cache.set('test-object', {
+        value: { default: false },
+        reason: StandardResolutionReasons.STATIC,
+      });
+
+      const result = await provider.resolveObjectEvaluation('test-object', { default: true }, {});
+
+      expect(result).toEqual({
+        value: { default: false },
+        reason: StandardResolutionReasons.CACHED,
+      });
+    });
+
+    it("should return default value when getObjectValue rejects", async () => {
+      getObjectValueSpy.mockRejectedValue(new Error());
+
+      const result = await provider.resolveObjectEvaluation('test-object-error', { default: true }, {});
+
+      expect(result).toEqual({
+        value: { default: true },
+        reason: StandardResolutionReasons.ERROR,
+        errorMessage: 'An unknown error occurred',
+        errorCode: ErrorCode.GENERAL,
+      });
+    });
+
+    it("should resolve with expected value when getObjectValue resolves", async () => {
+      getObjectValueSpy.mockResolvedValue({
+        value: { default: true },
+        reason: StandardResolutionReasons.STATIC,
+      });
+
+      const result = await provider.resolveObjectEvaluation('test-object-success', -1, {});
+
+      expect(result).toEqual({
+        value: { default: true },
+        reason: StandardResolutionReasons.STATIC,
+      });
+    });
+  });
+
+  afterEach(() => {
+    provider.cache.clear();
+    jest.clearAllMocks();
   });
 });

--- a/libs/providers/aws-ssm/src/lib/aws-ssm-provider.spec.ts
+++ b/libs/providers/aws-ssm/src/lib/aws-ssm-provider.spec.ts
@@ -196,7 +196,7 @@ describe('aws-ssm-provider.ts - AwsSsmProvider', () => {
         reason: StandardResolutionReasons.STATIC,
       });
 
-      const result = await provider.resolveObjectEvaluation('test-object-success', -1, {});
+      const result = await provider.resolveObjectEvaluation('test-object-success', {}, {});
 
       expect(result).toEqual({
         value: { default: true },

--- a/libs/providers/aws-ssm/src/lib/cache.spec.ts
+++ b/libs/providers/aws-ssm/src/lib/cache.spec.ts
@@ -1,59 +1,47 @@
 import { Cache } from './cache';
 
-describe(Cache.name, () => {
-  describe(Cache.prototype.get.name, () => {
-    describe('when cache is disabled', () => {
-      it('should return undefined', () => {
-        const cache = new Cache({ enabled: false, size: 1, ttl: 1 });
-        expect(cache.get('test')).toBeUndefined();
-      });
-    });
-    describe('when cache is enabled', () => {
-      describe('when key is not in cache', () => {
-        it('should return undefined', () => {
-          const cache = new Cache({ enabled: true, size: 1, ttl: 1 });
-          expect(cache.get('test')).toBeUndefined();
-        });
-      });
-      describe('when key is in cache', () => {
-        it('should return the value', () => {
-          const cache = new Cache({ enabled: true, size: 1, ttl: 1 });
-          cache.set('test', { value: true, reason: 'test' });
-          expect(cache.get('test')).toEqual({ value: true, reason: 'test' });
-        });
-      });
-    });
-  });
-  describe(Cache.prototype.set.name, () => {
-    describe('when cache is disabled', () => {
-      it('should not set the value', () => {
-        const spy = jest.spyOn(Cache.prototype, 'set');
-        expect(spy).not.toHaveBeenCalled();
-      });
-    });
-    describe('when cache is enabled', () => {
-      it('should set the value', () => {
-        const cache = new Cache({ enabled: true, size: 1, ttl: 1 });
-        cache.set('test', { value: true, reason: 'test' });
-        expect(cache.get('test')).toEqual({ value: true, reason: 'test' });
-      });
-    });
-  });
+describe("cache.ts - Cache", ()=>{
 
-  describe(Cache.prototype.clear.name, () => {
-    describe('when cache is disabled', () => {
-      it('should not clear the cache', () => {
-        const spy = jest.spyOn(Cache.prototype, 'clear');
-        expect(spy).not.toHaveBeenCalled();
-      });
-    });
-    describe('when cache is enabled', () => {
-      it('should clear the cache', () => {
-        const cache = new Cache({ enabled: true, size: 1, ttl: 1 });
-        cache.set('test', { value: true, reason: 'test' });
-        cache.clear();
-        expect(cache.get('test')).toBeUndefined();
-      });
-    });
-  });
-});
+  let cache : Cache
+  let setSpy : jest.SpyInstance
+
+  beforeAll(()=>{
+    cache = new Cache({enabled : true})
+    setSpy = jest.spyOn(Cache.prototype, 'set');
+
+  })
+
+  it("should return undefined when cache is disabled", ()=>{
+    cache = new Cache({enabled : false})
+    expect(cache.get('test')).toBeUndefined();
+  })
+
+  it("should return undefined when cache is enabled but key is not cached", ()=>{
+    cache = new Cache({enabled : true})
+    expect(cache.get('test')).toBeUndefined();
+  })
+
+
+  it("should return the cached value when cache is enabled and key is in cache", ()=>{
+    const cache = new Cache({ enabled: true, size: 1, ttl: 1 });
+    cache.set('test', { value: true, reason: 'test' });
+    expect(cache.get('test')).toEqual({ value: true, reason: 'test' });
+  })
+
+  it("should not set any value when cache is disabled", ()=>{
+    expect(setSpy).not.toHaveBeenCalled();
+  })
+
+  it("should clear the cache when cache is enabled and .clear() is called", ()=>{
+    const cache = new Cache({ enabled: true, size: 1, ttl: 1 });
+    cache.set('test', { value: true, reason: 'test' });
+    cache.clear();
+    expect(cache.get('test')).toBeUndefined();
+  })
+
+  afterEach(()=>{
+    cache = new Cache({enabled : true})
+    jest.clearAllMocks()
+  })
+})
+

--- a/libs/providers/aws-ssm/src/lib/cache.spec.ts
+++ b/libs/providers/aws-ssm/src/lib/cache.spec.ts
@@ -1,47 +1,43 @@
 import { Cache } from './cache';
 
-describe("cache.ts - Cache", ()=>{
+describe('cache.ts - Cache', () => {
+  let cache: Cache;
+  let setSpy: jest.SpyInstance;
 
-  let cache : Cache
-  let setSpy : jest.SpyInstance
-
-  beforeAll(()=>{
-    cache = new Cache({enabled : true})
+  beforeAll(() => {
+    cache = new Cache({ enabled: true });
     setSpy = jest.spyOn(Cache.prototype, 'set');
+  });
 
-  })
-
-  it("should return undefined when cache is disabled", ()=>{
-    cache = new Cache({enabled : false})
+  it('should return undefined when cache is disabled', () => {
+    cache = new Cache({ enabled: false });
     expect(cache.get('test')).toBeUndefined();
-  })
+  });
 
-  it("should return undefined when cache is enabled but key is not cached", ()=>{
-    cache = new Cache({enabled : true})
+  it('should return undefined when cache is enabled but key is not cached', () => {
+    cache = new Cache({ enabled: true });
     expect(cache.get('test')).toBeUndefined();
-  })
+  });
 
-
-  it("should return the cached value when cache is enabled and key is in cache", ()=>{
+  it('should return the cached value when cache is enabled and key is in cache', () => {
     const cache = new Cache({ enabled: true, size: 1, ttl: 1 });
     cache.set('test', { value: true, reason: 'test' });
     expect(cache.get('test')).toEqual({ value: true, reason: 'test' });
-  })
+  });
 
-  it("should not set any value when cache is disabled", ()=>{
+  it('should not set any value when cache is disabled', () => {
     expect(setSpy).not.toHaveBeenCalled();
-  })
+  });
 
-  it("should clear the cache when cache is enabled and .clear() is called", ()=>{
+  it('should clear the cache when cache is enabled and .clear() is called', () => {
     const cache = new Cache({ enabled: true, size: 1, ttl: 1 });
     cache.set('test', { value: true, reason: 'test' });
     cache.clear();
     expect(cache.get('test')).toBeUndefined();
-  })
+  });
 
-  afterEach(()=>{
-    cache = new Cache({enabled : true})
-    jest.clearAllMocks()
-  })
-})
-
+  afterEach(() => {
+    cache = new Cache({ enabled: true });
+    jest.clearAllMocks();
+  });
+});

--- a/libs/providers/aws-ssm/src/lib/cache.spec.ts
+++ b/libs/providers/aws-ssm/src/lib/cache.spec.ts
@@ -25,8 +25,10 @@ describe('cache.ts - Cache', () => {
     expect(cache.get('test')).toEqual({ value: true, reason: 'test' });
   });
 
-  it('should not set any value when cache is disabled', () => {
-    expect(setSpy).not.toHaveBeenCalled();
+  it('should not set a value when cache is disabled', () => {
+    const cache = new Cache({ enabled: false });
+    cache.set('test', { value: true, reason: 'test' });
+    expect(cache.get('test')).toBeUndefined();
   });
 
   it('should clear the cache when cache is enabled and .clear() is called', () => {

--- a/libs/providers/aws-ssm/src/lib/ssm-service.spec.ts
+++ b/libs/providers/aws-ssm/src/lib/ssm-service.spec.ts
@@ -1,122 +1,107 @@
 import { ParseError, StandardResolutionReasons, TypeMismatchError } from '@openfeature/core';
 import { SSMService } from './ssm-service';
 
-describe(SSMService.name, () => {
-  describe(SSMService.prototype.getBooleanValue.name, () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-    describe(`when _getParamFromSSM returns "true"`, () => {
-      it(`should return a ResolutionDetails with value true`, async () => {
-        jest
-          .spyOn(SSMService.prototype, '_getValueFromSSM')
-          .mockResolvedValue({ val: 'true', metadata: { httpStatusCode: 200 } });
-        const service = new SSMService({});
-        const result = await service.getBooleanValue('test');
-        expect(result).toEqual({
-          value: true,
-          reason: StandardResolutionReasons.STATIC,
-          flagMetadata: { httpStatusCode: 200 },
-        });
+describe("ssm-service.ts - SSMService", () => {
+
+  let service: SSMService;
+  let getValueFromSSMSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    service = new SSMService({});
+    getValueFromSSMSpy = jest.spyOn(SSMService.prototype, '_getValueFromSSM');
+  });
+
+  describe("getBooleanValue", () => {
+
+    it("should return true when _getValueFromSSM returns 'true'", async () => {
+      getValueFromSSMSpy.mockResolvedValue({ val: 'true', metadata: { httpStatusCode: 200 } });
+      
+      const result = await service.getBooleanValue('test');
+      
+      expect(result).toEqual({
+        value: true,
+        reason: StandardResolutionReasons.STATIC,
+        flagMetadata: { httpStatusCode: 200 },
       });
     });
-    describe(`when _getParamFromSSM returns "false"`, () => {
-      it(`should return a ResolutionDetails with value true`, async () => {
-        jest
-          .spyOn(SSMService.prototype, '_getValueFromSSM')
-          .mockResolvedValue({ val: 'false', metadata: { httpStatusCode: 200 } });
-        const service = new SSMService({});
-        const result = await service.getBooleanValue('test');
-        expect(result).toEqual({
-          value: false,
-          reason: StandardResolutionReasons.STATIC,
-          flagMetadata: { httpStatusCode: 200 },
-        });
+
+    it("should return false when _getValueFromSSM returns 'false'", async () => {
+      getValueFromSSMSpy.mockResolvedValue({ val: 'false', metadata: { httpStatusCode: 200 } });
+      
+      const result = await service.getBooleanValue('test');
+      
+      expect(result).toEqual({
+        value: false,
+        reason: StandardResolutionReasons.STATIC,
+        flagMetadata: { httpStatusCode: 200 },
       });
     });
-    describe(`when _getParamFromSSM returns an invalid value`, () => {
-      it('should throw a TypeMismatchError', () => {
-        jest
-          .spyOn(SSMService.prototype, '_getValueFromSSM')
-          .mockResolvedValue({ val: 'invalid boolean', metadata: { httpStatusCode: 400 } });
-        const service = new SSMService({});
-        expect(() => service.getBooleanValue('test')).rejects.toThrow(TypeMismatchError);
+
+    it("should throw TypeMismatchError when _getValueFromSSM returns invalid boolean", async () => {
+      getValueFromSSMSpy.mockResolvedValue({ val: 'invalid boolean', metadata: { httpStatusCode: 400 } });
+      
+      await expect(service.getBooleanValue('test')).rejects.toThrow(TypeMismatchError);
+    });
+  });
+
+  describe("getStringValue", () => {
+
+    it("should return the string value when _getValueFromSSM returns valid value", async () => {
+      getValueFromSSMSpy.mockResolvedValue({ val: 'example', metadata: { httpStatusCode: 200 } });
+      
+      const result = await service.getStringValue('example');
+      
+      expect(result).toEqual({
+        value: 'example',
+        reason: StandardResolutionReasons.STATIC,
+        flagMetadata: { httpStatusCode: 200 },
       });
     });
   });
-  describe(SSMService.prototype.getStringValue.name, () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-    describe(`when _getParamFromSSM returns a valid value`, () => {
-      it(`should return a ResolutionDetails with that value`, async () => {
-        jest
-          .spyOn(SSMService.prototype, '_getValueFromSSM')
-          .mockResolvedValue({ val: 'example', metadata: { httpStatusCode: 200 } });
-        const service = new SSMService({});
-        const result = await service.getStringValue('example');
-        expect(result).toEqual({
-          value: 'example',
-          reason: StandardResolutionReasons.STATIC,
-          flagMetadata: { httpStatusCode: 200 },
-        });
+
+  describe("getNumberValue", () => {
+
+    it("should return the number value when _getValueFromSSM returns valid number", async () => {
+      getValueFromSSMSpy.mockResolvedValue({ val: '1478', metadata: { httpStatusCode: 200 } });
+      
+      const result = await service.getNumberValue('test');
+      
+      expect(result).toEqual({
+        value: 1478,
+        reason: StandardResolutionReasons.STATIC,
+        flagMetadata: { httpStatusCode: 200 },
       });
+    });
+
+    it("should throw TypeMismatchError when _getValueFromSSM returns invalid number", async () => {
+      getValueFromSSMSpy.mockResolvedValue({ val: 'invalid number', metadata: { httpStatusCode: 400 } });
+      
+      await expect(service.getNumberValue('test')).rejects.toThrow(TypeMismatchError);
     });
   });
-  describe(SSMService.prototype.getNumberValue.name, () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-    describe(`when _getParamFromSSM returns a valid number`, () => {
-      it(`should return a ResolutionDetails with value true`, async () => {
-        jest
-          .spyOn(SSMService.prototype, '_getValueFromSSM')
-          .mockResolvedValue({ val: '1478', metadata: { httpStatusCode: 200 } });
-        const service = new SSMService({});
-        const result = await service.getNumberValue('test');
-        expect(result).toEqual({
-          value: 1478,
-          reason: StandardResolutionReasons.STATIC,
-          flagMetadata: { httpStatusCode: 200 },
-        });
+
+  describe("getObjectValue", () => {
+
+    it("should return the parsed object when _getValueFromSSM returns valid JSON", async () => {
+      getValueFromSSMSpy.mockResolvedValue({ val: JSON.stringify({ test: true }), metadata: { httpStatusCode: 400 } });
+      
+      const result = await service.getObjectValue('test');
+      
+      expect(result).toEqual({
+        value: { test: true },
+        reason: StandardResolutionReasons.STATIC,
+        flagMetadata: { httpStatusCode: 400 },
       });
     });
-    describe(`when _getParamFromSSM returns a value that is not a number`, () => {
-      it(`should return a TypeMismatchError`, async () => {
-        jest
-          .spyOn(SSMService.prototype, '_getValueFromSSM')
-          .mockResolvedValue({ val: 'invalid number', metadata: { httpStatusCode: 400 } });
-        const service = new SSMService({});
-        expect(() => service.getNumberValue('test')).rejects.toThrow(TypeMismatchError);
-      });
+
+    it("should throw ParseError when _getValueFromSSM returns invalid JSON", async () => {
+      getValueFromSSMSpy.mockResolvedValue({ val: 'invalid object', metadata: { httpStatusCode: 400 } });
+      
+      await expect(service.getObjectValue('test')).rejects.toThrow(ParseError);
     });
   });
-  describe(SSMService.prototype.getObjectValue.name, () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-    describe(`when _getParamFromSSM returns a valid object`, () => {
-      it(`should return a ResolutionDetails with that object`, async () => {
-        jest
-          .spyOn(SSMService.prototype, '_getValueFromSSM')
-          .mockResolvedValue({ val: JSON.stringify({ test: true }), metadata: { httpStatusCode: 400 } });
-        const service = new SSMService({});
-        const result = await service.getObjectValue('test');
-        expect(result).toEqual({
-          value: { test: true },
-          reason: StandardResolutionReasons.STATIC,
-          flagMetadata: { httpStatusCode: 400 },
-        });
-      });
-    });
-    describe(`when _getParamFromSSM returns an invalid object`, () => {
-      it(`should return a ParseError`, async () => {
-        jest
-          .spyOn(SSMService.prototype, '_getValueFromSSM')
-          .mockResolvedValue({ val: 'invalid object', metadata: { httpStatusCode: 400 } });
-        const service = new SSMService({});
-        expect(() => service.getObjectValue('test')).rejects.toThrow(ParseError);
-      });
-    });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 });

--- a/libs/providers/aws-ssm/src/lib/ssm-service.spec.ts
+++ b/libs/providers/aws-ssm/src/lib/ssm-service.spec.ts
@@ -1,8 +1,7 @@
 import { ParseError, StandardResolutionReasons, TypeMismatchError } from '@openfeature/core';
 import { SSMService } from './ssm-service';
 
-describe("ssm-service.ts - SSMService", () => {
-
+describe('ssm-service.ts - SSMService', () => {
   let service: SSMService;
   let getValueFromSSMSpy: jest.SpyInstance;
 
@@ -11,13 +10,12 @@ describe("ssm-service.ts - SSMService", () => {
     getValueFromSSMSpy = jest.spyOn(SSMService.prototype, '_getValueFromSSM');
   });
 
-  describe("getBooleanValue", () => {
-
+  describe('getBooleanValue', () => {
     it("should return true when _getValueFromSSM returns 'true'", async () => {
       getValueFromSSMSpy.mockResolvedValue({ val: 'true', metadata: { httpStatusCode: 200 } });
-      
+
       const result = await service.getBooleanValue('test');
-      
+
       expect(result).toEqual({
         value: true,
         reason: StandardResolutionReasons.STATIC,
@@ -27,9 +25,9 @@ describe("ssm-service.ts - SSMService", () => {
 
     it("should return false when _getValueFromSSM returns 'false'", async () => {
       getValueFromSSMSpy.mockResolvedValue({ val: 'false', metadata: { httpStatusCode: 200 } });
-      
+
       const result = await service.getBooleanValue('test');
-      
+
       expect(result).toEqual({
         value: false,
         reason: StandardResolutionReasons.STATIC,
@@ -37,20 +35,19 @@ describe("ssm-service.ts - SSMService", () => {
       });
     });
 
-    it("should throw TypeMismatchError when _getValueFromSSM returns invalid boolean", async () => {
+    it('should throw TypeMismatchError when _getValueFromSSM returns invalid boolean', async () => {
       getValueFromSSMSpy.mockResolvedValue({ val: 'invalid boolean', metadata: { httpStatusCode: 400 } });
-      
+
       await expect(service.getBooleanValue('test')).rejects.toThrow(TypeMismatchError);
     });
   });
 
-  describe("getStringValue", () => {
-
-    it("should return the string value when _getValueFromSSM returns valid value", async () => {
+  describe('getStringValue', () => {
+    it('should return the string value when _getValueFromSSM returns valid value', async () => {
       getValueFromSSMSpy.mockResolvedValue({ val: 'example', metadata: { httpStatusCode: 200 } });
-      
+
       const result = await service.getStringValue('example');
-      
+
       expect(result).toEqual({
         value: 'example',
         reason: StandardResolutionReasons.STATIC,
@@ -59,13 +56,12 @@ describe("ssm-service.ts - SSMService", () => {
     });
   });
 
-  describe("getNumberValue", () => {
-
-    it("should return the number value when _getValueFromSSM returns valid number", async () => {
+  describe('getNumberValue', () => {
+    it('should return the number value when _getValueFromSSM returns valid number', async () => {
       getValueFromSSMSpy.mockResolvedValue({ val: '1478', metadata: { httpStatusCode: 200 } });
-      
+
       const result = await service.getNumberValue('test');
-      
+
       expect(result).toEqual({
         value: 1478,
         reason: StandardResolutionReasons.STATIC,
@@ -73,20 +69,19 @@ describe("ssm-service.ts - SSMService", () => {
       });
     });
 
-    it("should throw TypeMismatchError when _getValueFromSSM returns invalid number", async () => {
+    it('should throw TypeMismatchError when _getValueFromSSM returns invalid number', async () => {
       getValueFromSSMSpy.mockResolvedValue({ val: 'invalid number', metadata: { httpStatusCode: 400 } });
-      
+
       await expect(service.getNumberValue('test')).rejects.toThrow(TypeMismatchError);
     });
   });
 
-  describe("getObjectValue", () => {
-
-    it("should return the parsed object when _getValueFromSSM returns valid JSON", async () => {
+  describe('getObjectValue', () => {
+    it('should return the parsed object when _getValueFromSSM returns valid JSON', async () => {
       getValueFromSSMSpy.mockResolvedValue({ val: JSON.stringify({ test: true }), metadata: { httpStatusCode: 400 } });
-      
+
       const result = await service.getObjectValue('test');
-      
+
       expect(result).toEqual({
         value: { test: true },
         reason: StandardResolutionReasons.STATIC,
@@ -94,9 +89,9 @@ describe("ssm-service.ts - SSMService", () => {
       });
     });
 
-    it("should throw ParseError when _getValueFromSSM returns invalid JSON", async () => {
+    it('should throw ParseError when _getValueFromSSM returns invalid JSON', async () => {
       getValueFromSSMSpy.mockResolvedValue({ val: 'invalid object', metadata: { httpStatusCode: 400 } });
-      
+
       await expect(service.getObjectValue('test')).rejects.toThrow(ParseError);
     });
   });


### PR DESCRIPTION

## This PR

Improves the readability and maintainability of AWS SSM provider test files by standardizing their structure.


### Related Issues

No related issues.

### Notes

- Simplified test organization by removing unnecessary nested describe blocks
- Restructured `cache.spec.ts`
- Restructured `aws-ssm-provider.spec.ts` 
- Restructured `ssm-service.spec.ts`


### How to test

All existing tests should continue to pass with the same coverage. The refactoring only improved structure and readability without changing test logic or assertions.

