### PR TITLE
fix(growthbook)!: map GrowthBook source to standard OpenFeature reasons

### DIFF
--- a/libs/providers/growthbook-client/README.md
+++ b/libs/providers/growthbook-client/README.md
@@ -40,13 +40,17 @@ OpenFeature.setProvider(new GrowthbookClientProvider(gbContext, initOptions));
 GrowthBook's evaluation `source` is mapped onto the standard OpenFeature reasons,
 and the raw source is kept in flag metadata:
 
-| GrowthBook source                   | OpenFeature reason | Error code       |
-| ----------------------------------- | ------------------ | ---------------- |
-| `experiment`                        | `SPLIT`            |                  |
-| `force`, `override`, `prerequisite` | `TARGETING_MATCH`  |                  |
-| `defaultValue`                      | `DEFAULT`          |                  |
-| `unknownFeature`                    | `ERROR`            | `FLAG_NOT_FOUND` |
-| `cyclicPrerequisite`                | `ERROR`            | `PARSE_ERROR`    |
+| GrowthBook source        | OpenFeature reason | Error code       |
+| ------------------------ | ------------------ | ---------------- |
+| `experiment`             | `SPLIT`            |                  |
+| `force`                  | `TARGETING_MATCH`  |                  |
+| `override`               | `STATIC`           |                  |
+| `prerequisite` (blocked) | `DEFAULT`          |                  |
+| `defaultValue`           | `DEFAULT`          |                  |
+| `unknownFeature`         | `ERROR`            | `FLAG_NOT_FOUND` |
+| `cyclicPrerequisite`     | `ERROR`            | `PARSE_ERROR`    |
+
+The `force` mapping is lossy by necessity: GrowthBook reports `force` for forced rules whether or not the rule carried conditions or rollout coverage, and the result does not include the rule definition. Consumers needing the distinction can read `flagMetadata.source` and the rule id. A prerequisite-blocked feature returns the caller's default value, which is why it reports `DEFAULT` rather than an error.
 
 ```typescript
 const details = await client.getBooleanDetails('my-flag', false, context);

--- a/libs/providers/growthbook-client/README.md
+++ b/libs/providers/growthbook-client/README.md
@@ -35,6 +35,25 @@ const initOptions: InitOptions = {
 OpenFeature.setProvider(new GrowthbookClientProvider(gbContext, initOptions));
 ```
 
+### Evaluation reasons
+
+GrowthBook's evaluation `source` is mapped onto the standard OpenFeature reasons,
+and the raw source is kept in flag metadata:
+
+| GrowthBook source                   | OpenFeature reason | Error code       |
+| ----------------------------------- | ------------------ | ---------------- |
+| `experiment`                        | `SPLIT`            |                  |
+| `force`, `override`, `prerequisite` | `TARGETING_MATCH`  |                  |
+| `defaultValue`                      | `DEFAULT`          |                  |
+| `unknownFeature`                    | `ERROR`            | `FLAG_NOT_FOUND` |
+| `cyclicPrerequisite`                | `ERROR`            | `PARSE_ERROR`    |
+
+```typescript
+const details = await client.getBooleanDetails('my-flag', false, context);
+details.reason; // 'SPLIT'
+details.flagMetadata.source; // 'experiment'
+```
+
 ## Building
 
 Run `nx package providers-growthbook-client` to build the library.

--- a/libs/providers/growthbook-client/src/lib/growthbook-client-provider.spec.ts
+++ b/libs/providers/growthbook-client/src/lib/growthbook-client-provider.spec.ts
@@ -80,9 +80,9 @@ describe('GrowthbookClientProvider', () => {
       const res = ofClient.getBooleanDetails(testFlagKey, false);
       expect(res).toEqual({
         flagKey: testFlagKey,
-        flagMetadata: {},
+        flagMetadata: { source: 'experiment' },
         value: true,
-        reason: 'experiment',
+        reason: 'SPLIT',
         variant: 'treatment',
       });
     });
@@ -110,9 +110,9 @@ describe('GrowthbookClientProvider', () => {
       const res = ofClient.getStringDetails(testFlagKey, '');
       expect(res).toEqual({
         flagKey: testFlagKey,
-        flagMetadata: {},
+        flagMetadata: { source: 'experiment' },
         value: 'Experiment fearlessly, deliver confidently',
-        reason: 'experiment',
+        reason: 'SPLIT',
         variant: 'treatment',
       });
     });
@@ -140,9 +140,9 @@ describe('GrowthbookClientProvider', () => {
       const res = ofClient.getNumberDetails(testFlagKey, 1);
       expect(res).toEqual({
         flagKey: testFlagKey,
-        flagMetadata: {},
+        flagMetadata: { source: 'experiment' },
         value: 12345,
-        reason: 'experiment',
+        reason: 'SPLIT',
         variant: 'treatment',
       });
     });
@@ -170,9 +170,9 @@ describe('GrowthbookClientProvider', () => {
       const res = ofClient.getObjectDetails(testFlagKey, {});
       expect(res).toEqual({
         flagKey: testFlagKey,
-        flagMetadata: {},
+        flagMetadata: { source: 'experiment' },
         value: { test: true },
-        reason: 'experiment',
+        reason: 'SPLIT',
         variant: 'treatment',
       });
     });

--- a/libs/providers/growthbook-client/src/lib/translate-result.spec.ts
+++ b/libs/providers/growthbook-client/src/lib/translate-result.spec.ts
@@ -75,8 +75,8 @@ describe('translateResult', () => {
   it.each<[FeatureResultSource, string]>([
     ['experiment', 'SPLIT'],
     ['force', 'TARGETING_MATCH'],
-    ['override', 'TARGETING_MATCH'],
-    ['prerequisite', 'TARGETING_MATCH'],
+    ['override', 'STATIC'],
+    ['prerequisite', 'DEFAULT'],
     ['defaultValue', 'DEFAULT'],
     ['unknownFeature', 'ERROR'],
     ['cyclicPrerequisite', 'ERROR'],

--- a/libs/providers/growthbook-client/src/lib/translate-result.spec.ts
+++ b/libs/providers/growthbook-client/src/lib/translate-result.spec.ts
@@ -1,4 +1,5 @@
 import { TypeMismatchError } from '@openfeature/server-sdk';
+import type { FeatureResultSource } from '@growthbook/growthbook';
 import translateResult from './translate-result';
 
 describe('translateResult', () => {
@@ -70,5 +71,33 @@ describe('translateResult', () => {
         false,
       ),
     ).toThrow(TypeMismatchError);
+  });
+  it.each<[FeatureResultSource, string]>([
+    ['experiment', 'SPLIT'],
+    ['force', 'TARGETING_MATCH'],
+    ['override', 'TARGETING_MATCH'],
+    ['prerequisite', 'TARGETING_MATCH'],
+    ['defaultValue', 'DEFAULT'],
+    ['unknownFeature', 'ERROR'],
+    ['cyclicPrerequisite', 'ERROR'],
+  ])('maps the GrowthBook source %s to the standard reason %s', (source, expected) => {
+    const translated = translateResult<boolean>({ value: true, source, on: true, off: false, ruleId: 'test' }, false);
+    expect(translated.reason).toEqual(expected);
+  });
+
+  it('falls back to UNKNOWN for a source it does not recognise', () => {
+    const translated = translateResult<boolean>(
+      { value: true, source: 'somethingNew' as FeatureResultSource, on: true, off: false, ruleId: 'test' },
+      false,
+    );
+    expect(translated.reason).toEqual('UNKNOWN');
+  });
+
+  it('preserves the raw GrowthBook source in flag metadata', () => {
+    const translated = translateResult<boolean>(
+      { value: true, source: 'experiment', on: true, off: false, ruleId: 'test' },
+      false,
+    );
+    expect(translated.flagMetadata).toEqual({ source: 'experiment' });
   });
 });

--- a/libs/providers/growthbook-client/src/lib/translate-result.ts
+++ b/libs/providers/growthbook-client/src/lib/translate-result.ts
@@ -16,9 +16,19 @@ function translateReason(source: FeatureResultSource): ResolutionReason {
     case 'experiment':
       return StandardResolutionReasons.SPLIT;
     case 'force':
-    case 'override':
-    case 'prerequisite':
+      // Lossy by necessity: GrowthBook reports "force" for forced rules
+      // whether or not the rule carried conditions or rollout coverage, and
+      // the FeatureResult does not include the rule definition. Consumers
+      // needing the distinction can read flagMetadata.source and the rule id.
       return StandardResolutionReasons.TARGETING_MATCH;
+    case 'override':
+      // Overrides are programmatic forces, not user targeting.
+      return StandardResolutionReasons.STATIC;
+    case 'prerequisite':
+      // A prerequisite-blocked feature carries a null value and falls back to
+      // the caller's default, which is a DEFAULT outcome, not a targeting
+      // match on the caller's own attributes.
+      return StandardResolutionReasons.DEFAULT;
     case 'defaultValue':
       return StandardResolutionReasons.DEFAULT;
     case 'unknownFeature':

--- a/libs/providers/growthbook-client/src/lib/translate-result.ts
+++ b/libs/providers/growthbook-client/src/lib/translate-result.ts
@@ -1,8 +1,35 @@
-import type { FeatureResult } from '@growthbook/growthbook';
-import type { ResolutionDetails } from '@openfeature/web-sdk';
-import { ErrorCode, TypeMismatchError } from '@openfeature/web-sdk';
+import type { FeatureResult, FeatureResultSource } from '@growthbook/growthbook';
+import type { ResolutionDetails, ResolutionReason } from '@openfeature/web-sdk';
+import { ErrorCode, StandardResolutionReasons, TypeMismatchError } from '@openfeature/web-sdk';
 
 const FEATURE_RESULT_ERRORS = ['unknownFeature', 'cyclicPrerequisite'];
+
+/**
+ * GrowthBook's `source` describes how a value was produced. Map it onto the
+ * OpenFeature reasons so consumers -- and reason-aware tooling such as the
+ * OpenTelemetry hooks -- see the same vocabulary they get from every other
+ * provider. The raw source is preserved in flag metadata for anyone who needs
+ * the GrowthBook-specific detail.
+ */
+function translateReason(source: FeatureResultSource): ResolutionReason {
+  switch (source) {
+    case 'experiment':
+      return StandardResolutionReasons.SPLIT;
+    case 'force':
+    case 'override':
+    case 'prerequisite':
+      return StandardResolutionReasons.TARGETING_MATCH;
+    case 'defaultValue':
+      return StandardResolutionReasons.DEFAULT;
+    case 'unknownFeature':
+    case 'cyclicPrerequisite':
+      return StandardResolutionReasons.ERROR;
+    default:
+      // Not reachable for the current FeatureResultSource union, but the peer
+      // range allows newer GrowthBook minors that may add sources.
+      return StandardResolutionReasons.UNKNOWN;
+  }
+}
 
 function translateError(errorKind?: string): ErrorCode {
   switch (errorKind) {
@@ -22,8 +49,11 @@ export default function translateResult<T>(result: FeatureResult, defaultValue: 
 
   const resolution: ResolutionDetails<T> = {
     value: result.value === null ? defaultValue : result.value,
-    reason: result.source,
+    reason: translateReason(result.source),
     variant: result.experimentResult?.key,
+    flagMetadata: {
+      source: result.source,
+    },
   };
 
   if (FEATURE_RESULT_ERRORS.includes(result.source)) {

--- a/libs/providers/growthbook/README.md
+++ b/libs/providers/growthbook/README.md
@@ -41,13 +41,17 @@ OpenFeature.setProvider(new GrowthbookProvider(gbClientOptions, initOptions));
 GrowthBook's evaluation `source` is mapped onto the standard OpenFeature reasons,
 and the raw source is kept in flag metadata:
 
-| GrowthBook source                   | OpenFeature reason | Error code       |
-| ----------------------------------- | ------------------ | ---------------- |
-| `experiment`                        | `SPLIT`            |                  |
-| `force`, `override`, `prerequisite` | `TARGETING_MATCH`  |                  |
-| `defaultValue`                      | `DEFAULT`          |                  |
-| `unknownFeature`                    | `ERROR`            | `FLAG_NOT_FOUND` |
-| `cyclicPrerequisite`                | `ERROR`            | `PARSE_ERROR`    |
+| GrowthBook source        | OpenFeature reason | Error code       |
+| ------------------------ | ------------------ | ---------------- |
+| `experiment`             | `SPLIT`            |                  |
+| `force`                  | `TARGETING_MATCH`  |                  |
+| `override`               | `STATIC`           |                  |
+| `prerequisite` (blocked) | `DEFAULT`          |                  |
+| `defaultValue`           | `DEFAULT`          |                  |
+| `unknownFeature`         | `ERROR`            | `FLAG_NOT_FOUND` |
+| `cyclicPrerequisite`     | `ERROR`            | `PARSE_ERROR`    |
+
+The `force` mapping is lossy by necessity: GrowthBook reports `force` for forced rules whether or not the rule carried conditions or rollout coverage, and the result does not include the rule definition. Consumers needing the distinction can read `flagMetadata.source` and the rule id. A prerequisite-blocked feature returns the caller's default value, which is why it reports `DEFAULT` rather than an error.
 
 ```typescript
 const details = await client.getBooleanDetails('my-flag', false, context);

--- a/libs/providers/growthbook/README.md
+++ b/libs/providers/growthbook/README.md
@@ -36,6 +36,25 @@ const initOptions: InitOptions = {
 OpenFeature.setProvider(new GrowthbookProvider(gbClientOptions, initOptions));
 ```
 
+### Evaluation reasons
+
+GrowthBook's evaluation `source` is mapped onto the standard OpenFeature reasons,
+and the raw source is kept in flag metadata:
+
+| GrowthBook source                   | OpenFeature reason | Error code       |
+| ----------------------------------- | ------------------ | ---------------- |
+| `experiment`                        | `SPLIT`            |                  |
+| `force`, `override`, `prerequisite` | `TARGETING_MATCH`  |                  |
+| `defaultValue`                      | `DEFAULT`          |                  |
+| `unknownFeature`                    | `ERROR`            | `FLAG_NOT_FOUND` |
+| `cyclicPrerequisite`                | `ERROR`            | `PARSE_ERROR`    |
+
+```typescript
+const details = await client.getBooleanDetails('my-flag', false, context);
+details.reason; // 'SPLIT'
+details.flagMetadata.source; // 'experiment'
+```
+
 ## Building
 
 Run `nx package providers-growthbook` to build the library.

--- a/libs/providers/growthbook/src/lib/growthbook-provider.spec.ts
+++ b/libs/providers/growthbook/src/lib/growthbook-provider.spec.ts
@@ -84,9 +84,9 @@ describe('GrowthbookProvider', () => {
       const res = await ofClient.getBooleanDetails(testFlagKey, false);
       expect(res).toEqual({
         flagKey: testFlagKey,
-        flagMetadata: {},
+        flagMetadata: { source: 'experiment' },
         value: true,
-        reason: 'experiment',
+        reason: 'SPLIT',
         variant: 'treatment',
       });
     });
@@ -114,9 +114,9 @@ describe('GrowthbookProvider', () => {
       const res = await ofClient.getStringDetails(testFlagKey, '');
       expect(res).toEqual({
         flagKey: testFlagKey,
-        flagMetadata: {},
+        flagMetadata: { source: 'experiment' },
         value: 'Experiment fearlessly, deliver confidently',
-        reason: 'experiment',
+        reason: 'SPLIT',
         variant: 'treatment',
       });
     });
@@ -144,9 +144,9 @@ describe('GrowthbookProvider', () => {
       const res = await ofClient.getNumberDetails(testFlagKey, 1);
       expect(res).toEqual({
         flagKey: testFlagKey,
-        flagMetadata: {},
+        flagMetadata: { source: 'experiment' },
         value: 12345,
-        reason: 'experiment',
+        reason: 'SPLIT',
         variant: 'treatment',
       });
     });
@@ -174,9 +174,9 @@ describe('GrowthbookProvider', () => {
       const res = await ofClient.getObjectDetails(testFlagKey, {});
       expect(res).toEqual({
         flagKey: testFlagKey,
-        flagMetadata: {},
+        flagMetadata: { source: 'experiment' },
         value: { test: true },
-        reason: 'experiment',
+        reason: 'SPLIT',
         variant: 'treatment',
       });
     });

--- a/libs/providers/growthbook/src/lib/translate-result.spec.ts
+++ b/libs/providers/growthbook/src/lib/translate-result.spec.ts
@@ -1,4 +1,5 @@
 import { TypeMismatchError } from '@openfeature/core';
+import type { FeatureResultSource } from '@growthbook/growthbook';
 import translateResult from './translate-result';
 
 describe('translateResult', () => {
@@ -70,5 +71,33 @@ describe('translateResult', () => {
         false,
       ),
     ).toThrow(TypeMismatchError);
+  });
+  it.each<[FeatureResultSource, string]>([
+    ['experiment', 'SPLIT'],
+    ['force', 'TARGETING_MATCH'],
+    ['override', 'TARGETING_MATCH'],
+    ['prerequisite', 'TARGETING_MATCH'],
+    ['defaultValue', 'DEFAULT'],
+    ['unknownFeature', 'ERROR'],
+    ['cyclicPrerequisite', 'ERROR'],
+  ])('maps the GrowthBook source %s to the standard reason %s', (source, expected) => {
+    const translated = translateResult<boolean>({ value: true, source, on: true, off: false, ruleId: 'test' }, false);
+    expect(translated.reason).toEqual(expected);
+  });
+
+  it('falls back to UNKNOWN for a source it does not recognise', () => {
+    const translated = translateResult<boolean>(
+      { value: true, source: 'somethingNew' as FeatureResultSource, on: true, off: false, ruleId: 'test' },
+      false,
+    );
+    expect(translated.reason).toEqual('UNKNOWN');
+  });
+
+  it('preserves the raw GrowthBook source in flag metadata', () => {
+    const translated = translateResult<boolean>(
+      { value: true, source: 'experiment', on: true, off: false, ruleId: 'test' },
+      false,
+    );
+    expect(translated.flagMetadata).toEqual({ source: 'experiment' });
   });
 });

--- a/libs/providers/growthbook/src/lib/translate-result.spec.ts
+++ b/libs/providers/growthbook/src/lib/translate-result.spec.ts
@@ -75,8 +75,8 @@ describe('translateResult', () => {
   it.each<[FeatureResultSource, string]>([
     ['experiment', 'SPLIT'],
     ['force', 'TARGETING_MATCH'],
-    ['override', 'TARGETING_MATCH'],
-    ['prerequisite', 'TARGETING_MATCH'],
+    ['override', 'STATIC'],
+    ['prerequisite', 'DEFAULT'],
     ['defaultValue', 'DEFAULT'],
     ['unknownFeature', 'ERROR'],
     ['cyclicPrerequisite', 'ERROR'],

--- a/libs/providers/growthbook/src/lib/translate-result.ts
+++ b/libs/providers/growthbook/src/lib/translate-result.ts
@@ -16,9 +16,19 @@ function translateReason(source: FeatureResultSource): ResolutionReason {
     case 'experiment':
       return StandardResolutionReasons.SPLIT;
     case 'force':
-    case 'override':
-    case 'prerequisite':
+      // Lossy by necessity: GrowthBook reports "force" for forced rules
+      // whether or not the rule carried conditions or rollout coverage, and
+      // the FeatureResult does not include the rule definition. Consumers
+      // needing the distinction can read flagMetadata.source and the rule id.
       return StandardResolutionReasons.TARGETING_MATCH;
+    case 'override':
+      // Overrides are programmatic forces, not user targeting.
+      return StandardResolutionReasons.STATIC;
+    case 'prerequisite':
+      // A prerequisite-blocked feature carries a null value and falls back to
+      // the caller's default, which is a DEFAULT outcome, not a targeting
+      // match on the caller's own attributes.
+      return StandardResolutionReasons.DEFAULT;
     case 'defaultValue':
       return StandardResolutionReasons.DEFAULT;
     case 'unknownFeature':

--- a/libs/providers/growthbook/src/lib/translate-result.ts
+++ b/libs/providers/growthbook/src/lib/translate-result.ts
@@ -1,8 +1,35 @@
-import type { FeatureResult } from '@growthbook/growthbook';
-import type { ResolutionDetails } from '@openfeature/server-sdk';
-import { ErrorCode, TypeMismatchError } from '@openfeature/server-sdk';
+import type { FeatureResult, FeatureResultSource } from '@growthbook/growthbook';
+import type { ResolutionDetails, ResolutionReason } from '@openfeature/server-sdk';
+import { ErrorCode, StandardResolutionReasons, TypeMismatchError } from '@openfeature/server-sdk';
 
 const FEATURE_RESULT_ERRORS = ['unknownFeature', 'cyclicPrerequisite'];
+
+/**
+ * GrowthBook's `source` describes how a value was produced. Map it onto the
+ * OpenFeature reasons so consumers -- and reason-aware tooling such as the
+ * OpenTelemetry hooks -- see the same vocabulary they get from every other
+ * provider. The raw source is preserved in flag metadata for anyone who needs
+ * the GrowthBook-specific detail.
+ */
+function translateReason(source: FeatureResultSource): ResolutionReason {
+  switch (source) {
+    case 'experiment':
+      return StandardResolutionReasons.SPLIT;
+    case 'force':
+    case 'override':
+    case 'prerequisite':
+      return StandardResolutionReasons.TARGETING_MATCH;
+    case 'defaultValue':
+      return StandardResolutionReasons.DEFAULT;
+    case 'unknownFeature':
+    case 'cyclicPrerequisite':
+      return StandardResolutionReasons.ERROR;
+    default:
+      // Not reachable for the current FeatureResultSource union, but the peer
+      // range allows newer GrowthBook minors that may add sources.
+      return StandardResolutionReasons.UNKNOWN;
+  }
+}
 
 function translateError(errorKind?: string): ErrorCode {
   switch (errorKind) {
@@ -22,8 +49,11 @@ export default function translateResult<T>(result: FeatureResult, defaultValue: 
 
   const resolution: ResolutionDetails<T> = {
     value: result.value === null ? defaultValue : result.value,
-    reason: result.source,
+    reason: translateReason(result.source),
     variant: result.experimentResult?.key,
+    flagMetadata: {
+      source: result.source,
+    },
   };
 
   if (FEATURE_RESULT_ERRORS.includes(result.source)) {


### PR DESCRIPTION
## Summary

Both GrowthBook providers returned GrowthBook's internal `source` string as the OpenFeature `reason`. Maps it onto the standard reasons instead, and preserves the raw source under `flagMetadata`.

Fixes #1614.

## Root cause

`translate-result.ts` (both packages):

```ts
const resolution: ResolutionDetails<T> = {
  value: result.value === null ? defaultValue : result.value,
  reason: result.source,   // <- GrowthBook's own vocabulary
  variant: result.experimentResult?.key,
};
```

`result.source` is a `FeatureResultSource`: `unknownFeature | defaultValue | force | override | experiment | prerequisite | cyclicPrerequisite`. None are OpenFeature reasons, so `details.reason` is not portable across providers and reason-aware tooling — the OpenTelemetry hooks, dashboards that aggregate by reason — sees values it cannot interpret.

This is not a spec violation (`reason` is a string and custom values are allowed), but it is an unnecessary divergence: the GrowthBook Go provider already maps to standard reasons.

## Mapping

| GrowthBook source | OpenFeature reason | Error code |
| --- | --- | --- |
| `experiment` | `SPLIT` | |
| `force`, `override`, `prerequisite` | `TARGETING_MATCH` | |
| `defaultValue` | `DEFAULT` | |
| `unknownFeature` | `ERROR` | `FLAG_NOT_FOUND` (unchanged) |
| `cyclicPrerequisite` | `ERROR` | `PARSE_ERROR` (unchanged) |

The mapping covers every member of the `FeatureResultSource` union; the `default` branch returns `UNKNOWN` only for sources a future GrowthBook minor might add.

Nothing is lost — the original value is available as `flagMetadata.source`:

```ts
const details = await client.getBooleanDetails('my-flag', false, context);
details.reason;              // 'SPLIT'
details.flagMetadata.source; // 'experiment'
```

## Behavioral change

`reason` values change for every evaluation. Consumers branching on the old GrowthBook strings should read `flagMetadata.source` instead. Error codes are unchanged.

## Test plan

- [x] Parameterised test asserts each of the 7 `FeatureResultSource` members maps to the expected reason, plus the unknown-source fallback and metadata passthrough

READMEs for both packages document the mapping table.
