### PR TITLE
feat(growthbook): map targetingKey to id and support the tracking API

### DIFF
--- a/libs/providers/growthbook-client/README.md
+++ b/libs/providers/growthbook-client/README.md
@@ -35,6 +35,18 @@ const initOptions: InitOptions = {
 OpenFeature.setProvider(new GrowthbookClientProvider(gbContext, initOptions));
 ```
 
+## Evaluation context
+
+GrowthBook buckets users on the `id` attribute. The provider maps OpenFeature's
+`targetingKey` onto `id` for you, so a standard evaluation context works:
+
+```typescript
+await client.getBooleanValue('my-flag', false, { targetingKey: 'user-123' });
+```
+
+If you set an `id` attribute explicitly it takes precedence over `targetingKey`.
+All other attributes are passed through to GrowthBook unchanged.
+
 ## Building
 
 Run `nx package providers-growthbook-client` to build the library.

--- a/libs/providers/growthbook-client/README.md
+++ b/libs/providers/growthbook-client/README.md
@@ -47,6 +47,16 @@ await client.getBooleanValue('my-flag', false, { targetingKey: 'user-123' });
 If you set an `id` attribute explicitly it takes precedence over `targetingKey`.
 All other attributes are passed through to GrowthBook unchanged.
 
+## Tracking
+
+OpenFeature tracking events are forwarded to GrowthBook via `logEvent`. The web
+client attributes events to the current context set through
+`OpenFeature.setContext`.
+
+```typescript
+client.track('purchase', { value: 42 });
+```
+
 ## Building
 
 Run `nx package providers-growthbook-client` to build the library.

--- a/libs/providers/growthbook-client/README.md
+++ b/libs/providers/growthbook-client/README.md
@@ -45,7 +45,9 @@ await client.getBooleanValue('my-flag', false, { targetingKey: 'user-123' });
 ```
 
 If you set an `id` attribute explicitly it takes precedence over `targetingKey`.
-All other attributes are passed through to GrowthBook unchanged.
+All attributes — the targeting key included, under its own `targetingKey` name —
+pass through to GrowthBook unchanged, so existing rules that reference
+`targetingKey` directly keep matching.
 
 ## Tracking
 

--- a/libs/providers/growthbook-client/package.json
+++ b/libs/providers/growthbook-client/package.json
@@ -17,7 +17,7 @@
     "current-version": "echo $npm_package_version"
   },
   "peerDependencies": {
-    "@growthbook/growthbook": "^1.0.0",
-    "@openfeature/web-sdk": "^1.0.0"
+    "@growthbook/growthbook": "^1.4.0",
+    "@openfeature/web-sdk": "^1.3.0"
   }
 }

--- a/libs/providers/growthbook-client/src/lib/context-mapper.spec.ts
+++ b/libs/providers/growthbook-client/src/lib/context-mapper.spec.ts
@@ -1,0 +1,33 @@
+import { toAttributes } from './context-mapper';
+
+describe('toAttributes', () => {
+  it('maps targetingKey onto the id attribute GrowthBook buckets on', () => {
+    expect(toAttributes({ targetingKey: 'user-123' })).toEqual({ id: 'user-123' });
+  });
+
+  it('passes other attributes through untouched', () => {
+    expect(toAttributes({ targetingKey: 'user-123', country: 'US', premium: true })).toEqual({
+      id: 'user-123',
+      country: 'US',
+      premium: true,
+    });
+  });
+
+  it('does not leak targetingKey through as its own attribute', () => {
+    expect(toAttributes({ targetingKey: 'user-123' })).not.toHaveProperty('targetingKey');
+  });
+
+  it('prefers an explicit id over targetingKey', () => {
+    expect(toAttributes({ targetingKey: 'from-targeting-key', id: 'explicit' })).toEqual({
+      id: 'explicit',
+    });
+  });
+
+  it('leaves attributes alone when there is no targeting key', () => {
+    expect(toAttributes({ country: 'US' })).toEqual({ country: 'US' });
+  });
+
+  it('handles an empty context', () => {
+    expect(toAttributes({})).toEqual({});
+  });
+});

--- a/libs/providers/growthbook-client/src/lib/context-mapper.spec.ts
+++ b/libs/providers/growthbook-client/src/lib/context-mapper.spec.ts
@@ -2,24 +2,26 @@ import { toAttributes } from './context-mapper';
 
 describe('toAttributes', () => {
   it('maps targetingKey onto the id attribute GrowthBook buckets on', () => {
-    expect(toAttributes({ targetingKey: 'user-123' })).toEqual({ id: 'user-123' });
+    expect(toAttributes({ targetingKey: 'user-123' })).toEqual({ id: 'user-123', targetingKey: 'user-123' });
   });
 
   it('passes other attributes through untouched', () => {
     expect(toAttributes({ targetingKey: 'user-123', country: 'US', premium: true })).toEqual({
       id: 'user-123',
+      targetingKey: 'user-123',
       country: 'US',
       premium: true,
     });
   });
 
-  it('does not leak targetingKey through as its own attribute', () => {
-    expect(toAttributes({ targetingKey: 'user-123' })).not.toHaveProperty('targetingKey');
+  it('also preserves targetingKey verbatim for rules that reference it directly', () => {
+    expect(toAttributes({ targetingKey: 'user-123' })).toHaveProperty('targetingKey', 'user-123');
   });
 
   it('prefers an explicit id over targetingKey', () => {
     expect(toAttributes({ targetingKey: 'from-targeting-key', id: 'explicit' })).toEqual({
       id: 'explicit',
+      targetingKey: 'from-targeting-key',
     });
   });
 

--- a/libs/providers/growthbook-client/src/lib/context-mapper.ts
+++ b/libs/providers/growthbook-client/src/lib/context-mapper.ts
@@ -1,0 +1,25 @@
+import type { EvaluationContext } from '@openfeature/web-sdk';
+import type { Attributes } from '@growthbook/growthbook';
+
+/**
+ * Convert an OpenFeature evaluation context into GrowthBook attributes.
+ *
+ * GrowthBook buckets on the `id` attribute by default, while OpenFeature carries
+ * the subject in `targetingKey`. Without this mapping GrowthBook receives an
+ * attribute literally named `targetingKey` and nothing named `id`, so percentage
+ * rollouts return their default and experiments never assign a variation --
+ * silently, because a missing hash attribute is not an error.
+ *
+ * An explicitly supplied `id` wins over `targetingKey`: setting both is the
+ * portable pattern, and the caller's named attribute should not be overwritten.
+ */
+export function toAttributes(context: EvaluationContext): Attributes {
+  const { targetingKey, ...rest } = context;
+  const attributes: Attributes = { ...rest };
+
+  if (targetingKey !== undefined && attributes['id'] === undefined) {
+    attributes['id'] = targetingKey;
+  }
+
+  return attributes;
+}

--- a/libs/providers/growthbook-client/src/lib/context-mapper.ts
+++ b/libs/providers/growthbook-client/src/lib/context-mapper.ts
@@ -12,13 +12,18 @@ import type { Attributes } from '@growthbook/growthbook';
  *
  * An explicitly supplied `id` wins over `targetingKey`: setting both is the
  * portable pattern, and the caller's named attribute should not be overwritten.
+ * The targeting key is also forwarded under its own name, preserving the
+ * provider's original pass-through behaviour for rules that reference it.
  */
 export function toAttributes(context: EvaluationContext): Attributes {
-  const { targetingKey, ...rest } = context;
-  const attributes: Attributes = { ...rest };
+  // The whole context passes through unchanged, targetingKey included: the
+  // provider historically forwarded the evaluation context verbatim, so
+  // GrowthBook rules or custom-hash rollouts written against a "targetingKey"
+  // attribute must keep matching.
+  const attributes: Attributes = { ...context };
 
-  if (targetingKey !== undefined && attributes['id'] === undefined) {
-    attributes['id'] = targetingKey;
+  if (context.targetingKey !== undefined && attributes['id'] === undefined) {
+    attributes['id'] = context.targetingKey;
   }
 
   return attributes;

--- a/libs/providers/growthbook-client/src/lib/growthbook-client-provider.spec.ts
+++ b/libs/providers/growthbook-client/src/lib/growthbook-client-provider.spec.ts
@@ -177,4 +177,16 @@ describe('GrowthbookClientProvider', () => {
       });
     });
   });
+  describe('track', () => {
+    it('forwards the event to GrowthBook', () => {
+      const logEvent = jest.spyOn(GrowthBook.prototype, 'logEvent').mockResolvedValue(undefined);
+
+      // The web client's track takes (name, details): the context comes from
+      // OpenFeature.setContext, which the provider mirrors onto the GrowthBook
+      // client via onContextChange.
+      ofClient.track('purchase', { value: 42 });
+
+      expect(logEvent).toHaveBeenCalledWith('purchase', { value: 42 });
+    });
+  });
 });

--- a/libs/providers/growthbook-client/src/lib/growthbook-client-provider.ts
+++ b/libs/providers/growthbook-client/src/lib/growthbook-client-provider.ts
@@ -5,6 +5,7 @@ import type { InitOptions, Context } from '@growthbook/growthbook';
 import { GrowthBook } from '@growthbook/growthbook';
 import isEmpty from 'lodash.isempty';
 import translateResult from './translate-result';
+import { toAttributes } from './context-mapper';
 
 export class GrowthbookClientProvider implements Provider {
   metadata = {
@@ -36,7 +37,7 @@ export class GrowthbookClientProvider implements Provider {
 
     if (!isEmpty(evalContext)) {
       // Set attributes from the global provider context
-      await this.client.setAttributes(evalContext);
+      await this.client.setAttributes(toAttributes(evalContext));
     }
 
     await this.client.init(this._initOptions);
@@ -55,7 +56,7 @@ export class GrowthbookClientProvider implements Provider {
   }
 
   async onContextChange(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void> {
-    await this.client.setAttributes(newContext);
+    await this.client.setAttributes(toAttributes(newContext));
   }
 
   resolveBooleanEvaluation(flagKey: string, defaultValue: boolean): ResolutionDetails<boolean> {

--- a/libs/providers/growthbook-client/src/lib/growthbook-client-provider.ts
+++ b/libs/providers/growthbook-client/src/lib/growthbook-client-provider.ts
@@ -1,4 +1,10 @@
-import type { EvaluationContext, Provider, JsonValue, ResolutionDetails } from '@openfeature/web-sdk';
+import type {
+  EvaluationContext,
+  Provider,
+  JsonValue,
+  ResolutionDetails,
+  TrackingEventDetails,
+} from '@openfeature/web-sdk';
 import { GeneralError, OpenFeatureEventEmitter, ProviderEvents } from '@openfeature/web-sdk';
 
 import type { InitOptions, Context } from '@growthbook/growthbook';
@@ -81,5 +87,16 @@ export class GrowthbookClientProvider implements Provider {
     const res = this.client.evalFeature(flagKey);
 
     return translateResult(res, defaultValue);
+  }
+  /**
+   * Forward an OpenFeature tracking event to GrowthBook.
+   *
+   * The web client already carries the current context as its attributes, so the
+   * event is attributed to whoever OpenFeature.setContext last set. GrowthBook's
+   * logEvent returns a promise; it is intentionally not awaited, since track()
+   * is synchronous by contract and tracking must not block the caller.
+   */
+  track(trackingEventName: string, context: EvaluationContext, trackingEventDetails: TrackingEventDetails): void {
+    void this.client.logEvent(trackingEventName, trackingEventDetails);
   }
 }

--- a/libs/providers/growthbook/README.md
+++ b/libs/providers/growthbook/README.md
@@ -46,7 +46,9 @@ await client.getBooleanValue('my-flag', false, { targetingKey: 'user-123' });
 ```
 
 If you set an `id` attribute explicitly it takes precedence over `targetingKey`.
-All other attributes are passed through to GrowthBook unchanged.
+All attributes — the targeting key included, under its own `targetingKey` name —
+pass through to GrowthBook unchanged, so existing rules that reference
+`targetingKey` directly keep matching.
 
 ## Tracking
 

--- a/libs/providers/growthbook/README.md
+++ b/libs/providers/growthbook/README.md
@@ -48,6 +48,16 @@ await client.getBooleanValue('my-flag', false, { targetingKey: 'user-123' });
 If you set an `id` attribute explicitly it takes precedence over `targetingKey`.
 All other attributes are passed through to GrowthBook unchanged.
 
+## Tracking
+
+OpenFeature tracking events are forwarded to GrowthBook via `logEvent`. The
+evaluation context becomes the GrowthBook user context, so the event is
+attributed to the same user your flags are bucketed for.
+
+```typescript
+client.track('purchase', { targetingKey: 'user-123' }, { value: 42 });
+```
+
 ## Building
 
 Run `nx package providers-growthbook` to build the library.

--- a/libs/providers/growthbook/README.md
+++ b/libs/providers/growthbook/README.md
@@ -36,6 +36,18 @@ const initOptions: InitOptions = {
 OpenFeature.setProvider(new GrowthbookProvider(gbClientOptions, initOptions));
 ```
 
+## Evaluation context
+
+GrowthBook buckets users on the `id` attribute. The provider maps OpenFeature's
+`targetingKey` onto `id` for you, so a standard evaluation context works:
+
+```typescript
+await client.getBooleanValue('my-flag', false, { targetingKey: 'user-123' });
+```
+
+If you set an `id` attribute explicitly it takes precedence over `targetingKey`.
+All other attributes are passed through to GrowthBook unchanged.
+
 ## Building
 
 Run `nx package providers-growthbook` to build the library.

--- a/libs/providers/growthbook/package.json
+++ b/libs/providers/growthbook/package.json
@@ -14,8 +14,8 @@
     "current-version": "echo $npm_package_version"
   },
   "peerDependencies": {
-    "@growthbook/growthbook": "^1.3.1",
-    "@openfeature/server-sdk": "^1.13.0"
+    "@growthbook/growthbook": "^1.4.0",
+    "@openfeature/server-sdk": "^1.16.0"
   },
   "dependencies": {}
 }

--- a/libs/providers/growthbook/src/lib/context-mapper.spec.ts
+++ b/libs/providers/growthbook/src/lib/context-mapper.spec.ts
@@ -1,0 +1,33 @@
+import { toAttributes } from './context-mapper';
+
+describe('toAttributes', () => {
+  it('maps targetingKey onto the id attribute GrowthBook buckets on', () => {
+    expect(toAttributes({ targetingKey: 'user-123' })).toEqual({ id: 'user-123' });
+  });
+
+  it('passes other attributes through untouched', () => {
+    expect(toAttributes({ targetingKey: 'user-123', country: 'US', premium: true })).toEqual({
+      id: 'user-123',
+      country: 'US',
+      premium: true,
+    });
+  });
+
+  it('does not leak targetingKey through as its own attribute', () => {
+    expect(toAttributes({ targetingKey: 'user-123' })).not.toHaveProperty('targetingKey');
+  });
+
+  it('prefers an explicit id over targetingKey', () => {
+    expect(toAttributes({ targetingKey: 'from-targeting-key', id: 'explicit' })).toEqual({
+      id: 'explicit',
+    });
+  });
+
+  it('leaves attributes alone when there is no targeting key', () => {
+    expect(toAttributes({ country: 'US' })).toEqual({ country: 'US' });
+  });
+
+  it('handles an empty context', () => {
+    expect(toAttributes({})).toEqual({});
+  });
+});

--- a/libs/providers/growthbook/src/lib/context-mapper.spec.ts
+++ b/libs/providers/growthbook/src/lib/context-mapper.spec.ts
@@ -2,24 +2,26 @@ import { toAttributes } from './context-mapper';
 
 describe('toAttributes', () => {
   it('maps targetingKey onto the id attribute GrowthBook buckets on', () => {
-    expect(toAttributes({ targetingKey: 'user-123' })).toEqual({ id: 'user-123' });
+    expect(toAttributes({ targetingKey: 'user-123' })).toEqual({ id: 'user-123', targetingKey: 'user-123' });
   });
 
   it('passes other attributes through untouched', () => {
     expect(toAttributes({ targetingKey: 'user-123', country: 'US', premium: true })).toEqual({
       id: 'user-123',
+      targetingKey: 'user-123',
       country: 'US',
       premium: true,
     });
   });
 
-  it('does not leak targetingKey through as its own attribute', () => {
-    expect(toAttributes({ targetingKey: 'user-123' })).not.toHaveProperty('targetingKey');
+  it('also preserves targetingKey verbatim for rules that reference it directly', () => {
+    expect(toAttributes({ targetingKey: 'user-123' })).toHaveProperty('targetingKey', 'user-123');
   });
 
   it('prefers an explicit id over targetingKey', () => {
     expect(toAttributes({ targetingKey: 'from-targeting-key', id: 'explicit' })).toEqual({
       id: 'explicit',
+      targetingKey: 'from-targeting-key',
     });
   });
 

--- a/libs/providers/growthbook/src/lib/context-mapper.ts
+++ b/libs/providers/growthbook/src/lib/context-mapper.ts
@@ -1,0 +1,25 @@
+import type { EvaluationContext } from '@openfeature/server-sdk';
+import type { Attributes } from '@growthbook/growthbook';
+
+/**
+ * Convert an OpenFeature evaluation context into GrowthBook attributes.
+ *
+ * GrowthBook buckets on the `id` attribute by default, while OpenFeature carries
+ * the subject in `targetingKey`. Without this mapping GrowthBook receives an
+ * attribute literally named `targetingKey` and nothing named `id`, so percentage
+ * rollouts return their default and experiments never assign a variation --
+ * silently, because a missing hash attribute is not an error.
+ *
+ * An explicitly supplied `id` wins over `targetingKey`: setting both is the
+ * portable pattern, and the caller's named attribute should not be overwritten.
+ */
+export function toAttributes(context: EvaluationContext): Attributes {
+  const { targetingKey, ...rest } = context;
+  const attributes: Attributes = { ...rest };
+
+  if (targetingKey !== undefined && attributes['id'] === undefined) {
+    attributes['id'] = targetingKey;
+  }
+
+  return attributes;
+}

--- a/libs/providers/growthbook/src/lib/context-mapper.ts
+++ b/libs/providers/growthbook/src/lib/context-mapper.ts
@@ -12,13 +12,18 @@ import type { Attributes } from '@growthbook/growthbook';
  *
  * An explicitly supplied `id` wins over `targetingKey`: setting both is the
  * portable pattern, and the caller's named attribute should not be overwritten.
+ * The targeting key is also forwarded under its own name, preserving the
+ * provider's original pass-through behaviour for rules that reference it.
  */
 export function toAttributes(context: EvaluationContext): Attributes {
-  const { targetingKey, ...rest } = context;
-  const attributes: Attributes = { ...rest };
+  // The whole context passes through unchanged, targetingKey included: the
+  // provider historically forwarded the evaluation context verbatim, so
+  // GrowthBook rules or custom-hash rollouts written against a "targetingKey"
+  // attribute must keep matching.
+  const attributes: Attributes = { ...context };
 
-  if (targetingKey !== undefined && attributes['id'] === undefined) {
-    attributes['id'] = targetingKey;
+  if (context.targetingKey !== undefined && attributes['id'] === undefined) {
+    attributes['id'] = context.targetingKey;
   }
 
   return attributes;

--- a/libs/providers/growthbook/src/lib/growthbook-provider.spec.ts
+++ b/libs/providers/growthbook/src/lib/growthbook-provider.spec.ts
@@ -214,4 +214,17 @@ describe('GrowthbookProvider', () => {
       });
     });
   });
+  describe('track', () => {
+    it('forwards the event to GrowthBook with the mapped user context', async () => {
+      const logEvent = jest.spyOn(GrowthBookClient.prototype, 'logEvent').mockImplementation(() => undefined);
+
+      ofClient.track('purchase', { targetingKey: 'user-123', country: 'US' }, { value: 42 });
+
+      expect(logEvent).toHaveBeenCalledWith(
+        'purchase',
+        { value: 42 },
+        { attributes: { id: 'user-123', country: 'US' } },
+      );
+    });
+  });
 });

--- a/libs/providers/growthbook/src/lib/growthbook-provider.spec.ts
+++ b/libs/providers/growthbook/src/lib/growthbook-provider.spec.ts
@@ -181,4 +181,37 @@ describe('GrowthbookProvider', () => {
       });
     });
   });
+  describe('evaluation context mapping', () => {
+    it('passes targetingKey to GrowthBook as the id attribute', async () => {
+      const evalFeature = jest.spyOn(GrowthBookClient.prototype, 'evalFeature').mockImplementation(() => ({
+        value: true,
+        source: 'defaultValue',
+        on: true,
+        off: false,
+        ruleId: '',
+      }));
+
+      await ofClient.getBooleanDetails(testFlagKey, false, { targetingKey: 'user-123', country: 'US' });
+
+      expect(evalFeature).toHaveBeenCalledWith(testFlagKey, {
+        attributes: { id: 'user-123', country: 'US' },
+      });
+    });
+
+    it('prefers an explicit id attribute over targetingKey', async () => {
+      const evalFeature = jest.spyOn(GrowthBookClient.prototype, 'evalFeature').mockImplementation(() => ({
+        value: true,
+        source: 'defaultValue',
+        on: true,
+        off: false,
+        ruleId: '',
+      }));
+
+      await ofClient.getBooleanDetails(testFlagKey, false, { targetingKey: 'ignored', id: 'explicit' });
+
+      expect(evalFeature).toHaveBeenCalledWith(testFlagKey, {
+        attributes: { id: 'explicit' },
+      });
+    });
+  });
 });

--- a/libs/providers/growthbook/src/lib/growthbook-provider.spec.ts
+++ b/libs/providers/growthbook/src/lib/growthbook-provider.spec.ts
@@ -194,7 +194,7 @@ describe('GrowthbookProvider', () => {
       await ofClient.getBooleanDetails(testFlagKey, false, { targetingKey: 'user-123', country: 'US' });
 
       expect(evalFeature).toHaveBeenCalledWith(testFlagKey, {
-        attributes: { id: 'user-123', country: 'US' },
+        attributes: { id: 'user-123', targetingKey: 'user-123', country: 'US' },
       });
     });
 
@@ -210,7 +210,7 @@ describe('GrowthbookProvider', () => {
       await ofClient.getBooleanDetails(testFlagKey, false, { targetingKey: 'ignored', id: 'explicit' });
 
       expect(evalFeature).toHaveBeenCalledWith(testFlagKey, {
-        attributes: { id: 'explicit' },
+        attributes: { id: 'explicit', targetingKey: 'ignored' },
       });
     });
   });
@@ -223,7 +223,7 @@ describe('GrowthbookProvider', () => {
       expect(logEvent).toHaveBeenCalledWith(
         'purchase',
         { value: 42 },
-        { attributes: { id: 'user-123', country: 'US' } },
+        { attributes: { id: 'user-123', targetingKey: 'user-123', country: 'US' } },
       );
     });
   });

--- a/libs/providers/growthbook/src/lib/growthbook-provider.ts
+++ b/libs/providers/growthbook/src/lib/growthbook-provider.ts
@@ -3,6 +3,7 @@ import { GrowthBookClient } from '@growthbook/growthbook';
 import type { EvaluationContext, Provider, JsonValue, ResolutionDetails } from '@openfeature/server-sdk';
 import { OpenFeatureEventEmitter, GeneralError, ProviderEvents } from '@openfeature/server-sdk';
 import translateResult from './translate-result';
+import { toAttributes } from './context-mapper';
 
 export class GrowthbookProvider implements Provider {
   metadata = {
@@ -31,7 +32,10 @@ export class GrowthbookProvider implements Provider {
   async initialize(evalContext?: EvaluationContext): Promise<void> {
     // Use context to construct the instance to instantiate GrowthBook
     const globalContext = {
-      globalAttributes: { ...this.options.globalAttributes, ...evalContext },
+      globalAttributes: {
+        ...this.options.globalAttributes,
+        ...(evalContext ? toAttributes(evalContext) : {}),
+      },
     };
     this._client = new GrowthBookClient({ ...this.options, ...globalContext });
 
@@ -56,7 +60,7 @@ export class GrowthbookProvider implements Provider {
     context: EvaluationContext,
   ): Promise<ResolutionDetails<boolean>> {
     const userContext = {
-      attributes: context,
+      attributes: toAttributes(context),
     };
 
     const res = this.client.evalFeature(flagKey, userContext);
@@ -70,7 +74,7 @@ export class GrowthbookProvider implements Provider {
     context: EvaluationContext,
   ): Promise<ResolutionDetails<string>> {
     const userContext = {
-      attributes: context,
+      attributes: toAttributes(context),
     };
 
     const res = this.client.evalFeature(flagKey, userContext);
@@ -84,7 +88,7 @@ export class GrowthbookProvider implements Provider {
     context: EvaluationContext,
   ): Promise<ResolutionDetails<number>> {
     const userContext = {
-      attributes: context,
+      attributes: toAttributes(context),
     };
 
     const res = this.client.evalFeature(flagKey, userContext);
@@ -98,7 +102,7 @@ export class GrowthbookProvider implements Provider {
     context: EvaluationContext,
   ): Promise<ResolutionDetails<U>> {
     const userContext = {
-      attributes: context,
+      attributes: toAttributes(context),
     };
 
     const res = this.client.evalFeature(flagKey, userContext);

--- a/libs/providers/growthbook/src/lib/growthbook-provider.ts
+++ b/libs/providers/growthbook/src/lib/growthbook-provider.ts
@@ -1,6 +1,12 @@
 import type { ClientOptions, InitOptions } from '@growthbook/growthbook';
 import { GrowthBookClient } from '@growthbook/growthbook';
-import type { EvaluationContext, Provider, JsonValue, ResolutionDetails } from '@openfeature/server-sdk';
+import type {
+  EvaluationContext,
+  Provider,
+  JsonValue,
+  ResolutionDetails,
+  TrackingEventDetails,
+} from '@openfeature/server-sdk';
 import { OpenFeatureEventEmitter, GeneralError, ProviderEvents } from '@openfeature/server-sdk';
 import translateResult from './translate-result';
 import { toAttributes } from './context-mapper';
@@ -108,5 +114,16 @@ export class GrowthbookProvider implements Provider {
     const res = this.client.evalFeature(flagKey, userContext);
 
     return translateResult(res, defaultValue);
+  }
+  /**
+   * Forward an OpenFeature tracking event to GrowthBook.
+   *
+   * The evaluation context becomes the GrowthBook user context, so the event is
+   * attributed to the same user the flag evaluations are bucketed for.
+   */
+  track(trackingEventName: string, context: EvaluationContext, trackingEventDetails: TrackingEventDetails): void {
+    this.client.logEvent(trackingEventName, trackingEventDetails, {
+      attributes: toAttributes(context),
+    });
   }
 }


### PR DESCRIPTION
## Summary

Two related changes to both GrowthBook providers, kept together because they share the context mapping:

1. Map OpenFeature's `targetingKey` onto GrowthBook's `id` attribute (fixes #1613).
2. Implement the provider `track()` hook against GrowthBook's `logEvent`.

## Root cause (targetingKey)

Both providers passed the evaluation context to GrowthBook verbatim:

- `growthbook-provider.ts` — `const userContext = { attributes: context }`
- `growthbook-client-provider.ts` — `setAttributes(evalContext)`

`EvaluationContext` is `{ targetingKey?: string } & Record<string, EvaluationContextValue>`, so GrowthBook received an attribute literally named `targetingKey` and nothing named `id`.

`id` is GrowthBook's default hash attribute. Without it (`@growthbook/growthbook` `core.ts`):

| Path | Behaviour with no `id` |
| --- | --- |
| `isIncludedInRollout` | returns `false` — a percentage rollout never matches |
| `runExperiment` | skips with variation `-1` — an experiment never assigns |

Nothing throws, so the flag simply appears to be off:

```ts
// feature configured with a 50% rollout
await client.getBooleanValue('my-flag', false, { targetingKey: 'user-123' });
// => always false, for every targetingKey
```

An explicitly supplied `id` takes precedence over `targetingKey`, so anyone already working around this by setting `id` directly is unaffected, and setting both (the portable pattern) keeps working.

The three other GrowthBook providers already do this mapping: [Python](https://github.com/growthbook/growthbook-openfeature-provider-python), [Java](https://github.com/growthbook/growthbook-openfeature-provider-java), [.NET](https://github.com/growthbook/growthbook-openfeature-provider-dot-net).

## Tracking

`track()` forwards to GrowthBook's `logEvent`. On the server the evaluation context becomes the GrowthBook user context, so events are attributed to the same user flags are bucketed for. On the web the client already holds the context set through `OpenFeature.setContext` (kept in sync by `onContextChange`), and the returned promise is deliberately not awaited since `track()` is synchronous by contract.

Peer floors are raised to what `track()` actually requires, verified against the published packages:

| Package | Peer | Was | Now | Why |
| --- | --- | --- | --- | --- |
| growthbook | `@openfeature/server-sdk` | `^1.13.0` | `^1.16.0` | `track` first appears in 1.16.0 |
| growthbook | `@growthbook/growthbook` | `^1.3.1` | `^1.4.0` | `logEvent` first appears in 1.4.0 |
| growthbook-client | `@openfeature/web-sdk` | `^1.0.0` | `^1.3.0` | `track` first appears in 1.3.0 |
| growthbook-client | `@growthbook/growthbook` | `^1.0.0` | `^1.4.0` | `logEvent` first appears in 1.4.0 |

## Test plan

- [x] New `context-mapper.spec.ts` in both projects covers targeting-key mapping, `id` precedence, and the no-targeting-key case

READMEs for both packages document the mapping and tracking.
