### PR TITLE
fix: named export provider

### DIFF
--- a/libs/providers/flagsmith/README.md
+++ b/libs/providers/flagsmith/README.md
@@ -18,8 +18,8 @@ It can be created by passing a configured Flagsmith client instance to the `Flag
 
 ```javascript
 import { OpenFeature } from '@openfeature/server-sdk';
-import FlagsmithOpenFeatureProvider from '@openfeature/flagsmith-provider';
-import Flagsmith from 'flagsmith-nodejs';
+import { FlagsmithOpenFeatureProvider } from '@openfeature/flagsmith-provider';
+import { Flagsmith } from 'flagsmith-nodejs';
 
 // Create the Flagsmith client
 const flagsmith = new Flagsmith({

--- a/libs/providers/flagsmith/src/lib/flagsmith-provider.spec.ts
+++ b/libs/providers/flagsmith/src/lib/flagsmith-provider.spec.ts
@@ -1,4 +1,4 @@
-import FlagsmithOpenFeatureProvider from './flagsmith-provider';
+import { FlagsmithOpenFeatureProvider } from './flagsmith-provider';
 import { type Logger, StandardResolutionReasons, ErrorCode, GeneralError } from '@openfeature/server-sdk';
 import { type Flagsmith, type Flags, type BaseFlag } from 'flagsmith-nodejs';
 import { mockFlagData } from './flagsmith.mocks';

--- a/libs/providers/flagsmith/src/lib/flagsmith-provider.ts
+++ b/libs/providers/flagsmith/src/lib/flagsmith-provider.ts
@@ -19,7 +19,7 @@ type FlagsmithTrait = Record<string, FlagsmithValue | TraitConfig>;
 /**
  * Configuration options for the Flagsmith OpenFeature provider.
  */
-interface FlagsmithProviderConfig {
+export interface FlagsmithProviderConfig {
   /** Whether to return values for disabled flags instead of throwing errors */
   returnValueForDisabledFlags?: boolean;
   /** Whether to allow Flagsmith default flag values instead of treating as not found */
@@ -28,7 +28,7 @@ interface FlagsmithProviderConfig {
   useBooleanConfigValue?: boolean;
 }
 
-export default class FlagsmithOpenFeatureProvider implements Provider {
+export class FlagsmithOpenFeatureProvider implements Provider {
   readonly metadata: ProviderMetadata = {
     name: 'flagsmith-provider',
   };


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
While sanity check the provider after first release, this fixes the unresolvable export of the provider.
Besides that - locally tested - all functionalities work as expected.

- Changed `export default class` to `export class FlagsmithOpenFeatureProvider` -> index file doesn't re-export default
- Updated README examples to use named imports
- Exported `FlagsmithProviderConfig` interface

### Related Issues

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
Follow the Readme steps