### PR TITLE
feat(ofrep-web): ADR-0009 domain-aware cache key + domainScoped

### DIFF
--- a/libs/providers/ofrep-web/README.md
+++ b/libs/providers/ofrep-web/README.md
@@ -110,7 +110,9 @@ The provider supports persistent local caching via `localStorage` to reduce late
 
 **`cacheTTL`** — maximum age in seconds of a persisted cache entry before it is treated as a miss and removed. Defaults to `2_592_000` (30 days).
 
-**`cacheKeyPrefix`** — a string included in the cache key to avoid collisions when multiple provider instances share the same browser origin. A good value is the OFREP base URL or a project key.
+**`cacheKeyPrefix`** — an optional extra namespace prepended to the ADR-0009 cache key input (`baseUrl`, auth credential, bound OpenFeature `domain`, and `targetingKey`). Use it when you need additional separation across storage partitions you control directly.
+
+The provider declares itself `domain-scoped`, so each instance is bound to at most one OpenFeature domain. The bound domain is supplied by the SDK at `initialize()` and included in the cache key.
 
 ```ts
 import { OFREPWebProvider } from '@openfeature/ofrep-web-provider';

--- a/libs/providers/ofrep-web/README.md
+++ b/libs/providers/ofrep-web/README.md
@@ -114,15 +114,16 @@ The provider supports persistent local caching via `localStorage` per [ADR-0009]
 
 #### Cache key
 
-Persisted entries are keyed by a hash of the OFREP resource and evaluation identity, not the full evaluation context. The key input is a JSON-encoded array of:
+Persisted entries are keyed by a hash of key material returned by a cache-key generator, not the full evaluation context. The default generator uses:
 
-1. **`cacheKeyPrefix`** (optional) — extra namespace when you control the storage partition directly
-2. **`baseUrl`** — the configured OFREP base URL
-3. **Auth credential** — serialized from known auth headers (`Authorization`, `Api-Key`, `X-Api-Key`, `X-Auth-Token`, `X-Access-Token`), taken from `headers` and `headersFactory` at read/write time
-4. **`domain`** — the OpenFeature domain the provider is bound to via `OpenFeature.setProvider('domain', provider)` (passed to `initialize()` by the SDK; empty when registered as the default provider)
-5. **`targetingKey`** — the evaluation context's targeting key
+1. **`baseUrl`** — the configured OFREP base URL
+2. **Auth credential** — serialized from known auth headers (`Authorization`, `Api-Key`, `X-Api-Key`, `X-Auth-Token`, `X-Access-Token`), taken from `headers` and `headersFactory` at read/write time
+3. **`domain`** — the OpenFeature domain the provider is bound to via `OpenFeature.setProvider('domain', provider)` (passed to `initialize()` by the SDK; empty when registered as the default provider)
+4. **`targetingKey`** — the evaluation context's targeting key
 
-The localStorage key is `ofrep-web-provider:v2:{hash}` where `{hash}` is the first 16 hex characters of SHA-256 (or an FNV-1a fallback in non-secure contexts where `crypto.subtle` is unavailable).
+Use **`cacheKeyGenerator`** to customize the key material (namespace instances, drop auth for rotating tokens, or include stable context fields). The provider always hashes whatever the generator returns.
+
+The localStorage key is `ofrep-web-provider:v3:{hash}` where `{hash}` is the first 16 hex characters of SHA-256 (or an FNV-1a fallback in non-secure contexts where `crypto.subtle` is unavailable).
 
 #### Domain scoping
 
@@ -148,7 +149,7 @@ OpenFeature.setProvider(
     baseUrl: 'https://localhost:8080',
     cacheMode: 'local-cache-first',
     cacheTTL: 3600, // 1 hour
-    cacheKeyPrefix: 'my-app',
+    cacheKeyGenerator: (input) => `my-app:${JSON.stringify([input.url, input.auth, input.domain, input.targetingKey])}`,
     headers: [['Authorization', 'my-api-key']],
   }),
 );

--- a/libs/providers/ofrep-web/README.md
+++ b/libs/providers/ofrep-web/README.md
@@ -100,29 +100,56 @@ OpenFeature.setProvider(
 
 ### Caching
 
-The provider supports persistent local caching via `localStorage` to reduce latency on startup and improve resilience to transient network failures. Caching is controlled with three options.
+The provider supports persistent local caching via `localStorage` per [ADR-0009](https://github.com/open-feature/protocol/blob/main/service/adrs/0009-local-storage-for-static-context-providers.md). Caching reduces latency on startup and improves resilience to transient network failures.
 
-**`cacheMode`** — controls the startup strategy:
+#### Cache modes
+
+**`cacheMode`** controls the startup strategy:
 
 - `'local-cache-first'` _(default)_ — `initialize()` resolves immediately from the persisted cache if one exists, then refreshes from the network in the background. Evaluations served before the refresh completes will have reason `CACHED`.
 - `'network-first'` — `initialize()` blocks on the network request. The persisted cache is used as a fallback only on transient failures (network unavailable, timeout, 5xx). Auth and configuration errors (400, 401, 403, 404) are always surfaced immediately and never masked by cached values.
 - `'disabled'` — no persistence. `initialize()` always blocks on the network and the other cache options have no effect.
 
-**`cacheTTL`** — maximum age in seconds of a persisted cache entry before it is treated as a miss and removed. Defaults to `2_592_000` (30 days).
+**`cacheTTL`** — maximum age in seconds of a persisted cache entry before it is treated as a miss and removed. Defaults to `2_592_000` (30 days). Auth and configuration errors do not clear persisted entries; TTL governs expiry.
 
-**`cacheKeyPrefix`** — an optional extra namespace prepended to the ADR-0009 cache key input (`baseUrl`, auth credential, bound OpenFeature `domain`, and `targetingKey`). Use it when you need additional separation across storage partitions you control directly.
+#### Cache key
 
-The provider declares itself `domain-scoped`, so each instance is bound to at most one OpenFeature domain. The bound domain is supplied by the SDK at `initialize()` and included in the cache key.
+Persisted entries are keyed by a hash of the OFREP resource and evaluation identity, not the full evaluation context. The key input is a JSON-encoded array of:
+
+1. **`cacheKeyPrefix`** (optional) — extra namespace when you control the storage partition directly
+2. **`baseUrl`** — the configured OFREP base URL
+3. **Auth credential** — serialized from known auth headers (`Authorization`, `Api-Key`, `X-Api-Key`, `X-Auth-Token`, `X-Access-Token`), taken from `headers` and `headersFactory` at read/write time
+4. **`domain`** — the OpenFeature domain the provider is bound to via `OpenFeature.setProvider('domain', provider)` (passed to `initialize()` by the SDK; empty when registered as the default provider)
+5. **`targetingKey`** — the evaluation context's targeting key
+
+The localStorage key is `ofrep-web-provider:v2:{hash}` where `{hash}` is the first 16 hex characters of SHA-256 (or an FNV-1a fallback in non-secure contexts where `crypto.subtle` is unavailable).
+
+#### Domain scoping
+
+The provider declares itself `domain-scoped`, so each instance is bound to at most one OpenFeature domain via `OpenFeature.setProvider('domain', provider)`. The SDK forwards that domain to `initialize(context, domain?)`; persistence is not initialized until then, so nothing is read from or written to `localStorage` before initialization.
+
+Bind a separate provider instance per domain in micro-frontend or multi-tenant setups:
+
+```ts
+OpenFeature.setProvider('billing', new OFREPWebProvider({ baseUrl: 'https://flags.example.com' }));
+OpenFeature.setProvider('checkout', new OFREPWebProvider({ baseUrl: 'https://flags.example.com' }));
+```
+
+#### Auth headers and rotating tokens
+
+Only the auth header names listed above participate in the cache key. Other custom headers (for example `X-My-Header`) are sent on requests but do not affect persistence.
 
 ```ts
 import { OFREPWebProvider } from '@openfeature/ofrep-web-provider';
 
 OpenFeature.setProvider(
+  'my-app',
   new OFREPWebProvider({
     baseUrl: 'https://localhost:8080',
     cacheMode: 'local-cache-first',
     cacheTTL: 3600, // 1 hour
     cacheKeyPrefix: 'my-app',
+    headers: [['Authorization', 'my-api-key']],
   }),
 );
 ```

--- a/libs/providers/ofrep-web/README.md
+++ b/libs/providers/ofrep-web/README.md
@@ -123,7 +123,7 @@ Persisted entries are keyed by a hash of key material returned by a cache-key ge
 
 Use **`cacheKeyGenerator`** to customize the key material (namespace instances, drop auth for rotating tokens, or include stable context fields). The provider always hashes whatever the generator returns.
 
-The localStorage key is `ofrep-web-provider:v3:{hash}` where `{hash}` is the first 16 hex characters of SHA-256 (or an FNV-1a fallback in non-secure contexts where `crypto.subtle` is unavailable).
+The localStorage key is `ofrep-web-provider:v2:{hash}` where `{hash}` is the first 16 hex characters of SHA-256 (or an FNV-1a fallback in non-secure contexts where `crypto.subtle` is unavailable).
 
 #### Domain scoping
 

--- a/libs/providers/ofrep-web/README.md
+++ b/libs/providers/ofrep-web/README.md
@@ -40,9 +40,7 @@ OpenFeature.setProvider(new OFREPWebProvider({ baseUrl: 'https://localhost:8080'
 Flags are automatically re-fetched when the page becomes visible (e.g. the user switches back to the tab). This follows [ADR-0010](https://github.com/open-feature/protocol/pull/69) and is **enabled by default**. To opt out:
 
 ```ts
-OpenFeature.setProvider(
-  new OFREPWebProvider({ baseUrl: 'https://localhost:8080', disableVisibilityRefresh: true }),
-);
+OpenFeature.setProvider(new OFREPWebProvider({ baseUrl: 'https://localhost:8080', disableVisibilityRefresh: true }));
 ```
 
 ### HTTP headers
@@ -122,6 +120,8 @@ Persisted entries are keyed by a hash of key material returned by a cache-key ge
 4. **`targetingKey`** — the evaluation context's targeting key
 
 Use **`cacheKeyGenerator`** to customize the key material (namespace instances, drop auth for rotating tokens, or include stable context fields). The provider always hashes whatever the generator returns.
+
+Only omit `input.auth` when authentication cannot affect flag results for the same `baseUrl`, `domain`, and `targetingKey`. Otherwise retain `input.auth` or include another stable identity discriminator so different credentials do not share persisted values.
 
 The localStorage key is `ofrep-web-provider:v2:{hash}` where `{hash}` is the first 16 hex characters of SHA-256 (or an FNV-1a fallback in non-secure contexts where `crypto.subtle` is unavailable).
 

--- a/libs/providers/ofrep-web/package.json
+++ b/libs/providers/ofrep-web/package.json
@@ -14,7 +14,7 @@
     "current-version": "echo $npm_package_version"
   },
   "peerDependencies": {
-    "@openfeature/web-sdk": "^1.4.0"
+    "@openfeature/web-sdk": "^1.10.0"
   },
   "dependencies": {
     "@openfeature/ofrep-core": "^2.3.0"

--- a/libs/providers/ofrep-web/src/lib/model/ofrep-web-provider-options.ts
+++ b/libs/providers/ofrep-web/src/lib/model/ofrep-web-provider-options.ts
@@ -1,5 +1,6 @@
 import type { OFREPProviderBaseOptions } from '@openfeature/ofrep-core';
 import type { SseEventParser } from '../sse-manager';
+import type { CacheKeyGenerator } from '../store/cache-key';
 
 export type CacheMode = 'local-cache-first' | 'network-first' | 'disabled';
 
@@ -75,11 +76,9 @@ export type OFREPWebProviderOptions = OFREPProviderBaseOptions & {
   cacheTTL?: number;
 
   /**
-   * cacheKeyPrefix is prepended to the ADR-0009 cache key input
-   * (`baseUrl`, auth credential, bound `domain`, and `targetingKey`) for additional namespacing
-   * across storage partitions an application controls directly.
-   *
-   * A sensible value is a project key or any other string that uniquely identifies this provider instance.
+   * cacheKeyGenerator returns the key material the provider hashes into `cacheKeyHash`.
+   * The default generator uses the OFREP base URL, auth credential, bound `domain`, and `targetingKey`.
+   * Customize to namespace instances, drop auth for rotating tokens, or include stable context fields.
    */
-  cacheKeyPrefix?: string;
+  cacheKeyGenerator?: CacheKeyGenerator;
 };

--- a/libs/providers/ofrep-web/src/lib/model/ofrep-web-provider-options.ts
+++ b/libs/providers/ofrep-web/src/lib/model/ofrep-web-provider-options.ts
@@ -75,12 +75,11 @@ export type OFREPWebProviderOptions = OFREPProviderBaseOptions & {
   cacheTTL?: number;
 
   /**
-   * cacheKeyPrefix is included in the cache key hash to prevent collisions when multiple
-   * OFREP provider instances share the same storage partition (e.g. the same browser origin).
-   * When set, the cache key becomes `hash(cacheKeyPrefix + ":" + targetingKey)`.
+   * cacheKeyPrefix is prepended to the ADR-0009 cache key input
+   * (`baseUrl`, auth credential, bound `domain`, and `targetingKey`) for additional namespacing
+   * across storage partitions an application controls directly.
    *
-   * A sensible value is the OFREP base URL, a project key, or any other string that
-   * uniquely identifies this provider instance.
+   * A sensible value is a project key or any other string that uniquely identifies this provider instance.
    */
   cacheKeyPrefix?: string;
 };

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
@@ -462,7 +462,7 @@ describe('OFREPWebProvider', () => {
       localStorage.setItem(
         key,
         JSON.stringify({
-          version: 3,
+          version: 2,
           cacheKeyHash: key.split(':')[2],
           etag: null,
           writtenAt: new Date().toISOString(),
@@ -503,7 +503,7 @@ describe('OFREPWebProvider', () => {
       localStorage.setItem(
         key,
         JSON.stringify({
-          version: 3,
+          version: 2,
           cacheKeyHash: key.split(':')[2],
           etag: '"cached-etag"',
           writtenAt: new Date().toISOString(),
@@ -881,7 +881,7 @@ describe('OFREPWebProvider', () => {
       const storage = createTestStorage(domain);
       const key = await storage.getStorageKey({ targetingKey });
       const entry: PersistedEntry = {
-        version: 3,
+        version: 2,
         cacheKeyHash: key.split(':')[2],
         etag,
         writtenAt: writtenAt.toISOString(),

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
@@ -38,9 +38,16 @@ describe('OFREPWebProvider', () => {
     lastname: 'Doe',
   };
 
-  function createTestStorage(domain = ''): Storage {
-    return new Storage('local-cache-first', endpointBaseURL, () =>
-      deriveAuthCredential({ baseUrl: endpointBaseURL }),
+  /** Matches the domain passed to `setProvider(name, provider)` in each test. */
+  function testDomain(): string {
+    return expect.getState().currentTestName || 'test-provider';
+  }
+
+  function createTestStorage(domain = testDomain()): Storage {
+    return new Storage(
+      'local-cache-first',
+      endpointBaseURL,
+      () => deriveAuthCredential({ baseUrl: endpointBaseURL }),
       domain,
     );
   }
@@ -876,7 +883,7 @@ describe('OFREPWebProvider', () => {
       etag: string | null = null,
       writtenAt: Date = new Date(),
       metadata?: Record<string, unknown>,
-      domain = '',
+      domain = testDomain(),
     ): Promise<void> {
       const storage = createTestStorage(domain);
       const key = await storage.getStorageKey({ targetingKey });

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
@@ -463,7 +463,7 @@ describe('OFREPWebProvider', () => {
         key,
         JSON.stringify({
           version: 2,
-          cacheKeyHash: key,
+          cacheKeyHash: key.split(':')[2],
           etag: null,
           writtenAt: new Date().toISOString(),
           data: {},
@@ -504,7 +504,7 @@ describe('OFREPWebProvider', () => {
         key,
         JSON.stringify({
           version: 2,
-          cacheKeyHash: key,
+          cacheKeyHash: key.split(':')[2],
           etag: '"cached-etag"',
           writtenAt: new Date().toISOString(),
           data: {},

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
@@ -39,16 +39,32 @@ describe('OFREPWebProvider', () => {
   };
 
   function createTestStorage(domain = ''): Storage {
-    const storage = new Storage('local-cache-first', endpointBaseURL, () =>
+    return new Storage('local-cache-first', endpointBaseURL, () =>
       deriveAuthCredential({ baseUrl: endpointBaseURL }),
+      domain,
     );
-    storage.setDomain(domain);
-    return storage;
   }
 
   it('declares itself domain-scoped', () => {
     const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL });
     expect(provider.domainScoped).toBe(true);
+  });
+
+  it('does not read or write persisted storage before initialize', async () => {
+    const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL, pollInterval: -1 }, new TestLogger());
+    const storeSpy = jest.spyOn(Storage.prototype, 'store');
+    const retrieveSpy = jest.spyOn(Storage.prototype, 'retrieve');
+
+    await provider.onContextChange?.(defaultContext, {
+      ...defaultContext,
+      targetingKey: 'other-user',
+    });
+
+    expect(storeSpy).not.toHaveBeenCalled();
+    expect(retrieveSpy).not.toHaveBeenCalled();
+
+    storeSpy.mockRestore();
+    retrieveSpy.mockRestore();
   });
 
   it('uses the bound domain from initialize for persisted cache lookup', async () => {

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
@@ -77,7 +77,7 @@ describe('OFREPWebProvider', () => {
       },
     };
     const storage = createTestStorage('billing');
-    await storage.store(defaultContext.targetingKey, boolFlagCache, null);
+    await storage.store(defaultContext, boolFlagCache, null);
 
     const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL, pollInterval: -1 }, new TestLogger());
     await provider.initialize(defaultContext, 'billing');
@@ -458,11 +458,11 @@ describe('OFREPWebProvider', () => {
     it('connects SSE after the background refresh following a local-cache-first cache hit', async () => {
       // Seed the cache so initialize() hits the cache-first path.
       const storage = createTestStorage();
-      const key = await storage.getStorageKey(defaultContext.targetingKey);
+      const key = await storage.getStorageKey(defaultContext);
       localStorage.setItem(
         key,
         JSON.stringify({
-          version: 2,
+          version: 3,
           cacheKeyHash: key.split(':')[2],
           etag: null,
           writtenAt: new Date().toISOString(),
@@ -499,11 +499,11 @@ describe('OFREPWebProvider', () => {
       // and the server responds 304 (no body, no eventStreams), so SSE must be established
       // from the persisted configuration rather than from a 200 response.
       const storage = createTestStorage();
-      const key = await storage.getStorageKey(defaultContext.targetingKey);
+      const key = await storage.getStorageKey(defaultContext);
       localStorage.setItem(
         key,
         JSON.stringify({
-          version: 2,
+          version: 3,
           cacheKeyHash: key.split(':')[2],
           etag: '"cached-etag"',
           writtenAt: new Date().toISOString(),
@@ -879,9 +879,9 @@ describe('OFREPWebProvider', () => {
       domain = '',
     ): Promise<void> {
       const storage = createTestStorage(domain);
-      const key = await storage.getStorageKey(targetingKey);
+      const key = await storage.getStorageKey({ targetingKey });
       const entry: PersistedEntry = {
-        version: 2,
+        version: 3,
         cacheKeyHash: key.split(':')[2],
         etag,
         writtenAt: writtenAt.toISOString(),
@@ -940,7 +940,7 @@ describe('OFREPWebProvider', () => {
     it('does not read or write localStorage when cacheMode is disabled', async () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
       const storage = createTestStorage();
-      const seededKey = await storage.getStorageKey(defaultContext.targetingKey);
+      const seededKey = await storage.getStorageKey(defaultContext);
       await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
       expect(localStorage.getItem(seededKey)).not.toBeNull();
       const provider = new OFREPWebProvider(
@@ -998,7 +998,7 @@ describe('OFREPWebProvider', () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
       await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
       const storage = createTestStorage();
-      const lsKey = await storage.getStorageKey(defaultContext.targetingKey);
+      const lsKey = await storage.getStorageKey(defaultContext);
       expect(localStorage.getItem(lsKey)).not.toBeNull();
 
       server.use(
@@ -1019,7 +1019,7 @@ describe('OFREPWebProvider', () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
       await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
       const storage = createTestStorage();
-      const lsKey = await storage.getStorageKey(defaultContext.targetingKey);
+      const lsKey = await storage.getStorageKey(defaultContext);
 
       server.use(
         http.post('https://localhost:8080/ofrep/v1/evaluate/flags', () =>
@@ -1042,7 +1042,7 @@ describe('OFREPWebProvider', () => {
       await seedPersistentCache(defaultContext.targetingKey, boolFlagCache, null, expiredDate);
 
       const storage = createTestStorage();
-      const lsKey = await storage.getStorageKey(defaultContext.targetingKey);
+      const lsKey = await storage.getStorageKey(defaultContext);
       expect(localStorage.getItem(lsKey)).not.toBeNull(); // Exists before init.
 
       const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL, pollInterval: -1 }, new TestLogger());
@@ -1096,7 +1096,7 @@ describe('OFREPWebProvider', () => {
       await OpenFeature.setProviderAndWait(providerName, provider);
 
       const storage = createTestStorage();
-      const user1Key = await storage.getStorageKey(user1);
+      const user1Key = await storage.getStorageKey({ targetingKey: user1 });
       // After init, user1's entry should have been written by the network fetch.
       expect(localStorage.getItem(user1Key)).not.toBeNull();
 

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
@@ -6,6 +6,7 @@ import type { FlagCache } from './model/in-memory-cache';
 import type { OFREPWebProviderOptions } from './model/ofrep-web-provider-options';
 import type { PersistedEntry } from './store/storage';
 import { Storage } from './store/storage';
+import { deriveAuthCredential } from './store/cache-key';
 import {
   ClientProviderEvents,
   ClientProviderStatus,
@@ -36,6 +37,42 @@ describe('OFREPWebProvider', () => {
     firstname: 'John',
     lastname: 'Doe',
   };
+
+  function createTestStorage(domain = ''): Storage {
+    const storage = new Storage('local-cache-first', endpointBaseURL, () =>
+      deriveAuthCredential({ baseUrl: endpointBaseURL }),
+    );
+    storage.setDomain(domain);
+    return storage;
+  }
+
+  it('declares itself domain-scoped', () => {
+    const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL });
+    expect(provider.domainScoped).toBe(true);
+  });
+
+  it('uses the bound domain from initialize for persisted cache lookup', async () => {
+    const boolFlagCache: FlagCache = {
+      'bool-flag': {
+        key: 'bool-flag',
+        value: true,
+        metadata: TEST_FLAG_METADATA,
+        reason: StandardResolutionReasons.STATIC,
+      },
+    };
+    const storage = createTestStorage('billing');
+    await storage.store(defaultContext.targetingKey, boolFlagCache, null);
+
+    const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL, pollInterval: -1 }, new TestLogger());
+    await provider.initialize(defaultContext, 'billing');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((provider as any)._isUsingCache).toBe(true);
+
+    const otherDomainProvider = new OFREPWebProvider({ baseUrl: endpointBaseURL, pollInterval: -1 }, new TestLogger());
+    await otherDomainProvider.initialize(defaultContext, 'checkout');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((otherDomainProvider as any)._isUsingCache).toBe(false);
+  });
 
   it('should call the READY handler, when the provider is ready', async () => {
     const providerName = expect.getState().currentTestName || 'test-provider';
@@ -404,12 +441,12 @@ describe('OFREPWebProvider', () => {
 
     it('connects SSE after the background refresh following a local-cache-first cache hit', async () => {
       // Seed the cache so initialize() hits the cache-first path.
-      const storage = new Storage('local-cache-first');
+      const storage = createTestStorage();
       const key = await storage.getStorageKey(defaultContext.targetingKey);
       localStorage.setItem(
         key,
         JSON.stringify({
-          version: 1,
+          version: 2,
           cacheKeyHash: key,
           etag: null,
           writtenAt: new Date().toISOString(),
@@ -445,12 +482,12 @@ describe('OFREPWebProvider', () => {
       // start where the flags are unchanged: the background refresh sends If-None-Match
       // and the server responds 304 (no body, no eventStreams), so SSE must be established
       // from the persisted configuration rather than from a 200 response.
-      const storage = new Storage('local-cache-first');
+      const storage = createTestStorage();
       const key = await storage.getStorageKey(defaultContext.targetingKey);
       localStorage.setItem(
         key,
         JSON.stringify({
-          version: 1,
+          version: 2,
           cacheKeyHash: key,
           etag: '"cached-etag"',
           writtenAt: new Date().toISOString(),
@@ -823,12 +860,13 @@ describe('OFREPWebProvider', () => {
       etag: string | null = null,
       writtenAt: Date = new Date(),
       metadata?: Record<string, unknown>,
+      domain = '',
     ): Promise<void> {
-      const storage = new Storage('local-cache-first');
+      const storage = createTestStorage(domain);
       const key = await storage.getStorageKey(targetingKey);
       const entry: PersistedEntry = {
-        version: 1,
-        cacheKeyHash: key,
+        version: 2,
+        cacheKeyHash: key.split(':')[2],
         etag,
         writtenAt: writtenAt.toISOString(),
         data: cache,
@@ -885,7 +923,7 @@ describe('OFREPWebProvider', () => {
 
     it('does not read or write localStorage when cacheMode is disabled', async () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
-      const storage = new Storage('local-cache-first');
+      const storage = createTestStorage();
       const seededKey = await storage.getStorageKey(defaultContext.targetingKey);
       await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
       expect(localStorage.getItem(seededKey)).not.toBeNull();
@@ -943,7 +981,7 @@ describe('OFREPWebProvider', () => {
     it('keeps the persisted cache when a background fetch returns 401 (ADR 0009: TTL governs expiry, not auth errors)', async () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
       await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
-      const storage = new Storage('local-cache-first');
+      const storage = createTestStorage();
       const lsKey = await storage.getStorageKey(defaultContext.targetingKey);
       expect(localStorage.getItem(lsKey)).not.toBeNull();
 
@@ -964,7 +1002,7 @@ describe('OFREPWebProvider', () => {
     it('keeps the persisted cache when a background fetch returns 400 (ADR 0009: TTL governs expiry, not config errors)', async () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
       await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
-      const storage = new Storage('local-cache-first');
+      const storage = createTestStorage();
       const lsKey = await storage.getStorageKey(defaultContext.targetingKey);
 
       server.use(
@@ -987,7 +1025,7 @@ describe('OFREPWebProvider', () => {
       const expiredDate = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
       await seedPersistentCache(defaultContext.targetingKey, boolFlagCache, null, expiredDate);
 
-      const storage = new Storage('local-cache-first');
+      const storage = createTestStorage();
       const lsKey = await storage.getStorageKey(defaultContext.targetingKey);
       expect(localStorage.getItem(lsKey)).not.toBeNull(); // Exists before init.
 
@@ -1041,7 +1079,7 @@ describe('OFREPWebProvider', () => {
       await OpenFeature.setContext({ ...defaultContext, targetingKey: user1 });
       await OpenFeature.setProviderAndWait(providerName, provider);
 
-      const storage = new Storage('local-cache-first');
+      const storage = createTestStorage();
       const user1Key = await storage.getStorageKey(user1);
       // After init, user1's entry should have been written by the network fetch.
       expect(localStorage.getItem(user1Key)).not.toBeNull();

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
@@ -42,6 +42,7 @@ import { BulkEvaluationStatus } from './model/evaluate-flags-response';
 import type { FlagCache, MetadataCache } from './model/in-memory-cache';
 import type { CacheMode, OFREPWebProviderOptions } from './model/ofrep-web-provider-options';
 import { DEFAULT_CACHE_TTL_SECONDS } from './model/ofrep-web-provider-options';
+import { deriveAuthCredential } from './store/cache-key';
 import { Storage } from './store/storage';
 import { SseManager } from './sse-manager';
 
@@ -52,6 +53,7 @@ export class OFREPWebProvider implements Provider {
     name: 'OpenFeature Remote Evaluation Protocol Web Provider',
   };
   readonly runsOn = 'client';
+  readonly domainScoped = true;
   readonly events = new OpenFeatureEventEmitter();
   readonly hooks?: Hook[] | undefined;
 
@@ -85,7 +87,13 @@ export class OFREPWebProvider implements Provider {
     this._pollingInterval = this._options.pollInterval ?? this.DEFAULT_POLL_INTERVAL;
     this._cacheMode = this._options.cacheMode ?? 'local-cache-first';
     this._cacheTTL = this._options.cacheTTL ?? DEFAULT_CACHE_TTL_SECONDS;
-    this._storage = new Storage(this._cacheMode, this._options.cacheKeyPrefix, logger);
+    this._storage = new Storage(
+      this._cacheMode,
+      this._options.baseUrl,
+      () => deriveAuthCredential(this._options),
+      this._options.cacheKeyPrefix,
+      logger,
+    );
     this._isUsingCache = false;
   }
 
@@ -99,9 +107,11 @@ export class OFREPWebProvider implements Provider {
   /**
    * Initialize the provider, it will evaluate the flags and start the polling if it is not disabled.
    * @param context - the context to use for the evaluation
+   * @param domain - the bound OpenFeature domain, if any
    */
-  async initialize(context?: EvaluationContext | undefined): Promise<void> {
+  async initialize(context?: EvaluationContext | undefined, domain?: string): Promise<void> {
     try {
+      this._storage.setDomain(domain);
       this._context = context;
 
       let result: EvaluateFlagsResponse | undefined;

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
@@ -68,7 +68,7 @@ export class OFREPWebProvider implements Provider {
   private _isUsingCache: boolean;
   private _context: EvaluationContext | undefined;
   private _pollingIntervalId?: number;
-  private _storage: Storage;
+  private _storage?: Storage;
   private _cacheMode: CacheMode;
   private _cacheTTL: number;
   private _contextRevision = 0;
@@ -87,13 +87,6 @@ export class OFREPWebProvider implements Provider {
     this._pollingInterval = this._options.pollInterval ?? this.DEFAULT_POLL_INTERVAL;
     this._cacheMode = this._options.cacheMode ?? 'local-cache-first';
     this._cacheTTL = this._options.cacheTTL ?? DEFAULT_CACHE_TTL_SECONDS;
-    this._storage = new Storage(
-      this._cacheMode,
-      this._options.baseUrl,
-      () => deriveAuthCredential(this._options),
-      this._options.cacheKeyPrefix,
-      logger,
-    );
     this._isUsingCache = false;
   }
 
@@ -111,7 +104,14 @@ export class OFREPWebProvider implements Provider {
    */
   async initialize(context?: EvaluationContext | undefined, domain?: string): Promise<void> {
     try {
-      this._storage.setDomain(domain);
+      this._storage = new Storage(
+        this._cacheMode,
+        this._options.baseUrl,
+        () => deriveAuthCredential(this._options),
+        domain ?? '',
+        this._options.cacheKeyPrefix,
+        this._logger,
+      );
       this._context = context;
 
       let result: EvaluateFlagsResponse | undefined;
@@ -188,7 +188,7 @@ export class OFREPWebProvider implements Provider {
     try {
       if (oldContext?.targetingKey !== newContext?.targetingKey) {
         this._etag = null;
-        void this._storage.clear(oldContext?.targetingKey ?? '');
+        void this._storage?.clear(oldContext?.targetingKey ?? '');
       }
       this._context = newContext;
 
@@ -246,6 +246,7 @@ export class OFREPWebProvider implements Provider {
     }
     this._sseManager?.dispose();
     this._sseManager = undefined;
+    this._storage = undefined;
     this._ofrepAPI.close();
     return Promise.resolve();
   }
@@ -272,7 +273,7 @@ export class OFREPWebProvider implements Provider {
         throw error;
       }
       // Transient / server errors (5xx, network failures, timeouts) — try the persisted cache as a fallback.
-      const cached = await this._storage.retrieve(context?.targetingKey ?? '', this._cacheTTL);
+      const cached = await this._storage?.retrieve(context?.targetingKey ?? '', this._cacheTTL);
       if (!cached) {
         throw error; // No usable cache — propagate the original error.
       }
@@ -351,7 +352,7 @@ export class OFREPWebProvider implements Provider {
       this._flagSetMetadataCache = toFlagMetadata(
         typeof bulkSuccessResp.metadata === 'object' ? bulkSuccessResp.metadata : {},
       );
-      await this._storage.store(
+      await this._storage?.store(
         context?.targetingKey ?? '',
         newCache,
         newEtag,
@@ -631,7 +632,7 @@ export class OFREPWebProvider implements Provider {
   }
 
   private async _tryLoadFlagsFromCache(context?: EvaluationContext | undefined): Promise<boolean> {
-    const cached = await this._storage.retrieve(context?.targetingKey ?? '', this._cacheTTL);
+    const cached = await this._storage?.retrieve(context?.targetingKey ?? '', this._cacheTTL);
     if (cached) {
       this._isUsingCache = true;
       this._flagCache = cached.flags;

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
@@ -42,7 +42,7 @@ import { BulkEvaluationStatus } from './model/evaluate-flags-response';
 import type { FlagCache, MetadataCache } from './model/in-memory-cache';
 import type { CacheMode, OFREPWebProviderOptions } from './model/ofrep-web-provider-options';
 import { DEFAULT_CACHE_TTL_SECONDS } from './model/ofrep-web-provider-options';
-import { deriveAuthCredential } from './store/cache-key';
+import { defaultCacheKeyGenerator, deriveAuthCredential } from './store/cache-key';
 import { Storage } from './store/storage';
 import { SseManager } from './sse-manager';
 
@@ -109,7 +109,7 @@ export class OFREPWebProvider implements Provider {
         this._options.baseUrl,
         () => deriveAuthCredential(this._options),
         domain ?? '',
-        this._options.cacheKeyPrefix,
+        this._options.cacheKeyGenerator ?? defaultCacheKeyGenerator,
         this._logger,
       );
       this._context = context;
@@ -188,7 +188,7 @@ export class OFREPWebProvider implements Provider {
     try {
       if (oldContext?.targetingKey !== newContext?.targetingKey) {
         this._etag = null;
-        void this._storage?.clear(oldContext?.targetingKey ?? '');
+        void this._storage?.clear(oldContext);
       }
       this._context = newContext;
 
@@ -273,7 +273,7 @@ export class OFREPWebProvider implements Provider {
         throw error;
       }
       // Transient / server errors (5xx, network failures, timeouts) — try the persisted cache as a fallback.
-      const cached = await this._storage?.retrieve(context?.targetingKey ?? '', this._cacheTTL);
+      const cached = await this._storage?.retrieve(context ?? {}, this._cacheTTL);
       if (!cached) {
         throw error; // No usable cache — propagate the original error.
       }
@@ -352,13 +352,7 @@ export class OFREPWebProvider implements Provider {
       this._flagSetMetadataCache = toFlagMetadata(
         typeof bulkSuccessResp.metadata === 'object' ? bulkSuccessResp.metadata : {},
       );
-      await this._storage?.store(
-        context?.targetingKey ?? '',
-        newCache,
-        newEtag,
-        this._flagSetMetadataCache,
-        this._eventStreams,
-      );
+      await this._storage?.store(context ?? {}, newCache, newEtag, this._flagSetMetadataCache, this._eventStreams);
       this._etag = newEtag;
       this._isUsingCache = false;
       return {
@@ -632,7 +626,7 @@ export class OFREPWebProvider implements Provider {
   }
 
   private async _tryLoadFlagsFromCache(context?: EvaluationContext | undefined): Promise<boolean> {
-    const cached = await this._storage?.retrieve(context?.targetingKey ?? '', this._cacheTTL);
+    const cached = await this._storage?.retrieve(context ?? {}, this._cacheTTL);
     if (cached) {
       this._isUsingCache = true;
       this._flagCache = cached.flags;

--- a/libs/providers/ofrep-web/src/lib/store/cache-key.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/store/cache-key.spec.ts
@@ -34,22 +34,39 @@ describe('cache key encoding', () => {
     expect(withPrefix).not.toBe(withoutPrefix);
   });
 
-  it('derives auth from static headers excluding content-type', async () => {
+  it('serializes Authorization from static headers', async () => {
     const auth = await deriveAuthCredential({
       baseUrl: 'https://example.com',
       headers: [
         ['Content-Type', 'application/json'],
         ['Authorization', 'Bearer token'],
+        ['X-My-Header', 'ignored'],
       ],
     });
     expect(auth).toBe(JSON.stringify([['Authorization', 'Bearer token']]));
   });
 
-  it('derives auth from headersFactory', async () => {
+  it('serializes known auth headers from headersFactory', async () => {
     const auth = await deriveAuthCredential({
       baseUrl: 'https://example.com',
       headersFactory: () => Promise.resolve([['X-Api-Key', 'secret']]),
     });
     expect(auth).toBe(JSON.stringify([['X-Api-Key', 'secret']]));
+  });
+
+  it('returns an empty array when no auth headers are configured', async () => {
+    const auth = await deriveAuthCredential({
+      baseUrl: 'https://example.com',
+      headers: [['X-Custom', 'value']],
+    });
+    expect(auth).toBe('[]');
+  });
+
+  it('matches auth header names case-insensitively', async () => {
+    const auth = await deriveAuthCredential({
+      baseUrl: 'https://example.com',
+      headers: [['x-api-key', 'secret']],
+    });
+    expect(auth).toBe(JSON.stringify([['x-api-key', 'secret']]));
   });
 });

--- a/libs/providers/ofrep-web/src/lib/store/cache-key.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/store/cache-key.spec.ts
@@ -1,0 +1,55 @@
+import { deriveAuthCredential, encodeCacheKeyInput } from './cache-key';
+
+describe('cache key encoding', () => {
+  it('uses JSON encoding so delimiter-like values do not collide', () => {
+    const keyA = encodeCacheKeyInput({
+      baseUrl: 'https://a:b',
+      auth: 'c',
+      domain: 'd',
+      targetingKey: 'e',
+    });
+    const keyB = encodeCacheKeyInput({
+      baseUrl: 'https://a',
+      auth: 'b:c',
+      domain: 'd:e',
+      targetingKey: '',
+    });
+    expect(keyA).not.toBe(keyB);
+  });
+
+  it('includes cacheKeyPrefix as the first component when set', () => {
+    const withPrefix = encodeCacheKeyInput({
+      cacheKeyPrefix: 'my-app',
+      baseUrl: 'https://example.com',
+      auth: '[]',
+      domain: 'billing',
+      targetingKey: 'user-1',
+    });
+    const withoutPrefix = encodeCacheKeyInput({
+      baseUrl: 'https://example.com',
+      auth: '[]',
+      domain: 'billing',
+      targetingKey: 'user-1',
+    });
+    expect(withPrefix).not.toBe(withoutPrefix);
+  });
+
+  it('derives auth from static headers excluding content-type', async () => {
+    const auth = await deriveAuthCredential({
+      baseUrl: 'https://example.com',
+      headers: [
+        ['Content-Type', 'application/json'],
+        ['Authorization', 'Bearer token'],
+      ],
+    });
+    expect(auth).toBe(JSON.stringify([['Authorization', 'Bearer token']]));
+  });
+
+  it('derives auth from headersFactory', async () => {
+    const auth = await deriveAuthCredential({
+      baseUrl: 'https://example.com',
+      headersFactory: () => Promise.resolve([['X-Api-Key', 'secret']]),
+    });
+    expect(auth).toBe(JSON.stringify([['X-Api-Key', 'secret']]));
+  });
+});

--- a/libs/providers/ofrep-web/src/lib/store/cache-key.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/store/cache-key.spec.ts
@@ -1,37 +1,34 @@
-import { deriveAuthCredential, encodeCacheKeyInput } from './cache-key';
+import { defaultCacheKeyGenerator, deriveAuthCredential } from './cache-key';
 
 describe('cache key encoding', () => {
   it('uses JSON encoding so delimiter-like values do not collide', () => {
-    const keyA = encodeCacheKeyInput({
-      baseUrl: 'https://a:b',
+    const keyA = defaultCacheKeyGenerator({
+      url: 'https://a:b',
       auth: 'c',
       domain: 'd',
       targetingKey: 'e',
+      context: { targetingKey: 'e' },
     });
-    const keyB = encodeCacheKeyInput({
-      baseUrl: 'https://a',
+    const keyB = defaultCacheKeyGenerator({
+      url: 'https://a',
       auth: 'b:c',
       domain: 'd:e',
       targetingKey: '',
+      context: {},
     });
     expect(keyA).not.toBe(keyB);
   });
 
-  it('includes cacheKeyPrefix as the first component when set', () => {
-    const withPrefix = encodeCacheKeyInput({
-      cacheKeyPrefix: 'my-app',
-      baseUrl: 'https://example.com',
+  it('allows custom generators to namespace key material', () => {
+    const input = {
+      url: 'https://example.com',
       auth: '[]',
       domain: 'billing',
       targetingKey: 'user-1',
-    });
-    const withoutPrefix = encodeCacheKeyInput({
-      baseUrl: 'https://example.com',
-      auth: '[]',
-      domain: 'billing',
-      targetingKey: 'user-1',
-    });
-    expect(withPrefix).not.toBe(withoutPrefix);
+      context: { targetingKey: 'user-1' },
+    };
+    const namespaced = (prefix: string) => `${prefix}:${defaultCacheKeyGenerator(input)}`;
+    expect(namespaced('provider-a')).not.toBe(namespaced('provider-b'));
   });
 
   it('serializes Authorization from static headers', async () => {

--- a/libs/providers/ofrep-web/src/lib/store/cache-key.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/store/cache-key.spec.ts
@@ -43,7 +43,7 @@ describe('cache key encoding', () => {
         ['X-My-Header', 'ignored'],
       ],
     });
-    expect(auth).toBe(JSON.stringify([['Authorization', 'Bearer token']]));
+    expect(auth).toBe(JSON.stringify([['authorization', 'Bearer token']]));
   });
 
   it('serializes known auth headers from headersFactory', async () => {
@@ -51,7 +51,7 @@ describe('cache key encoding', () => {
       baseUrl: 'https://example.com',
       headersFactory: () => Promise.resolve([['X-Api-Key', 'secret']]),
     });
-    expect(auth).toBe(JSON.stringify([['X-Api-Key', 'secret']]));
+    expect(auth).toBe(JSON.stringify([['x-api-key', 'secret']]));
   });
 
   it('returns an empty array when no auth headers are configured', async () => {

--- a/libs/providers/ofrep-web/src/lib/store/cache-key.ts
+++ b/libs/providers/ofrep-web/src/lib/store/cache-key.ts
@@ -1,5 +1,14 @@
 import type { OFREPProviderBaseOptions } from '@openfeature/ofrep-core';
 
+/** Header names treated as auth credentials for cache key derivation (matched case-insensitively). */
+const AUTH_HEADER_NAMES = new Set([
+  'authorization',
+  'api-key',
+  'x-api-key',
+  'x-auth-token',
+  'x-access-token',
+]);
+
 export type CacheKeyParts = {
   cacheKeyPrefix?: string;
   baseUrl: string;
@@ -8,16 +17,18 @@ export type CacheKeyParts = {
   targetingKey: string;
 };
 
+function isAuthHeader(name: string): boolean {
+  return AUTH_HEADER_NAMES.has(name.toLowerCase());
+}
+
 /**
- * Derives a stable auth credential string from static and factory-supplied headers.
+ * Serializes known auth headers from static and factory-supplied options for cache keying.
  * Rotating tokens will change the cache key on each rotation; stable credentials separate caches as intended.
  */
 export async function deriveAuthCredential(options: OFREPProviderBaseOptions): Promise<string> {
   const entries = [...(options.headers ?? []), ...((await options.headersFactory?.()) ?? [])];
-  const credentialHeaders = entries
-    .filter(([name]) => name.toLowerCase() !== 'content-type')
-    .sort(([a], [b]) => a.localeCompare(b));
-  return JSON.stringify(credentialHeaders);
+  const authHeaders = entries.filter(([name]) => isAuthHeader(name)).sort(([a], [b]) => a.localeCompare(b));
+  return JSON.stringify(authHeaders);
 }
 
 /**

--- a/libs/providers/ofrep-web/src/lib/store/cache-key.ts
+++ b/libs/providers/ofrep-web/src/lib/store/cache-key.ts
@@ -1,0 +1,35 @@
+import type { OFREPProviderBaseOptions } from '@openfeature/ofrep-core';
+
+export type CacheKeyParts = {
+  cacheKeyPrefix?: string;
+  baseUrl: string;
+  auth: string;
+  domain: string;
+  targetingKey: string;
+};
+
+/**
+ * Derives a stable auth credential string from static and factory-supplied headers.
+ * Rotating tokens will change the cache key on each rotation; stable credentials separate caches as intended.
+ */
+export async function deriveAuthCredential(options: OFREPProviderBaseOptions): Promise<string> {
+  const entries = [...(options.headers ?? []), ...((await options.headersFactory?.()) ?? [])];
+  const credentialHeaders = entries
+    .filter(([name]) => name.toLowerCase() !== 'content-type')
+    .sort(([a], [b]) => a.localeCompare(b));
+  return JSON.stringify(credentialHeaders);
+}
+
+/**
+ * Encodes cache key components without ambiguous delimiter collisions.
+ * Order matches ADR-0009: optional prefix, base URL, auth, domain, targeting key.
+ */
+export function encodeCacheKeyInput(parts: CacheKeyParts): string {
+  return JSON.stringify([
+    parts.cacheKeyPrefix ?? '',
+    parts.baseUrl,
+    parts.auth,
+    parts.domain,
+    parts.targetingKey,
+  ]);
+}

--- a/libs/providers/ofrep-web/src/lib/store/cache-key.ts
+++ b/libs/providers/ofrep-web/src/lib/store/cache-key.ts
@@ -27,7 +27,10 @@ function isAuthHeader(name: string): boolean {
  */
 export async function deriveAuthCredential(options: OFREPProviderBaseOptions): Promise<string> {
   const entries = [...(options.headers ?? []), ...((await options.headersFactory?.()) ?? [])];
-  const authHeaders = entries.filter(([name]) => isAuthHeader(name)).sort(([a], [b]) => a.localeCompare(b));
+  const authHeaders = entries
+    .filter(([name]) => isAuthHeader(name))
+    .map(([name, value]) => [name.toLowerCase(), value] as [string, string])
+    .sort(([a], [b]) => a.localeCompare(b));
   return JSON.stringify(authHeaders);
 }
 

--- a/libs/providers/ofrep-web/src/lib/store/cache-key.ts
+++ b/libs/providers/ofrep-web/src/lib/store/cache-key.ts
@@ -1,4 +1,5 @@
 import type { OFREPProviderBaseOptions } from '@openfeature/ofrep-core';
+import type { EvaluationContext } from '@openfeature/web-sdk';
 
 /** Header names treated as auth credentials for cache key derivation (matched case-insensitively). */
 const AUTH_HEADER_NAMES = new Set([
@@ -9,13 +10,15 @@ const AUTH_HEADER_NAMES = new Set([
   'x-access-token',
 ]);
 
-export type CacheKeyParts = {
-  cacheKeyPrefix?: string;
-  baseUrl: string;
-  auth: string;
-  domain: string;
-  targetingKey: string;
+export type CacheKeyGeneratorInput = {
+  url: string;
+  auth?: string;
+  domain?: string;
+  targetingKey?: string;
+  context: EvaluationContext;
 };
+
+export type CacheKeyGenerator = (input: CacheKeyGeneratorInput) => string;
 
 function isAuthHeader(name: string): boolean {
   return AUTH_HEADER_NAMES.has(name.toLowerCase());
@@ -35,15 +38,9 @@ export async function deriveAuthCredential(options: OFREPProviderBaseOptions): P
 }
 
 /**
- * Encodes cache key components without ambiguous delimiter collisions.
- * Order matches ADR-0009: optional prefix, base URL, auth, domain, targeting key.
+ * Default ADR-0009 cache-key generator: OFREP base URL, auth credential, bound domain, and targeting key.
+ * The provider hashes the returned key material into `cacheKeyHash`.
  */
-export function encodeCacheKeyInput(parts: CacheKeyParts): string {
-  return JSON.stringify([
-    parts.cacheKeyPrefix ?? '',
-    parts.baseUrl,
-    parts.auth,
-    parts.domain,
-    parts.targetingKey,
-  ]);
+export function defaultCacheKeyGenerator(input: CacheKeyGeneratorInput): string {
+  return JSON.stringify([input.url, input.auth ?? '', input.domain ?? '', input.targetingKey ?? '']);
 }

--- a/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
@@ -14,33 +14,74 @@ const boolFlagCache: FlagCache = {
   },
 };
 
+const defaultBaseUrl = 'https://example.com';
+
+function createStorage(
+  cacheMode: 'local-cache-first' | 'network-first' | 'disabled' = 'local-cache-first',
+  options: { baseUrl?: string; auth?: string; cacheKeyPrefix?: string; domain?: string } = {},
+): Storage {
+  const storage = new Storage(
+    cacheMode,
+    options.baseUrl ?? defaultBaseUrl,
+    () => Promise.resolve(options.auth ?? '[]'),
+    options.cacheKeyPrefix,
+  );
+  storage.setDomain(options.domain);
+  return storage;
+}
+
 describe('Storage (persistent flag cache)', () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
   it('uses a versioned storage key and does not embed the raw targeting key', async () => {
-    const storage = new Storage('local-cache-first');
+    const storage = createStorage();
     const targetingKey = 'user-pii-21640825-95e7-4335-b149-bd6881cf7875';
     const key = await storage.getStorageKey(targetingKey);
-    expect(key.startsWith('ofrep-web-provider:v1:')).toBe(true);
+    expect(key.startsWith('ofrep-web-provider:v2:')).toBe(true);
     expect(key).not.toContain(targetingKey);
   });
 
   it('maps different targeting keys to different storage keys', async () => {
-    const storage = new Storage('local-cache-first');
+    const storage = createStorage();
     expect(await storage.getStorageKey('a')).not.toBe(await storage.getStorageKey('b'));
   });
 
+  it('maps different base URLs to different storage keys', async () => {
+    const storageA = createStorage('local-cache-first', { baseUrl: 'https://a.example.com' });
+    const storageB = createStorage('local-cache-first', { baseUrl: 'https://b.example.com' });
+    const tk = 'same-user';
+    expect(await storageA.getStorageKey(tk)).not.toBe(await storageB.getStorageKey(tk));
+  });
+
+  it('maps different domains to different storage keys', async () => {
+    const storageA = createStorage('local-cache-first', { domain: 'billing' });
+    const storageB = createStorage('local-cache-first', { domain: 'checkout' });
+    const tk = 'same-user';
+    expect(await storageA.getStorageKey(tk)).not.toBe(await storageB.getStorageKey(tk));
+  });
+
+  it('maps different auth credentials to different storage keys', async () => {
+    const storageA = createStorage('local-cache-first', {
+      auth: JSON.stringify([['Authorization', 'Bearer a']]),
+    });
+    const storageB = createStorage('local-cache-first', {
+      auth: JSON.stringify([['Authorization', 'Bearer b']]),
+    });
+    const tk = 'same-user';
+    expect(await storageA.getStorageKey(tk)).not.toBe(await storageB.getStorageKey(tk));
+  });
+
   it('does not read or write when cacheMode is disabled', async () => {
-    const storage = new Storage('disabled');
+    const storage = createStorage('disabled');
     await storage.store('any-key', boolFlagCache, null);
     expect(localStorage.length).toBe(0);
     expect(await storage.retrieve('any-key', DEFAULT_CACHE_TTL_SECONDS)).toBeUndefined();
   });
 
   it('clears the hashed entry for the given targeting key', async () => {
-    const storage = new Storage('local-cache-first');
+    const storage = createStorage();
     const tk = 'clear-me';
     await storage.store(tk, boolFlagCache, null);
     const key = await storage.getStorageKey(tk);
@@ -50,7 +91,7 @@ describe('Storage (persistent flag cache)', () => {
   });
 
   it('stores and retrieves the flag cache and ETag in the persisted envelope', async () => {
-    const storage = new Storage('local-cache-first');
+    const storage = createStorage();
     const etag = '"abc123"';
     await storage.store('user-1', boolFlagCache, etag);
     const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
@@ -60,7 +101,7 @@ describe('Storage (persistent flag cache)', () => {
   });
 
   it('stores and retrieves the SSE event streams in the persisted envelope', async () => {
-    const storage = new Storage('local-cache-first');
+    const storage = createStorage();
     const eventStreams = [{ type: 'sse' as const, url: 'https://sse.example.com/stream' }];
     await storage.store('user-1', boolFlagCache, '"etag"', undefined, eventStreams);
     const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
@@ -68,21 +109,21 @@ describe('Storage (persistent flag cache)', () => {
   });
 
   it('omits event streams from the envelope when none are provided', async () => {
-    const storage = new Storage('local-cache-first');
+    const storage = createStorage();
     await storage.store('user-1', boolFlagCache, '"etag"');
     const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
     expect(result!.eventStreams).toBeUndefined();
   });
 
   it('stores null ETag when none is provided', async () => {
-    const storage = new Storage('local-cache-first');
+    const storage = createStorage();
     await storage.store('user-1', boolFlagCache, null);
     const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
     expect(result!.etag).toBeNull();
   });
 
   it('returns undefined for an expired entry and removes it from storage', async () => {
-    const storage = new Storage('local-cache-first');
+    const storage = createStorage();
     const tk = 'user-expired';
     await storage.store(tk, boolFlagCache, null);
 
@@ -99,7 +140,7 @@ describe('Storage (persistent flag cache)', () => {
   });
 
   it('returns undefined for an entry with an unknown schema version', async () => {
-    const storage = new Storage('local-cache-first');
+    const storage = createStorage();
     const tk = 'user-v99';
     await storage.store(tk, boolFlagCache, null);
     const key = await storage.getStorageKey(tk);
@@ -110,11 +151,10 @@ describe('Storage (persistent flag cache)', () => {
   });
 
   it('uses a different hash when cacheKeyPrefix is set, preventing key collisions', async () => {
-    const storageA = new Storage('local-cache-first', 'provider-a');
-    const storageB = new Storage('local-cache-first', 'provider-b');
-    const storageNoPrefix = new Storage('local-cache-first');
+    const storageA = createStorage('local-cache-first', { cacheKeyPrefix: 'provider-a' });
+    const storageB = createStorage('local-cache-first', { cacheKeyPrefix: 'provider-b' });
+    const storageNoPrefix = createStorage('local-cache-first');
     const tk = 'same-user';
-    // All three should produce different storage keys for the same targeting key.
     expect(await storageA.getStorageKey(tk)).not.toBe(await storageB.getStorageKey(tk));
     expect(await storageA.getStorageKey(tk)).not.toBe(await storageNoPrefix.getStorageKey(tk));
   });
@@ -131,21 +171,21 @@ describe('Storage (persistent flag cache)', () => {
     });
 
     it('produces a valid versioned storage key without the raw targeting key', async () => {
-      const storage = new Storage('local-cache-first');
+      const storage = createStorage();
       const tk = 'user-pii-21640825-95e7-4335-b149-bd6881cf7875';
       const key = await storage.getStorageKey(tk);
-      expect(key.startsWith('ofrep-web-provider:v1:')).toBe(true);
+      expect(key.startsWith('ofrep-web-provider:v2:')).toBe(true);
       expect(key).not.toContain(tk);
       expect(key.split(':')[2]).toMatch(/^[0-9a-f]{16}$/);
     });
 
     it('maps different targeting keys to different storage keys', async () => {
-      const storage = new Storage('local-cache-first');
+      const storage = createStorage();
       expect(await storage.getStorageKey('a')).not.toBe(await storage.getStorageKey('b'));
     });
 
     it('stores and retrieves flags without throwing', async () => {
-      const storage = new Storage('local-cache-first');
+      const storage = createStorage();
       await storage.store('user-1', boolFlagCache, '"etag"');
       const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
       expect(result).not.toBeUndefined();

--- a/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
@@ -47,7 +47,7 @@ describe('Storage (persistent flag cache)', () => {
     const storage = createStorage();
     const context = ctx('user-pii-21640825-95e7-4335-b149-bd6881cf7875');
     const key = await storage.getStorageKey(context);
-    expect(key.startsWith('ofrep-web-provider:v3:')).toBe(true);
+    expect(key.startsWith('ofrep-web-provider:v2:')).toBe(true);
     expect(key).not.toContain(context.targetingKey!);
   });
 
@@ -190,7 +190,7 @@ describe('Storage (persistent flag cache)', () => {
       const storage = createStorage();
       const context = ctx('user-pii-21640825-95e7-4335-b149-bd6881cf7875');
       const key = await storage.getStorageKey(context);
-      expect(key.startsWith('ofrep-web-provider:v3:')).toBe(true);
+      expect(key.startsWith('ofrep-web-provider:v2:')).toBe(true);
       expect(key).not.toContain(context.targetingKey!);
       expect(key.split(':')[2]).toMatch(/^[0-9a-f]{16}$/);
     });

--- a/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
@@ -20,14 +20,13 @@ function createStorage(
   cacheMode: 'local-cache-first' | 'network-first' | 'disabled' = 'local-cache-first',
   options: { baseUrl?: string; auth?: string; cacheKeyPrefix?: string; domain?: string } = {},
 ): Storage {
-  const storage = new Storage(
+  return new Storage(
     cacheMode,
     options.baseUrl ?? defaultBaseUrl,
     () => Promise.resolve(options.auth ?? '[]'),
+    options.domain ?? '',
     options.cacheKeyPrefix,
   );
-  storage.setDomain(options.domain);
-  return storage;
 }
 
 describe('Storage (persistent flag cache)', () => {

--- a/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
@@ -1,4 +1,6 @@
+import type { EvaluationContext } from '@openfeature/web-sdk';
 import type { FlagCache } from '../model/in-memory-cache';
+import { defaultCacheKeyGenerator } from './cache-key';
 import { Storage } from './storage';
 import { StandardResolutionReasons } from '@openfeature/web-sdk';
 // eslint-disable-next-line @nx/enforce-module-boundaries
@@ -16,16 +18,23 @@ const boolFlagCache: FlagCache = {
 
 const defaultBaseUrl = 'https://example.com';
 
+const ctx = (targetingKey: string): EvaluationContext => ({ targetingKey });
+
 function createStorage(
   cacheMode: 'local-cache-first' | 'network-first' | 'disabled' = 'local-cache-first',
-  options: { baseUrl?: string; auth?: string; cacheKeyPrefix?: string; domain?: string } = {},
+  options: {
+    baseUrl?: string;
+    auth?: string;
+    domain?: string;
+    cacheKeyGenerator?: (input: Parameters<typeof defaultCacheKeyGenerator>[0]) => string;
+  } = {},
 ): Storage {
   return new Storage(
     cacheMode,
     options.baseUrl ?? defaultBaseUrl,
     () => Promise.resolve(options.auth ?? '[]'),
     options.domain ?? '',
-    options.cacheKeyPrefix,
+    options.cacheKeyGenerator,
   );
 }
 
@@ -36,29 +45,29 @@ describe('Storage (persistent flag cache)', () => {
 
   it('uses a versioned storage key and does not embed the raw targeting key', async () => {
     const storage = createStorage();
-    const targetingKey = 'user-pii-21640825-95e7-4335-b149-bd6881cf7875';
-    const key = await storage.getStorageKey(targetingKey);
-    expect(key.startsWith('ofrep-web-provider:v2:')).toBe(true);
-    expect(key).not.toContain(targetingKey);
+    const context = ctx('user-pii-21640825-95e7-4335-b149-bd6881cf7875');
+    const key = await storage.getStorageKey(context);
+    expect(key.startsWith('ofrep-web-provider:v3:')).toBe(true);
+    expect(key).not.toContain(context.targetingKey!);
   });
 
   it('maps different targeting keys to different storage keys', async () => {
     const storage = createStorage();
-    expect(await storage.getStorageKey('a')).not.toBe(await storage.getStorageKey('b'));
+    expect(await storage.getStorageKey(ctx('a'))).not.toBe(await storage.getStorageKey(ctx('b')));
   });
 
   it('maps different base URLs to different storage keys', async () => {
     const storageA = createStorage('local-cache-first', { baseUrl: 'https://a.example.com' });
     const storageB = createStorage('local-cache-first', { baseUrl: 'https://b.example.com' });
-    const tk = 'same-user';
-    expect(await storageA.getStorageKey(tk)).not.toBe(await storageB.getStorageKey(tk));
+    const context = ctx('same-user');
+    expect(await storageA.getStorageKey(context)).not.toBe(await storageB.getStorageKey(context));
   });
 
   it('maps different domains to different storage keys', async () => {
     const storageA = createStorage('local-cache-first', { domain: 'billing' });
     const storageB = createStorage('local-cache-first', { domain: 'checkout' });
-    const tk = 'same-user';
-    expect(await storageA.getStorageKey(tk)).not.toBe(await storageB.getStorageKey(tk));
+    const context = ctx('same-user');
+    expect(await storageA.getStorageKey(context)).not.toBe(await storageB.getStorageKey(context));
   });
 
   it('maps different auth credentials to different storage keys', async () => {
@@ -68,32 +77,33 @@ describe('Storage (persistent flag cache)', () => {
     const storageB = createStorage('local-cache-first', {
       auth: JSON.stringify([['Authorization', 'Bearer b']]),
     });
-    const tk = 'same-user';
-    expect(await storageA.getStorageKey(tk)).not.toBe(await storageB.getStorageKey(tk));
+    const context = ctx('same-user');
+    expect(await storageA.getStorageKey(context)).not.toBe(await storageB.getStorageKey(context));
   });
 
   it('does not read or write when cacheMode is disabled', async () => {
     const storage = createStorage('disabled');
-    await storage.store('any-key', boolFlagCache, null);
+    await storage.store(ctx('any-key'), boolFlagCache, null);
     expect(localStorage.length).toBe(0);
-    expect(await storage.retrieve('any-key', DEFAULT_CACHE_TTL_SECONDS)).toBeUndefined();
+    expect(await storage.retrieve(ctx('any-key'), DEFAULT_CACHE_TTL_SECONDS)).toBeUndefined();
   });
 
   it('clears the hashed entry for the given targeting key', async () => {
     const storage = createStorage();
-    const tk = 'clear-me';
-    await storage.store(tk, boolFlagCache, null);
-    const key = await storage.getStorageKey(tk);
+    const context = ctx('clear-me');
+    await storage.store(context, boolFlagCache, null);
+    const key = await storage.getStorageKey(context);
     expect(localStorage.getItem(key)).not.toBeNull();
-    await storage.clear(tk);
+    await storage.clear(context);
     expect(localStorage.getItem(key)).toBeNull();
   });
 
   it('stores and retrieves the flag cache and ETag in the persisted envelope', async () => {
     const storage = createStorage();
+    const context = ctx('user-1');
     const etag = '"abc123"';
-    await storage.store('user-1', boolFlagCache, etag);
-    const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
+    await storage.store(context, boolFlagCache, etag);
+    const result = await storage.retrieve(context, DEFAULT_CACHE_TTL_SECONDS);
     expect(result).not.toBeUndefined();
     expect(result!.flags).toEqual(boolFlagCache);
     expect(result!.etag).toBe(etag);
@@ -101,38 +111,41 @@ describe('Storage (persistent flag cache)', () => {
 
   it('stores and retrieves the SSE event streams in the persisted envelope', async () => {
     const storage = createStorage();
+    const context = ctx('user-1');
     const eventStreams = [{ type: 'sse' as const, url: 'https://sse.example.com/stream' }];
-    await storage.store('user-1', boolFlagCache, '"etag"', undefined, eventStreams);
-    const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
+    await storage.store(context, boolFlagCache, '"etag"', undefined, eventStreams);
+    const result = await storage.retrieve(context, DEFAULT_CACHE_TTL_SECONDS);
     expect(result!.eventStreams).toEqual(eventStreams);
   });
 
   it('omits event streams from the envelope when none are provided', async () => {
     const storage = createStorage();
-    await storage.store('user-1', boolFlagCache, '"etag"');
-    const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
+    const context = ctx('user-1');
+    await storage.store(context, boolFlagCache, '"etag"');
+    const result = await storage.retrieve(context, DEFAULT_CACHE_TTL_SECONDS);
     expect(result!.eventStreams).toBeUndefined();
   });
 
   it('stores null ETag when none is provided', async () => {
     const storage = createStorage();
-    await storage.store('user-1', boolFlagCache, null);
-    const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
+    const context = ctx('user-1');
+    await storage.store(context, boolFlagCache, null);
+    const result = await storage.retrieve(context, DEFAULT_CACHE_TTL_SECONDS);
     expect(result!.etag).toBeNull();
   });
 
   it('returns undefined for an expired entry and removes it from storage', async () => {
     const storage = createStorage();
-    const tk = 'user-expired';
-    await storage.store(tk, boolFlagCache, null);
+    const context = ctx('user-expired');
+    await storage.store(context, boolFlagCache, null);
 
     // Patch the writtenAt to be 31 days ago.
-    const key = await storage.getStorageKey(tk);
+    const key = await storage.getStorageKey(context);
     const raw = JSON.parse(localStorage.getItem(key)!);
     raw.writtenAt = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString();
     localStorage.setItem(key, JSON.stringify(raw));
 
-    const result = await storage.retrieve(tk, DEFAULT_CACHE_TTL_SECONDS);
+    const result = await storage.retrieve(context, DEFAULT_CACHE_TTL_SECONDS);
     expect(result).toBeUndefined();
     // Expired entry should have been evicted.
     expect(localStorage.getItem(key)).toBeNull();
@@ -140,22 +153,26 @@ describe('Storage (persistent flag cache)', () => {
 
   it('returns undefined for an entry with an unknown schema version', async () => {
     const storage = createStorage();
-    const tk = 'user-v99';
-    await storage.store(tk, boolFlagCache, null);
-    const key = await storage.getStorageKey(tk);
+    const context = ctx('user-v99');
+    await storage.store(context, boolFlagCache, null);
+    const key = await storage.getStorageKey(context);
     const raw = JSON.parse(localStorage.getItem(key)!);
     raw.version = 99;
     localStorage.setItem(key, JSON.stringify(raw));
-    expect(await storage.retrieve(tk, DEFAULT_CACHE_TTL_SECONDS)).toBeUndefined();
+    expect(await storage.retrieve(context, DEFAULT_CACHE_TTL_SECONDS)).toBeUndefined();
   });
 
-  it('uses a different hash when cacheKeyPrefix is set, preventing key collisions', async () => {
-    const storageA = createStorage('local-cache-first', { cacheKeyPrefix: 'provider-a' });
-    const storageB = createStorage('local-cache-first', { cacheKeyPrefix: 'provider-b' });
-    const storageNoPrefix = createStorage('local-cache-first');
-    const tk = 'same-user';
-    expect(await storageA.getStorageKey(tk)).not.toBe(await storageB.getStorageKey(tk));
-    expect(await storageA.getStorageKey(tk)).not.toBe(await storageNoPrefix.getStorageKey(tk));
+  it('uses a different hash for custom cache-key generators', async () => {
+    const context = ctx('same-user');
+    const storageA = createStorage('local-cache-first', {
+      cacheKeyGenerator: (input) => `provider-a:${defaultCacheKeyGenerator(input)}`,
+    });
+    const storageB = createStorage('local-cache-first', {
+      cacheKeyGenerator: (input) => `provider-b:${defaultCacheKeyGenerator(input)}`,
+    });
+    const storageDefault = createStorage('local-cache-first');
+    expect(await storageA.getStorageKey(context)).not.toBe(await storageB.getStorageKey(context));
+    expect(await storageA.getStorageKey(context)).not.toBe(await storageDefault.getStorageKey(context));
   });
 
   describe('when crypto.subtle is unavailable (non-secure context)', () => {
@@ -171,22 +188,23 @@ describe('Storage (persistent flag cache)', () => {
 
     it('produces a valid versioned storage key without the raw targeting key', async () => {
       const storage = createStorage();
-      const tk = 'user-pii-21640825-95e7-4335-b149-bd6881cf7875';
-      const key = await storage.getStorageKey(tk);
-      expect(key.startsWith('ofrep-web-provider:v2:')).toBe(true);
-      expect(key).not.toContain(tk);
+      const context = ctx('user-pii-21640825-95e7-4335-b149-bd6881cf7875');
+      const key = await storage.getStorageKey(context);
+      expect(key.startsWith('ofrep-web-provider:v3:')).toBe(true);
+      expect(key).not.toContain(context.targetingKey!);
       expect(key.split(':')[2]).toMatch(/^[0-9a-f]{16}$/);
     });
 
     it('maps different targeting keys to different storage keys', async () => {
       const storage = createStorage();
-      expect(await storage.getStorageKey('a')).not.toBe(await storage.getStorageKey('b'));
+      expect(await storage.getStorageKey(ctx('a'))).not.toBe(await storage.getStorageKey(ctx('b')));
     });
 
     it('stores and retrieves flags without throwing', async () => {
       const storage = createStorage();
-      await storage.store('user-1', boolFlagCache, '"etag"');
-      const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
+      const context = ctx('user-1');
+      await storage.store(context, boolFlagCache, '"etag"');
+      const result = await storage.retrieve(context, DEFAULT_CACHE_TTL_SECONDS);
       expect(result).not.toBeUndefined();
       expect(result!.flags).toEqual(boolFlagCache);
       expect(result!.etag).toBe('"etag"');

--- a/libs/providers/ofrep-web/src/lib/store/storage.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.ts
@@ -32,34 +32,28 @@ export class Storage {
   private readonly _disabled: boolean;
   private readonly _baseUrl: string;
   private readonly _getAuthCredential: () => Promise<string>;
+  private readonly _domain: string;
   private readonly _cacheKeyPrefix?: string;
   private readonly _logger?: Logger;
-  private _domain = '';
 
   constructor(
     cacheMode: CacheMode = 'local-cache-first',
     baseUrl: string,
     getAuthCredential: () => Promise<string>,
+    domain: string,
     cacheKeyPrefix?: string,
     logger?: Logger,
   ) {
     this._disabled = cacheMode === 'disabled';
     this._baseUrl = baseUrl;
     this._getAuthCredential = getAuthCredential;
+    this._domain = domain;
     this._cacheKeyPrefix = cacheKeyPrefix;
     this._logger = logger;
   }
 
   get disabled(): boolean {
     return this._disabled;
-  }
-
-  /**
-   * Sets the bound OpenFeature domain for cache key derivation.
-   * Called once from provider initialization.
-   */
-  setDomain(domain?: string): void {
-    this._domain = domain ?? '';
   }
 
   /**

--- a/libs/providers/ofrep-web/src/lib/store/storage.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.ts
@@ -4,7 +4,7 @@ import type { FlagCache } from '../model/in-memory-cache';
 import type { CacheMode } from '../model/ofrep-web-provider-options';
 import { type CacheKeyGenerator, defaultCacheKeyGenerator } from './cache-key';
 
-const SCHEMA_VERSION = 3;
+const SCHEMA_VERSION = 2;
 const STORAGE_NS = 'ofrep-web-provider';
 
 /**

--- a/libs/providers/ofrep-web/src/lib/store/storage.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.ts
@@ -1,10 +1,10 @@
 import type { EventStream } from '@openfeature/ofrep-core';
-import type { Logger } from '@openfeature/web-sdk';
+import type { EvaluationContext, Logger } from '@openfeature/web-sdk';
 import type { FlagCache } from '../model/in-memory-cache';
 import type { CacheMode } from '../model/ofrep-web-provider-options';
-import { encodeCacheKeyInput } from './cache-key';
+import { type CacheKeyGenerator, defaultCacheKeyGenerator } from './cache-key';
 
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 const STORAGE_NS = 'ofrep-web-provider';
 
 /**
@@ -33,7 +33,7 @@ export class Storage {
   private readonly _baseUrl: string;
   private readonly _getAuthCredential: () => Promise<string>;
   private readonly _domain: string;
-  private readonly _cacheKeyPrefix?: string;
+  private readonly _cacheKeyGenerator: CacheKeyGenerator;
   private readonly _logger?: Logger;
 
   constructor(
@@ -41,14 +41,14 @@ export class Storage {
     baseUrl: string,
     getAuthCredential: () => Promise<string>,
     domain: string,
-    cacheKeyPrefix?: string,
+    cacheKeyGenerator: CacheKeyGenerator = defaultCacheKeyGenerator,
     logger?: Logger,
   ) {
     this._disabled = cacheMode === 'disabled';
     this._baseUrl = baseUrl;
     this._getAuthCredential = getAuthCredential;
     this._domain = domain;
-    this._cacheKeyPrefix = cacheKeyPrefix;
+    this._cacheKeyGenerator = cacheKeyGenerator;
     this._logger = logger;
   }
 
@@ -56,19 +56,24 @@ export class Storage {
     return this._disabled;
   }
 
+  private async _cacheKeyMaterial(context: EvaluationContext): Promise<string> {
+    const auth = await this._getAuthCredential();
+    return this._cacheKeyGenerator({
+      url: this._baseUrl,
+      auth: auth === '[]' ? undefined : auth,
+      domain: this._domain || undefined,
+      targetingKey: context.targetingKey,
+      context,
+    });
+  }
+
   /**
-   * Hashes the ADR-0009 cache key input to a 16-char hex string.
+   * Hashes the ADR-0009 cache key material to a 16-char hex string.
    * Uses SHA-256 via crypto.subtle when available (secure contexts).
    * Falls back to a double-pass FNV-1a-32 in non-secure contexts where crypto.subtle is absent.
    */
-  private async _hashInput(targetingKey: string): Promise<string> {
-    const input = encodeCacheKeyInput({
-      cacheKeyPrefix: this._cacheKeyPrefix,
-      baseUrl: this._baseUrl,
-      auth: await this._getAuthCredential(),
-      domain: this._domain,
-      targetingKey,
-    });
+  private async _hashInput(context: EvaluationContext): Promise<string> {
+    const input = await this._cacheKeyMaterial(context);
     if (typeof crypto !== 'undefined' && crypto.subtle) {
       const encoded = new TextEncoder().encode(input);
       const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);
@@ -100,11 +105,11 @@ export class Storage {
   }
 
   /**
-   * Returns the localStorage key for the given targeting key.
+   * Returns the localStorage key for the given evaluation context.
    * Format: `ofrep-web-provider:v{version}:{hash}`
    */
-  async getStorageKey(targetingKey: string): Promise<string> {
-    return `${STORAGE_NS}:v${SCHEMA_VERSION}:${await this._hashInput(targetingKey)}`;
+  async getStorageKey(context: EvaluationContext): Promise<string> {
+    return `${STORAGE_NS}:v${SCHEMA_VERSION}:${await this._hashInput(context)}`;
   }
 
   /**
@@ -113,17 +118,17 @@ export class Storage {
    * so the provider continues operating with the fresh in-memory values.
    */
   async store(
-    targetingKey: string,
+    context: EvaluationContext,
     flags: FlagCache,
     etag: string | null,
     metadata?: Record<string, unknown>,
     eventStreams?: EventStream[],
   ): Promise<void> {
     if (this._disabled) return;
-    const key = await this.getStorageKey(targetingKey);
+    const key = await this.getStorageKey(context);
     const entry: PersistedEntry = {
       version: SCHEMA_VERSION,
-      cacheKeyHash: await this._hashInput(targetingKey),
+      cacheKeyHash: await this._hashInput(context),
       etag,
       writtenAt: new Date().toISOString(),
       data: flags,
@@ -141,12 +146,12 @@ export class Storage {
    * Loads a previously persisted entry.
    * Returns `undefined` when:
    *  - cacheMode is 'disabled'
-   *  - no entry exists for this targeting key
+   *  - no entry exists for this context
    *  - the schema version does not match
    *  - the entry is older than `ttlSeconds` (expired entries are removed from storage)
    */
   async retrieve(
-    targetingKey: string,
+    context: EvaluationContext,
     ttlSeconds: number,
   ): Promise<
     | { flags: FlagCache; etag: string | null; metadata?: Record<string, unknown>; eventStreams?: EventStream[] }
@@ -154,7 +159,7 @@ export class Storage {
   > {
     if (this._disabled) return undefined;
     try {
-      const raw = localStorage.getItem(await this.getStorageKey(targetingKey));
+      const raw = localStorage.getItem(await this.getStorageKey(context));
       if (!raw) return undefined;
 
       const entry = JSON.parse(raw) as PersistedEntry;
@@ -165,7 +170,7 @@ export class Storage {
       // Enforce TTL — treat expired entries as a cache miss and evict them.
       const writtenAt = new Date(entry.writtenAt).getTime();
       if (Number.isNaN(writtenAt) || Date.now() - writtenAt > ttlSeconds * 1000) {
-        await this.clear(targetingKey);
+        await this.clear(context);
         return undefined;
       }
 
@@ -177,13 +182,13 @@ export class Storage {
   }
 
   /**
-   * Removes the persisted entry for the given targeting key.
+   * Removes the persisted entry for the given evaluation context.
    * No-op when cacheMode is 'disabled'.
    */
-  async clear(targetingKey: string): Promise<void> {
+  async clear(context: EvaluationContext): Promise<void> {
     if (this._disabled) return;
     try {
-      localStorage.removeItem(await this.getStorageKey(targetingKey));
+      localStorage.removeItem(await this.getStorageKey(context));
     } catch (error) {
       this._logger?.error(`Error clearing flag cache from local storage: ${error}`);
     }

--- a/libs/providers/ofrep-web/src/lib/store/storage.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.ts
@@ -2,8 +2,9 @@ import type { EventStream } from '@openfeature/ofrep-core';
 import type { Logger } from '@openfeature/web-sdk';
 import type { FlagCache } from '../model/in-memory-cache';
 import type { CacheMode } from '../model/ofrep-web-provider-options';
+import { encodeCacheKeyInput } from './cache-key';
 
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 const STORAGE_NS = 'ofrep-web-provider';
 
 /**
@@ -13,7 +14,7 @@ const STORAGE_NS = 'ofrep-web-provider';
 export interface PersistedEntry {
   /** Schema version — used to discard entries written by older provider versions. */
   version: number;
-  /** Hex digest (16 chars) of `targetingKey` (or `cacheKeyPrefix + ":" + targetingKey` when configured). SHA-256 when crypto.subtle is available, FNV-1a fallback otherwise. */
+  /** Hex digest (16 chars) of the ADR-0009 cache key input. SHA-256 when crypto.subtle is available, FNV-1a fallback otherwise. */
   cacheKeyHash: string;
   /** ETag returned by the server for this evaluation, used for efficient revalidation. */
   etag: string | null;
@@ -29,11 +30,22 @@ export interface PersistedEntry {
 
 export class Storage {
   private readonly _disabled: boolean;
+  private readonly _baseUrl: string;
+  private readonly _getAuthCredential: () => Promise<string>;
   private readonly _cacheKeyPrefix?: string;
   private readonly _logger?: Logger;
+  private _domain = '';
 
-  constructor(cacheMode: CacheMode = 'local-cache-first', cacheKeyPrefix?: string, logger?: Logger) {
+  constructor(
+    cacheMode: CacheMode = 'local-cache-first',
+    baseUrl: string,
+    getAuthCredential: () => Promise<string>,
+    cacheKeyPrefix?: string,
+    logger?: Logger,
+  ) {
     this._disabled = cacheMode === 'disabled';
+    this._baseUrl = baseUrl;
+    this._getAuthCredential = getAuthCredential;
     this._cacheKeyPrefix = cacheKeyPrefix;
     this._logger = logger;
   }
@@ -43,12 +55,26 @@ export class Storage {
   }
 
   /**
-   * Hashes the targeting key (with optional prefix) to a 16-char hex string.
+   * Sets the bound OpenFeature domain for cache key derivation.
+   * Called once from provider initialization.
+   */
+  setDomain(domain?: string): void {
+    this._domain = domain ?? '';
+  }
+
+  /**
+   * Hashes the ADR-0009 cache key input to a 16-char hex string.
    * Uses SHA-256 via crypto.subtle when available (secure contexts).
    * Falls back to a double-pass FNV-1a-32 in non-secure contexts where crypto.subtle is absent.
    */
   private async _hashInput(targetingKey: string): Promise<string> {
-    const input = this._cacheKeyPrefix ? `${this._cacheKeyPrefix}:${targetingKey}` : targetingKey;
+    const input = encodeCacheKeyInput({
+      cacheKeyPrefix: this._cacheKeyPrefix,
+      baseUrl: this._baseUrl,
+      auth: await this._getAuthCredential(),
+      domain: this._domain,
+      targetingKey,
+    });
     if (typeof crypto !== 'undefined' && crypto.subtle) {
       const encoded = new TextEncoder().encode(input);
       const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);

--- a/libs/providers/ofrep-web/src/lib/store/storage.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.ts
@@ -104,12 +104,16 @@ export class Storage {
     return lo.toString(16).padStart(8, '0') + hi.toString(16).padStart(8, '0');
   }
 
+  private _formatStorageKey(cacheKeyHash: string): string {
+    return `${STORAGE_NS}:v${SCHEMA_VERSION}:${cacheKeyHash}`;
+  }
+
   /**
    * Returns the localStorage key for the given evaluation context.
    * Format: `ofrep-web-provider:v{version}:{hash}`
    */
   async getStorageKey(context: EvaluationContext): Promise<string> {
-    return `${STORAGE_NS}:v${SCHEMA_VERSION}:${await this._hashInput(context)}`;
+    return this._formatStorageKey(await this._hashInput(context));
   }
 
   /**
@@ -125,17 +129,18 @@ export class Storage {
     eventStreams?: EventStream[],
   ): Promise<void> {
     if (this._disabled) return;
-    const key = await this.getStorageKey(context);
-    const entry: PersistedEntry = {
-      version: SCHEMA_VERSION,
-      cacheKeyHash: await this._hashInput(context),
-      etag,
-      writtenAt: new Date().toISOString(),
-      data: flags,
-      ...(metadata !== undefined && { metadata }),
-      ...(eventStreams !== undefined && { eventStreams }),
-    };
     try {
+      const cacheKeyHash = await this._hashInput(context);
+      const key = this._formatStorageKey(cacheKeyHash);
+      const entry: PersistedEntry = {
+        version: SCHEMA_VERSION,
+        cacheKeyHash,
+        etag,
+        writtenAt: new Date().toISOString(),
+        data: flags,
+        ...(metadata !== undefined && { metadata }),
+        ...(eventStreams !== undefined && { eventStreams }),
+      };
       localStorage.setItem(key, JSON.stringify(entry));
     } catch (error) {
       this._logger?.error(`Error storing flag cache in local storage: ${error}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "@nx/workspace": "22.7.1",
         "@openfeature/core": "^1.9.1",
         "@openfeature/server-sdk": "^1.19.0",
-        "@openfeature/web-sdk": "^1.6.2",
+        "@openfeature/web-sdk": "^1.10.0",
         "@opentelemetry/context-async-hooks": "^2.1.0",
         "@opentelemetry/sdk-logs": "^0.205.0",
         "@opentelemetry/sdk-metrics": "^1.30.1",
@@ -7034,9 +7034,9 @@
       "license": "MIT"
     },
     "node_modules/@openfeature/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-YySPtH4s/rKKnHRU0xyFGrqMU8XA+OIPNWDrlEFxE6DCVWCIrxE5YpiB94YD2jMFn6SSdA0cwQ8vLkCkl8lm8A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-7PCPzyd1OC19begz30+CRknFB0ChtyaZUhk7YWrk+Bov1fpVw0HYkTXtoxxsvPfDZB9P9WsT7uixN+Z8f9+bcA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -7054,13 +7054,13 @@
       }
     },
     "node_modules/@openfeature/web-sdk": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.6.2.tgz",
-      "integrity": "sha512-Dcj4o4sBNT8QSAFTBWpj8nJhRm2lhJRoGSel6eiiV0gIZSQ4sCc8pi+2jey4Ffkw6S/cMvfbxjEj2CZiCgzZaA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.10.0.tgz",
+      "integrity": "sha512-qf+JmJSnaslhegNwoDDLn2Cf72P6cIobuAQPUb61MSkzJOZuVLU6f9pv/90FlLcK6UDtp6od//xZHW712rBrmg==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@openfeature/core": "^1.9.0"
+        "@openfeature/core": "^1.12.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -30850,9 +30850,9 @@
       "dev": true
     },
     "@openfeature/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-YySPtH4s/rKKnHRU0xyFGrqMU8XA+OIPNWDrlEFxE6DCVWCIrxE5YpiB94YD2jMFn6SSdA0cwQ8vLkCkl8lm8A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-7PCPzyd1OC19begz30+CRknFB0ChtyaZUhk7YWrk+Bov1fpVw0HYkTXtoxxsvPfDZB9P9WsT7uixN+Z8f9+bcA==",
       "dev": true
     },
     "@openfeature/server-sdk": {
@@ -30863,9 +30863,9 @@
       "requires": {}
     },
     "@openfeature/web-sdk": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.6.2.tgz",
-      "integrity": "sha512-Dcj4o4sBNT8QSAFTBWpj8nJhRm2lhJRoGSel6eiiV0gIZSQ4sCc8pi+2jey4Ffkw6S/cMvfbxjEj2CZiCgzZaA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.10.0.tgz",
+      "integrity": "sha512-qf+JmJSnaslhegNwoDDLn2Cf72P6cIobuAQPUb61MSkzJOZuVLU6f9pv/90FlLcK6UDtp6od//xZHW712rBrmg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@nx/workspace": "22.7.1",
     "@openfeature/core": "^1.9.1",
     "@openfeature/server-sdk": "^1.19.0",
-    "@openfeature/web-sdk": "^1.6.2",
+    "@openfeature/web-sdk": "^1.10.0",
     "@opentelemetry/context-async-hooks": "^2.1.0",
     "@opentelemetry/sdk-logs": "^0.205.0",
     "@opentelemetry/sdk-metrics": "^1.30.1",


### PR DESCRIPTION
## Summary

- Replace `cacheKeyPrefix` with a `cacheKeyGenerator` per the [protocol ADR-0009 amendment](https://github.com/open-feature/protocol/pull/80). The default generator returns JSON-encoded key material from `baseUrl`, auth credential, bound `domain`, and `targetingKey`; the provider hashes that into `cacheKeyHash`.
- Declare `domainScoped: true` and create `Storage` only in `initialize(context, domain?)`, so nothing touches `localStorage` before the bound domain is known.
- Derive auth for the cache key from known auth headers only (`Authorization`, `Api-Key`, `X-Api-Key`, `X-Auth-Token`, `X-Access-Token`), matched case-insensitively and serialized with lowercased header names.
- Persist under schema v2 (`ofrep-web-provider:v2:{hash}`); v1 entries are discarded on read.
- Document caching, cache-key customization, and domain scoping in the provider README.
- Bump `@openfeature/web-sdk` peer dependency to `^1.10.0` (domain forwarding and `domainScoped` enforcement landed in [open-feature/js-sdk#1433](https://github.com/open-feature/js-sdk/pull/1433)).

## Motivation

OFREP web persistence needs the bound OpenFeature `domain` at init time to scope cache keys per ADR-0009. This supersedes #1566 (URL + full eval context keying).

Requires `@openfeature/web-sdk@1.10.0+` so the SDK forwards `domain` on `initialize` and enforces single-domain binding for `domainScoped` providers.

## Notes

- Use `cacheKeyGenerator` to namespace instances, drop auth for rotating tokens, or include stable context fields.
- `cacheKeyPrefix` is removed.

## Related Issues

- Supersedes #1566
- Relates to open-feature/js-sdk#1433, open-feature/protocol#80, open-feature/spec#393
