### PR TITLE
fix(flagd): stop reconnecting after disconnect

### DIFF
--- a/libs/providers/flagd/src/lib/flagd-provider.spec.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.spec.ts
@@ -553,6 +553,59 @@ describe(FlagdProvider.name, () => {
         // eventStream should have been called twice (initial + reconnect attempt)
         expect(streamingServiceClientMock.eventStream).toHaveBeenCalledTimes(2);
       });
+
+      it('should not reconnect after disconnect when an error has scheduled a retry', async () => {
+        const provider = new FlagdProvider(
+          undefined,
+          undefined,
+          new GRPCService(
+            { deadlineMs: 100, streamDeadlineMs: 600000, host: '', port: 123, tls: false, cache: 'lru' },
+            streamingServiceClientMock,
+          ),
+        );
+        const initializePromise = provider.initialize();
+        registeredOnMessageCallback({ type: EVENT_PROVIDER_READY, data: {} });
+        await initializePromise;
+
+        registeredOnErrorCallback();
+        await provider.onClose();
+        expect(jest.getTimerCount()).toBe(0);
+        jest.runOnlyPendingTimers();
+
+        expect(streamingServiceClientMock.eventStream).toHaveBeenCalledTimes(1);
+      });
+
+      it('should reject initialization when disconnected before the stream is ready', async () => {
+        const service = new GRPCService(
+          { deadlineMs: 100, streamDeadlineMs: 600000, host: '', port: 123, tls: false, cache: 'lru' },
+          streamingServiceClientMock,
+        );
+        const connectPromise = service.connect(jest.fn(), jest.fn(), jest.fn());
+        const rejection = expect(connectPromise).rejects.toThrow('gRPC client disconnected before connecting');
+
+        await service.disconnect();
+
+        await rejection;
+        expect(streamingServiceClientMock.eventStream).toHaveBeenCalledTimes(1);
+      });
+
+      it('should reject initialization when disconnected before the client is ready', async () => {
+        const pendingServiceClientMock = {
+          ...streamingServiceClientMock,
+          waitForReady: jest.fn(() => undefined),
+        } as unknown as ServiceClient;
+        const service = new GRPCService(
+          { deadlineMs: 100, streamDeadlineMs: 600000, host: '', port: 123, tls: false, cache: 'lru' },
+          pendingServiceClientMock,
+        );
+        const connectPromise = service.connect(jest.fn(), jest.fn(), jest.fn());
+        const rejection = expect(connectPromise).rejects.toThrow('gRPC client disconnected before connecting');
+
+        await service.disconnect();
+
+        await rejection;
+        expect(pendingServiceClientMock.eventStream).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
+++ b/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
@@ -87,6 +87,9 @@ export class GRPCService implements Service {
   private _maxBackoffMs: number;
   private _errorThrottled = false;
   private readonly _metadata: Metadata;
+  private _disconnected = false;
+  private _reconnectTimer?: ReturnType<typeof setTimeout>;
+  private _rejectConnect?: (reason: Error) => void;
 
   private get _cacheActive() {
     // the cache is "active" (able to be used) if the config enabled it, AND the gRPC stream is live
@@ -132,12 +135,32 @@ export class GRPCService implements Service {
     changedCallback: (flagsChanged: string[]) => void,
     disconnectCallback: (message: string) => void,
   ): Promise<void> {
-    return new Promise((resolve, reject) =>
-      this.listen(reconnectCallback, changedCallback, disconnectCallback, resolve, reject),
-    );
+    return new Promise((resolve, reject) => {
+      this._rejectConnect = reject;
+      this.listen(
+        reconnectCallback,
+        changedCallback,
+        disconnectCallback,
+        () => {
+          this._rejectConnect = undefined;
+          resolve();
+        },
+        (reason) => {
+          this._rejectConnect = undefined;
+          reject(reason);
+        },
+      );
+    });
   }
 
   async disconnect(): Promise<void> {
+    this._disconnected = true;
+    this._rejectConnect?.(new Error('gRPC client disconnected before connecting'));
+    this._rejectConnect = undefined;
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = undefined;
+    }
     closeStreamIfDefined(this._eventStream);
     this._client.close();
   }
@@ -192,6 +215,10 @@ export class GRPCService implements Service {
 
     // wait for connection to be stable
     this._client.waitForReady(Date.now() + this._deadline, (err) => {
+      if (this._disconnected) {
+        rejectConnect?.(err ?? new Error('gRPC client disconnected before connecting'));
+        return;
+      }
       if (err) {
         // Check if error is a fatal status code on first connection only
         if (isFatalStatusCodeError(err, this._initialized, this._fatalStatusCodes)) {
@@ -259,8 +286,16 @@ export class GRPCService implements Service {
     changedCallback: (flagsChanged: string[]) => void,
     disconnectCallback: (message: string) => void,
   ) {
-    setTimeout(
-      () => this.listen(reconnectCallback, changedCallback, disconnectCallback),
+    if (this._disconnected) {
+      return;
+    }
+    this._reconnectTimer = setTimeout(
+      () => {
+        this._reconnectTimer = undefined;
+        if (!this._disconnected) {
+          this.listen(reconnectCallback, changedCallback, disconnectCallback);
+        }
+      },
       this._errorThrottled ? this._maxBackoffMs : 0,
     );
     this._errorThrottled = false;

--- a/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.spec.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.spec.ts
@@ -47,6 +47,7 @@ const serviceMock: FlagSyncServiceClient = {
       destroy,
     };
   }),
+  close: jest.fn(),
 } as unknown as FlagSyncServiceClient;
 
 describe('grpc fetch', () => {
@@ -179,6 +180,46 @@ describe('grpc fetch', () => {
     });
 
     onErrorCallback(new Error('Some connection error'));
+  });
+
+  it('should not reconnect after disconnect when an error has scheduled a retry', async () => {
+    const fetch = new GrpcFetch(cfg, jest.fn(), serviceMock);
+    const connectPromise = fetch.connect(dataCallback, reconnectCallback, changedCallback, disconnectCallback);
+    onDataCallback({ flagConfiguration: '{"flags":{}}' });
+    await connectPromise;
+
+    onErrorCallback(new Error('Some connection error'));
+    await fetch.disconnect();
+    expect(jest.getTimerCount()).toBe(0);
+    jest.runOnlyPendingTimers();
+
+    expect(serviceMock.syncFlags).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject connection when disconnected before the stream emits data', async () => {
+    const fetch = new GrpcFetch(cfg, jest.fn(), serviceMock);
+    const connectPromise = fetch.connect(dataCallback, reconnectCallback, changedCallback, disconnectCallback);
+    const rejection = expect(connectPromise).rejects.toThrow('gRPC client disconnected before connecting');
+
+    await fetch.disconnect();
+
+    await rejection;
+    expect(serviceMock.syncFlags).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject connection when disconnected before the client is ready', async () => {
+    const pendingServiceMock = {
+      ...serviceMock,
+      waitForReady: jest.fn(() => undefined),
+    } as unknown as FlagSyncServiceClient;
+    const fetch = new GrpcFetch(cfg, jest.fn(), pendingServiceMock);
+    const connectPromise = fetch.connect(dataCallback, reconnectCallback, changedCallback, disconnectCallback);
+    const rejection = expect(connectPromise).rejects.toThrow('gRPC client disconnected before connecting');
+
+    await fetch.disconnect();
+
+    await rejection;
+    expect(pendingServiceMock.syncFlags).not.toHaveBeenCalled();
   });
 
   it('should send selector via flagd-selector metadata header', async () => {

--- a/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
@@ -31,6 +31,9 @@ export class GrpcFetch implements DataFetch {
   private _logger: Logger | undefined;
   private readonly _fatalStatusCodes: Set<number>;
   private _errorThrottled = false;
+  private _disconnected = false;
+  private _reconnectTimer?: ReturnType<typeof setTimeout>;
+  private _rejectConnect?: (reason: Error) => void;
   /**
    * Initialized will be set to true once the initial connection is successful
    * and the first payload has been received. Subsequent reconnects will not
@@ -86,14 +89,35 @@ export class GrpcFetch implements DataFetch {
     changedCallback: (flagsChanged: string[]) => void,
     disconnectCallback: (message: string) => void,
   ): Promise<void> {
-    await new Promise<void>((resolve, reject) =>
-      this.listen(dataCallback, reconnectCallback, changedCallback, disconnectCallback, resolve, reject),
-    );
+    await new Promise<void>((resolve, reject) => {
+      this._rejectConnect = reject;
+      this.listen(
+        dataCallback,
+        reconnectCallback,
+        changedCallback,
+        disconnectCallback,
+        () => {
+          this._rejectConnect = undefined;
+          resolve();
+        },
+        (reason) => {
+          this._rejectConnect = undefined;
+          reject(reason);
+        },
+      );
+    });
     this._initialized = true;
   }
 
   async disconnect() {
     this._logger?.debug('Disconnecting gRPC sync connection');
+    this._disconnected = true;
+    this._rejectConnect?.(new Error('gRPC client disconnected before connecting'));
+    this._rejectConnect = undefined;
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = undefined;
+    }
     closeStreamIfDefined(this._syncStream);
     this._syncClient.close();
   }
@@ -111,6 +135,10 @@ export class GrpcFetch implements DataFetch {
     try {
       // wait for connection to be stable
       this._syncClient.waitForReady(Date.now() + this._deadlineMs, (err) => {
+        if (this._disconnected) {
+          rejectConnect?.(err ?? new Error('gRPC client disconnected before connecting'));
+          return;
+        }
         if (err) {
           this.handleError(
             err as Error,
@@ -205,8 +233,16 @@ export class GrpcFetch implements DataFetch {
     changedCallback: (flagsChanged: string[]) => void,
     disconnectCallback: (message: string) => void,
   ) {
-    setTimeout(
-      () => this.listen(dataCallback, reconnectCallback, changedCallback, disconnectCallback),
+    if (this._disconnected) {
+      return;
+    }
+    this._reconnectTimer = setTimeout(
+      () => {
+        this._reconnectTimer = undefined;
+        if (!this._disconnected) {
+          this.listen(dataCallback, reconnectCallback, changedCallback, disconnectCallback);
+        }
+      },
       this._errorThrottled ? this._maxBackoffMs : 0,
     );
     this._errorThrottled = false;


### PR DESCRIPTION
## This PR

- retains and cancels pending reconnect timers in both flagd gRPC transports
- prevents ready and retry callbacks from reopening clients after shutdown
- rejects an in-flight initial connection when shutdown happens before the first ready payload
- covers retry cancellation and both startup race windows with deterministic tests

### Related Issues

Fixes #1484

### Notes

Both gRPC implementations scheduled reconnects without retaining the timer handle. A queued callback could therefore call `listen()` after `disconnect()` had closed the client. Shutdown during initial connection setup could also leave the connection promise unsettled.

### How to test

- `npx jest --config libs/providers/flagd/jest.config.ts --runInBand libs/providers/flagd/src/lib/flagd-provider.spec.ts libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.spec.ts` — 2 suites, 29 tests passed
- `npx nx run providers-flagd:test --skip-nx-cache --runInBand` — 6 suites, 165 tests passed
- `npx nx run providers-flagd:lint --skip-nx-cache` — passed with 0 errors and the existing warning baseline
- `npx tsc --noEmit -p libs/providers/flagd/tsconfig.lib.json` — passed
- Prettier and `git diff --check` — passed