### PR TITLE
feat(optimizely): add Node.js server provider

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -34,6 +34,8 @@ components:
     - markphelps
   libs/providers/flipt-web:
     - markphelps
+  libs/providers/optimizely:
+    - dflynn15
   libs/providers/unleash-web:
     - jarebudev
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -25,5 +25,6 @@
   "libs/providers/flagsmith": "0.1.2",
   "libs/hooks/debounce": "0.1.1",
   "libs/providers/localstorage": "0.1.2",
-  "libs/providers/azure-app-configuration": "0.1.1"
+  "libs/providers/azure-app-configuration": "0.1.1",
+  "libs/providers/optimizely": "0.1.0"
 }

--- a/libs/providers/optimizely/.eslintrc.json
+++ b/libs/providers/optimizely/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../../.eslintrc.json",
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": ["{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/libs/providers/optimizely/README.md
+++ b/libs/providers/optimizely/README.md
@@ -1,0 +1,136 @@
+# Optimizely Provider
+
+This is an [OpenFeature](https://openfeature.dev/) provider for the Optimizely Feature Experimentation JavaScript SDK (server-side Node.js applications). It adapts Optimizely decisions to the OpenFeature evaluation API while preserving the Optimizely variation key and decision metadata.
+
+## Framework compatibility
+
+The server provider is framework-agnostic: it can be registered once during application startup and used from any code that can run the Optimizely Node.js SDK.
+
+| Application surface                                           | Package and runtime                                                  | Status                                                                                |
+| ------------------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Next.js Server Components, server actions, and route handlers | `@openfeature/server-sdk` and this provider on the Node.js runtime   | Supported                                                                             |
+| Hono applications and route handlers                          | `@openfeature/server-sdk` and this provider with Hono's Node adapter | Supported                                                                             |
+| React client components                                       | `@openfeature/react-sdk` with a browser provider                     | Use the web provider; do not import this server package into a client bundle          |
+| Next.js Edge runtime or Cloudflare Workers                    | `@openfeature/web-sdk` + `@openfeature/optimizely-edge-provider`     | Use the separate Universal/Edge provider; this Node.js package is not edge-compatible |
+
+The framework labels above describe the integration boundary, not framework-specific test coverage. This package does not include Next.js, Hono, or React as dependencies. React clients require a browser-compatible provider registered with the web SDK. Edge deployments require a provider built on Optimizely's Universal entry point.
+
+## Installation
+
+```sh
+npm install @openfeature/optimizely-provider @openfeature/server-sdk @optimizely/optimizely-sdk
+```
+
+`@openfeature/server-sdk` and `@optimizely/optimizely-sdk` are peer dependencies. Use the Optimizely SDK v6 release supported by your application. The provider does not create a client from an SDK key; pass it a configured Optimizely client.
+
+## Setup
+
+The Optimizely SDK supports modular client construction. A typical application creates the client, passes it to the provider, and lets OpenFeature initialize the provider:
+
+```ts
+import { OpenFeature } from '@openfeature/server-sdk';
+import { createInstance } from '@optimizely/optimizely-sdk';
+import { OptimizelyProvider } from '@openfeature/optimizely-provider';
+
+const optimizely = createInstance({
+  sdkKey: process.env.OPTIMIZELY_SDK_KEY!,
+  // Use this when the datafile endpoint requires authentication.
+  datafileAccessToken: process.env.OPTIMIZELY_DATAFILE_ACCESS_TOKEN,
+});
+
+const provider = new OptimizelyProvider(optimizely);
+await OpenFeature.setProviderAndWait(provider);
+
+const client = OpenFeature.getClient();
+const enabled = await client.getBooleanValue('checkout-redesign', false, { targetingKey: 'user-123', country: 'US' });
+
+// On application shutdown:
+await OpenFeature.clearProviders();
+```
+
+See Optimizely's [JavaScript SDK initialization](https://docs.developers.optimizely.com/feature-experimentation/docs/initialize-the-javascript-sdk) and [modular SDK](https://docs.developers.optimizely.com/feature-experimentation/docs/javascript-sdk-v6) documentation for client options, datafile delivery, polling, and readiness.
+
+## Provider options and ownership
+
+```ts
+new OptimizelyProvider(client, {
+  closeClientOnShutdown: false,
+  decideOptions: [],
+});
+```
+
+The client is borrowed by default. `closeClientOnShutdown: false` means `onClose` will not dispose it; the application remains responsible for its lifetime. Set `closeClientOnShutdown: true` only when the provider owns the client and should close its polling, event-dispatch, and other resources when OpenFeature is cleared. Closing is idempotent.
+
+`decideOptions` is passed to each Optimizely `decideAsync` call. Use it for supported Optimizely decision options such as reasons or delivery rules; the provider does not mutate the array.
+
+The provider waits for the Optimizely client to be ready during initialization. Register it with `setProviderAndWait` when startup must fail fast if the datafile cannot be loaded.
+
+## Evaluation context
+
+`EvaluationContext.targetingKey` is required and is used as the Optimizely user ID. A missing targeting key is reported as an OpenFeature error; the provider does not invent a visitor ID. Other primitive context attributes are passed to Optimizely as user attributes. Keep attributes serializable and avoid putting secrets or personal data in them.
+
+```ts
+const context = {
+  targetingKey: 'user-123',
+  country: 'US',
+  plan: 'pro',
+  betaTester: true,
+};
+
+await OpenFeature.getClient().getBooleanValue('new-checkout', false, context);
+```
+
+## Decision and type mapping
+
+Each OpenFeature resolution performs one Optimizely `decideAsync` call. This is important because a decision may record an impression. The Optimizely `variationKey` is returned as the OpenFeature `variant`, and the `ruleKey` is exposed as evaluation metadata when available.
+
+Optimizely variables are mapped using the same variable-count convention as the OpenFeature Optimizely provider for Go:
+
+| Optimizely decision  | OpenFeature result                                                                                                    |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| No variables         | Boolean evaluation returns `decision.enabled`.                                                                        |
+| Exactly one variable | The typed resolver returns that variable's value. The variable name does not become part of the OpenFeature flag key. |
+| Multiple variables   | Object evaluation returns an object containing all variable names and values.                                         |
+
+The requested OpenFeature type must match the selected result. A string, number, boolean, or object request that cannot be represented by the decision returns `TYPE_MISMATCH` and the caller's default value. Missing flags return `FLAG_NOT_FOUND`. A disabled decision is still a successful resolution with `enabled: false` and is not treated as an error.
+
+Use an object flag when a decision intentionally exposes multiple Optimizely variables. For a single variable, use the corresponding OpenFeature typed getter and provide a default of the same type.
+
+## Provider events
+
+The provider forwards Optimizely configuration-update notifications as the OpenFeature `PROVIDER_CONFIGURATION_CHANGED` event. This allows applications to observe datafile updates without coupling application code to Optimizely's notification API. Readiness and initialization failures are surfaced through the normal OpenFeature provider lifecycle.
+
+See the OpenFeature [provider lifecycle and events](https://openfeature.dev/docs/reference/concepts/provider) and Optimizely's [notification listener](https://docs.developers.optimizely.com/feature-experimentation/docs/set-up-a-notification-listener-using-the-javascript-sdk) documentation.
+
+## Tracking
+
+`client.track(...)` is translated to an Optimizely user-context `trackEvent` call. The OpenFeature tracking value is passed as Optimizely's numeric `value` when it is numeric. An integer `revenue` detail is preserved when supplied; remaining details are sent as Optimizely event properties under `$opt_event_properties`. Tracking requires a targeting key and is subject to the Optimizely SDK's event-dispatch configuration.
+
+See Optimizely's [track event documentation](https://docs.developers.optimizely.com/feature-experimentation/docs/track-event-for-the-javascript-sdk).
+
+## Errors and limitations
+
+- This package is server-only and uses the asynchronous Optimizely `decideAsync` API. It is not a browser provider.
+- A targeting key is mandatory for evaluation and tracking.
+- The provider does not manage or expose Optimizely API/admin tokens. An SDK key is sufficient for the normal datafile flow; a datafile access token is only needed when the datafile endpoint is protected.
+- Human-readable Optimizely reason strings are not parsed to guess OpenFeature error codes.
+- Evaluation failures return the OpenFeature default value and include the provider error code in resolution details, as required by the OpenFeature API.
+- Keep the Optimizely client and provider on compatible major versions. The provider intentionally keeps both SDKs external rather than bundling them.
+
+## Deterministic tests and local development
+
+No Optimizely account, SDK key, environment variables, or network access is required to contribute to this provider. The tests use a committed static Optimizely datafile plus mocked clients and event dispatchers.
+
+The deterministic tests cover readiness, missing targeting keys, zero/one/multiple variables, each OpenFeature type, disabled decisions, variant and metadata mapping, one decision per evaluation, tracking, configuration changes, and client ownership on shutdown.
+
+From the repository root:
+
+```sh
+npx nx test optimizely --no-watchman
+npx nx lint optimizely
+npx nx package optimizely
+```
+
+## Contributing
+
+Run the checks above before opening a pull request. Follow the repository's [contribution guide](../../../CONTRIBUTING.md), keep the public package API documented, and use semantic commit/PR titles such as `feat(optimizely): add server provider`.

--- a/libs/providers/optimizely/README.md
+++ b/libs/providers/optimizely/README.md
@@ -2,18 +2,9 @@
 
 Use this provider to evaluate Optimizely Feature Experimentation flags through [OpenFeature](https://openfeature.dev/) in Node.js server applications. It preserves the Optimizely variation key and decision metadata in each OpenFeature resolution.
 
-## Framework compatibility
+## Runtime support
 
-The server provider is framework-agnostic: it can be registered once during application startup and used from any code that can run the Optimizely Node.js SDK.
-
-| Application surface                                           | Package and runtime                                                  | Status                                                                                |
-| ------------------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Next.js Server Components, server actions, and route handlers | `@openfeature/server-sdk` and this provider on the Node.js runtime   | Supported                                                                             |
-| Hono applications and route handlers                          | `@openfeature/server-sdk` and this provider with Hono's Node adapter | Supported                                                                             |
-| React client components                                       | `@openfeature/react-sdk` with a browser provider                     | Use the web provider; do not import this server package into a client bundle          |
-| Next.js Edge runtime or Cloudflare Workers                    | `@openfeature/web-sdk` + `@openfeature/optimizely-edge-provider`     | Use the separate Universal/Edge provider; this Node.js package is not edge-compatible |
-
-The framework labels above describe the integration boundary, not framework-specific test coverage. This package does not include Next.js, Hono, or React as dependencies. React clients require a browser-compatible provider registered with the web SDK. Edge deployments require a provider built on Optimizely's Universal entry point.
+This package is for Node.js server runtimes, including Next.js server code and Hono through its Node adapter. Do not import it into browser or Edge bundles. React clients require a browser provider registered with the OpenFeature web SDK; Edge deployments require a provider built on Optimizely's Universal entry point.
 
 ## Installation
 
@@ -130,7 +121,3 @@ npx nx test optimizely --no-watchman
 npx nx lint optimizely
 npx nx package optimizely
 ```
-
-## Contributing
-
-Run the checks above before opening a pull request. Follow the repository's [contribution guide](../../../CONTRIBUTING.md), keep the public package API documented, and use semantic commit/PR titles such as `feat(optimizely): add server provider`.

--- a/libs/providers/optimizely/README.md
+++ b/libs/providers/optimizely/README.md
@@ -1,6 +1,6 @@
 # Optimizely Provider
 
-This is an [OpenFeature](https://openfeature.dev/) provider for the Optimizely Feature Experimentation JavaScript SDK (server-side Node.js applications). It adapts Optimizely decisions to the OpenFeature evaluation API while preserving the Optimizely variation key and decision metadata.
+Use this provider to evaluate Optimizely Feature Experimentation flags through [OpenFeature](https://openfeature.dev/) in Node.js server applications. It preserves the Optimizely variation key and decision metadata in each OpenFeature resolution.
 
 ## Framework compatibility
 
@@ -25,7 +25,7 @@ npm install @openfeature/optimizely-provider @openfeature/server-sdk @optimizely
 
 ## Setup
 
-The Optimizely SDK supports modular client construction. A typical application creates the client, passes it to the provider, and lets OpenFeature initialize the provider:
+Create and configure the Optimizely client in application code, pass it to the provider, and let OpenFeature initialize it:
 
 ```ts
 import { OpenFeature } from '@openfeature/server-sdk';
@@ -82,7 +82,7 @@ await OpenFeature.getClient().getBooleanValue('new-checkout', false, context);
 
 ## Decision and type mapping
 
-Each OpenFeature resolution performs one Optimizely `decideAsync` call. This is important because a decision may record an impression. The Optimizely `variationKey` is returned as the OpenFeature `variant`, and the `ruleKey` is exposed as evaluation metadata when available.
+Each OpenFeature resolution performs one Optimizely `decideAsync` call because that decision may record an impression. The Optimizely `variationKey` is returned as the OpenFeature `variant`, and the `ruleKey` is exposed as evaluation metadata when available.
 
 Optimizely variables are mapped using the same variable-count convention as the OpenFeature Optimizely provider for Go:
 

--- a/libs/providers/optimizely/babel.config.json
+++ b/libs/providers/optimizely/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": [["minify", { "builtIns": false }]]
+}

--- a/libs/providers/optimizely/jest.config.cts
+++ b/libs/providers/optimizely/jest.config.cts
@@ -1,0 +1,10 @@
+module.exports = {
+  displayName: 'optimizely',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/providers/optimizely',
+};

--- a/libs/providers/optimizely/package.json
+++ b/libs/providers/optimizely/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@openfeature/optimizely-provider",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-feature/js-sdk-contrib.git",
+    "directory": "libs/providers/optimizely"
+  },
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi",
+    "current-version": "echo $npm_package_version"
+  },
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "@openfeature/server-sdk": "^1.17.0",
+    "@optimizely/optimizely-sdk": "^6.6.0"
+  }
+}

--- a/libs/providers/optimizely/project.json
+++ b/libs/providers/optimizely/project.json
@@ -1,0 +1,76 @@
+{
+  "name": "optimizely",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/providers/optimizely/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": ["dist/{projectRoot}"],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "{projectRoot}/jest.config.cts"
+      }
+    },
+    "package": {
+      "executor": "@nx/rollup:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "project": "libs/providers/optimizely/package.json",
+        "outputPath": "dist/libs/providers/optimizely",
+        "entryFile": "libs/providers/optimizely/src/index.ts",
+        "tsConfig": "libs/providers/optimizely/tsconfig.lib.json",
+        "compiler": "tsc",
+        "generateExportsField": true,
+        "umdName": "optimizely",
+        "external": "all",
+        "format": ["cjs", "esm"],
+        "assets": [
+          {
+            "glob": "package.json",
+            "input": "./assets",
+            "output": "./src/"
+          },
+          {
+            "glob": "LICENSE",
+            "input": "./",
+            "output": "./"
+          },
+          {
+            "glob": "README.md",
+            "input": "./libs/providers/optimizely",
+            "output": "./"
+          }
+        ]
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run publish-if-not-exists",
+        "cwd": "dist/libs/providers/optimizely"
+      },
+      "dependsOn": [
+        {
+          "projects": "self",
+          "target": "package"
+        }
+      ]
+    }
+  }
+}

--- a/libs/providers/optimizely/src/index.ts
+++ b/libs/providers/optimizely/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/optimizely-provider';

--- a/libs/providers/optimizely/src/lib/context-transformer.spec.ts
+++ b/libs/providers/optimizely/src/lib/context-transformer.spec.ts
@@ -1,0 +1,83 @@
+import { TargetingKeyMissingError } from '@openfeature/server-sdk';
+import type { EvaluationContext, Logger } from '@openfeature/server-sdk';
+import { transformContext } from './context-transformer';
+
+const logger: Logger = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+};
+
+describe('transformContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('maps targetingKey to the Optimizely user ID and omits it from attributes', () => {
+    expect(transformContext({ targetingKey: 'user-123', plan: 'pro' }, logger)).toEqual({
+      userId: 'user-123',
+      attributes: { plan: 'pro' },
+    });
+  });
+
+  it('preserves Optimizely-supported primitive attributes', () => {
+    expect(
+      transformContext(
+        {
+          targetingKey: 'user-123',
+          active: true,
+          age: 42,
+          nickname: 'Ada',
+          unset: null,
+        },
+        logger,
+      ),
+    ).toEqual({
+      userId: 'user-123',
+      attributes: {
+        active: true,
+        age: 42,
+        nickname: 'Ada',
+        unset: null,
+      },
+    });
+  });
+
+  it('converts valid Date attributes to ISO strings', () => {
+    const signupDate = new Date('2026-09-08T12:34:56.000Z');
+    const context = { targetingKey: 'user-123', signupDate } as unknown as EvaluationContext;
+
+    expect(transformContext(context, logger)).toEqual({
+      userId: 'user-123',
+      attributes: { signupDate: '2026-09-08T12:34:56.000Z' },
+    });
+  });
+
+  it('omits unsupported attribute values and warns once per omitted value', () => {
+    const context = {
+      targetingKey: 'user-123',
+      nested: { plan: 'pro' },
+      groups: ['admin'],
+      invalidDate: new Date('invalid'),
+      missing: undefined,
+    } as unknown as EvaluationContext;
+
+    expect(transformContext(context, logger)).toEqual({ userId: 'user-123', attributes: {} });
+    expect(logger.warn).toHaveBeenCalledTimes(4);
+    expect(logger.warn).toHaveBeenCalledWith("Ignoring unsupported Optimizely attribute 'nested'.");
+    expect(logger.warn).toHaveBeenCalledWith("Ignoring unsupported Optimizely attribute 'groups'.");
+    expect(logger.warn).toHaveBeenCalledWith("Ignoring unsupported Optimizely attribute 'invalidDate'.");
+    expect(logger.warn).toHaveBeenCalledWith("Ignoring unsupported Optimizely attribute 'missing'.");
+  });
+
+  it.each([
+    { context: {}, description: 'missing' },
+    { context: { targetingKey: '' }, description: 'empty' },
+    { context: { targetingKey: '   ' }, description: 'whitespace-only' },
+    { context: { targetingKey: 42 }, description: 'non-string' },
+    { context: { targetingKey: null }, description: 'null' },
+  ])('throws TargetingKeyMissingError for a $description targetingKey', ({ context }) => {
+    expect(() => transformContext(context as EvaluationContext, logger)).toThrow(TargetingKeyMissingError);
+  });
+});

--- a/libs/providers/optimizely/src/lib/context-transformer.ts
+++ b/libs/providers/optimizely/src/lib/context-transformer.ts
@@ -1,0 +1,36 @@
+import type { UserAttributes } from '@optimizely/optimizely-sdk';
+import { TargetingKeyMissingError } from '@openfeature/server-sdk';
+import type { EvaluationContext, Logger } from '@openfeature/server-sdk';
+
+export type OptimizelyContext = {
+  userId: string;
+  attributes: UserAttributes;
+};
+
+export function transformContext(context: EvaluationContext, logger: Logger): OptimizelyContext {
+  const targetingKey = context['targetingKey'];
+  if (typeof targetingKey !== 'string' || targetingKey.trim().length === 0) {
+    throw new TargetingKeyMissingError('Optimizely evaluations require a non-empty string targetingKey.');
+  }
+
+  const attributes: UserAttributes = {};
+  for (const [key, value] of Object.entries(context as Record<string, unknown>)) {
+    if (key === 'targetingKey') {
+      continue;
+    }
+
+    if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      attributes[key] = value;
+      continue;
+    }
+
+    if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      attributes[key] = value.toISOString();
+      continue;
+    }
+
+    logger.warn(`Ignoring unsupported Optimizely attribute '${key}'.`);
+  }
+
+  return { userId: targetingKey, attributes };
+}

--- a/libs/providers/optimizely/src/lib/decision-translator.spec.ts
+++ b/libs/providers/optimizely/src/lib/decision-translator.spec.ts
@@ -1,0 +1,115 @@
+import type { OptimizelyDecision } from '@optimizely/optimizely-sdk';
+import { GeneralError, StandardResolutionReasons, TypeMismatchError } from '@openfeature/server-sdk';
+import { translateDecision } from './decision-translator';
+
+function decision(overrides: Partial<OptimizelyDecision> = {}): OptimizelyDecision {
+  return {
+    enabled: true,
+    flagKey: 'flag-key',
+    reasons: [],
+    ruleKey: 'rule-key',
+    userContext: {} as OptimizelyDecision['userContext'],
+    variables: {},
+    variationKey: 'variation-key',
+    ...overrides,
+  };
+}
+
+describe('translateDecision', () => {
+  it('maps a flag without variables to its enabled state for a boolean evaluation', () => {
+    expect(translateDecision<boolean>(decision(), 'boolean')).toEqual({
+      value: true,
+      variant: 'variation-key',
+      flagMetadata: { ruleKey: 'rule-key' },
+      reason: StandardResolutionReasons.UNKNOWN,
+    });
+  });
+
+  it('uses the disabled reason while preserving the boolean enabled state', () => {
+    expect(translateDecision<boolean>(decision({ enabled: false }), 'boolean')).toEqual({
+      value: false,
+      variant: 'variation-key',
+      flagMetadata: { ruleKey: 'rule-key' },
+      reason: StandardResolutionReasons.DISABLED,
+    });
+  });
+
+  it.each(['string', 'number', 'object'] as const)(
+    'rejects a flag without variables for a %s evaluation',
+    (valueType) => {
+      expect(() => translateDecision(decision(), valueType)).toThrow(TypeMismatchError);
+    },
+  );
+
+  it.each([
+    ['boolean', true],
+    ['string', 'treatment'],
+    ['number', 42],
+    ['object', { theme: 'dark', quotas: [1, 2] }],
+    ['object', null],
+  ] as const)('maps a single matching %s variable', (valueType, value) => {
+    expect(translateDecision(decision({ variables: { variable: value } }), valueType)).toEqual({
+      value,
+      variant: 'variation-key',
+      flagMetadata: { ruleKey: 'rule-key' },
+      reason: StandardResolutionReasons.UNKNOWN,
+    });
+  });
+
+  it.each([
+    ['boolean', 'treatment'],
+    ['string', true],
+    ['number', '42'],
+    ['object', 'not-json-object'],
+  ] as const)('rejects a single variable when it does not match the requested %s type', (valueType, value) => {
+    expect(() => translateDecision(decision({ variables: { variable: value } }), valueType)).toThrow(TypeMismatchError);
+  });
+
+  it('maps multiple variables as an object evaluation', () => {
+    const variables = { color: 'blue', enabled: true, settings: { retries: 3 } };
+
+    expect(translateDecision(decision({ variables }), 'object')).toEqual({
+      value: variables,
+      variant: 'variation-key',
+      flagMetadata: { ruleKey: 'rule-key' },
+      reason: StandardResolutionReasons.UNKNOWN,
+    });
+  });
+
+  it.each(['boolean', 'string', 'number'] as const)('rejects multiple variables for a %s evaluation', (valueType) => {
+    expect(() => translateDecision(decision({ variables: { one: 1, two: 2 } }), valueType)).toThrow(TypeMismatchError);
+  });
+
+  it.each([{ variable: new Date('2026-09-08') }, { variable: Number.NaN }, { variable: { nested: undefined } }])(
+    'rejects a single non-JSON object variable',
+    (variables) => {
+      expect(() => translateDecision(decision({ variables }), 'object')).toThrow(TypeMismatchError);
+    },
+  );
+
+  it('rejects a multiple-variable result containing a non-JSON value', () => {
+    expect(() =>
+      translateDecision(decision({ variables: { valid: true, invalid: Number.POSITIVE_INFINITY } }), 'object'),
+    ).toThrow(TypeMismatchError);
+  });
+
+  it('throws a GeneralError using Optimizely reasons when the variation is absent', () => {
+    expect(() =>
+      translateDecision(decision({ variationKey: null, reasons: ['Unknown flag key: flag-key'] }), 'boolean'),
+    ).toThrow(new GeneralError('Unknown flag key: flag-key'));
+  });
+
+  it('uses a fallback GeneralError message when Optimizely provides no reasons', () => {
+    expect(() => translateDecision(decision({ variationKey: null }), 'boolean')).toThrow(
+      'Optimizely could not make a decision.',
+    );
+  });
+
+  it('omits rule metadata when Optimizely did not select a rule', () => {
+    expect(translateDecision<boolean>(decision({ ruleKey: null }), 'boolean')).toEqual({
+      value: true,
+      variant: 'variation-key',
+      reason: StandardResolutionReasons.UNKNOWN,
+    });
+  });
+});

--- a/libs/providers/optimizely/src/lib/decision-translator.ts
+++ b/libs/providers/optimizely/src/lib/decision-translator.ts
@@ -1,0 +1,101 @@
+import type { OptimizelyDecision } from '@optimizely/optimizely-sdk';
+import { GeneralError, StandardResolutionReasons, TypeMismatchError } from '@openfeature/server-sdk';
+import type { JsonValue, ResolutionDetails } from '@openfeature/server-sdk';
+
+export type EvaluationValueType = 'boolean' | 'string' | 'number' | 'object';
+
+export function translateDecision<T extends JsonValue>(
+  decision: OptimizelyDecision,
+  valueType: EvaluationValueType,
+): ResolutionDetails<T> {
+  if (decision.variationKey === null) {
+    throw new GeneralError(decision.reasons.join('; ') || 'Optimizely could not make a decision.');
+  }
+
+  const variables = Object.values(decision.variables);
+  const value = getValue(variables, decision.variables, decision.enabled, valueType);
+
+  return {
+    value: value as T,
+    variant: decision.variationKey,
+    ...(decision.ruleKey === null ? {} : { flagMetadata: { ruleKey: decision.ruleKey } }),
+    reason: decision.enabled ? StandardResolutionReasons.UNKNOWN : StandardResolutionReasons.DISABLED,
+  };
+}
+
+function getValue(
+  variables: unknown[],
+  variablesMap: Record<string, unknown>,
+  enabled: boolean,
+  valueType: EvaluationValueType,
+): JsonValue {
+  if (variables.length === 0) {
+    if (valueType === 'boolean') {
+      return enabled;
+    }
+    throwTypeMismatch(valueType, 'a flag with no variables');
+  }
+
+  if (variables.length > 1) {
+    if (valueType === 'object' && isJsonValue(variablesMap)) {
+      return variablesMap;
+    }
+    throwTypeMismatch(valueType, 'a flag with multiple variables');
+  }
+
+  const [variable] = variables;
+  if (isExpectedType(variable, valueType)) {
+    return variable;
+  }
+  throwTypeMismatch(valueType, `a ${describeValue(variable)} variable`);
+}
+
+function isExpectedType(value: unknown, valueType: EvaluationValueType): value is JsonValue {
+  switch (valueType) {
+    case 'boolean':
+    case 'string':
+    case 'number':
+      return typeof value === valueType;
+    case 'object':
+      return (value === null || typeof value === 'object') && isJsonValue(value);
+  }
+}
+
+function isJsonValue(value: unknown, visited = new Set<object>()): value is JsonValue {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') {
+    return true;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value);
+  }
+  if (typeof value !== 'object' || visited.has(value)) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    visited.add(value);
+    const isValid = value.every((item) => isJsonValue(item, visited));
+    visited.delete(value);
+    return isValid;
+  }
+  if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) {
+    return false;
+  }
+  visited.add(value);
+  const isValid = Object.values(value).every((item) => isJsonValue(item, visited));
+  visited.delete(value);
+  return isValid;
+}
+
+function throwTypeMismatch(valueType: EvaluationValueType, actual: string): never {
+  throw new TypeMismatchError(`Cannot resolve ${actual} as an OpenFeature ${valueType} value.`);
+}
+
+function describeValue(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  return typeof value;
+}

--- a/libs/providers/optimizely/src/lib/optimizely-provider.lifecycle.spec.ts
+++ b/libs/providers/optimizely/src/lib/optimizely-provider.lifecycle.spec.ts
@@ -1,0 +1,140 @@
+import { OptimizelyDecideOption, type Client, type EventTags } from '@optimizely/optimizely-sdk';
+import { ProviderEvents, type Logger } from '@openfeature/server-sdk';
+
+import { createStaticOptimizelyClient, OPTIMIZELY_TEST_FLAG_KEYS } from '../test/optimizely-datafile';
+import { OptimizelyProvider } from './optimizely-provider';
+
+const logger: Logger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+};
+
+describe('OptimizelyProvider lifecycle and side effects', () => {
+  it('shares concurrent initialization and cleans up when close races readiness', async () => {
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    const addNotificationListener = jest.fn().mockReturnValue(17);
+    const removeNotificationListener = jest.fn();
+    const client = {
+      onReady: jest.fn().mockReturnValue(ready),
+      close: jest.fn().mockResolvedValue(undefined),
+      notificationCenter: { addNotificationListener, removeNotificationListener },
+    } as unknown as Client;
+    const provider = new OptimizelyProvider(client);
+
+    const firstInitialization = provider.initialize();
+    const secondInitialization = provider.initialize();
+    const close = provider.onClose();
+    resolveReady();
+    await Promise.all([firstInitialization, secondInitialization, close]);
+
+    expect(client.onReady).toHaveBeenCalledTimes(1);
+    expect(addNotificationListener).toHaveBeenCalledTimes(1);
+    expect(removeNotificationListener).toHaveBeenCalledTimes(1);
+    expect(removeNotificationListener).toHaveBeenCalledWith(17);
+  });
+
+  it('registers one configuration listener and forwards updates', async () => {
+    const client = createStaticOptimizelyClient();
+    const addListener = jest.spyOn(client.notificationCenter, 'addNotificationListener');
+    const provider = new OptimizelyProvider(client);
+    const onConfigurationChanged = jest.fn();
+    provider.events.addHandler(ProviderEvents.ConfigurationChanged, onConfigurationChanged);
+
+    await provider.initialize();
+    await provider.initialize();
+    const callback = addListener.mock.calls[0]?.[1] as (() => void) | undefined;
+    callback?.();
+
+    expect(addListener).toHaveBeenCalledTimes(1);
+    expect(onConfigurationChanged).toHaveBeenCalledTimes(1);
+    await provider.onClose();
+    await client.close();
+  });
+
+  it('removes only its listener and borrows the client by default', async () => {
+    const client = createStaticOptimizelyClient();
+    const removeListener = jest.spyOn(client.notificationCenter, 'removeNotificationListener');
+    const close = jest.spyOn(client, 'close');
+    const provider = new OptimizelyProvider(client);
+
+    await provider.initialize();
+    await provider.onClose();
+    await provider.onClose();
+
+    expect(removeListener).toHaveBeenCalledTimes(1);
+    expect(close).not.toHaveBeenCalled();
+    await client.close();
+  });
+
+  it('closes an owned client once', async () => {
+    const client = createStaticOptimizelyClient();
+    const close = jest.spyOn(client, 'close');
+    const provider = new OptimizelyProvider(client, { closeClientOnShutdown: true });
+
+    await provider.initialize();
+    await Promise.all([provider.onClose(), provider.onClose()]);
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('makes one asynchronous Optimizely decision per resolution', async () => {
+    const client = createStaticOptimizelyClient();
+    const userContext = client.createUserContext('openfeature-user');
+    const decideAsync = jest.spyOn(userContext, 'decideAsync');
+    jest.spyOn(client, 'createUserContext').mockReturnValue(userContext);
+    const provider = new OptimizelyProvider(client);
+
+    await provider.initialize();
+    await provider.resolveStringEvaluation(
+      OPTIMIZELY_TEST_FLAG_KEYS.string,
+      'fallback',
+      { targetingKey: 'openfeature-user' },
+      logger,
+    );
+
+    expect(decideAsync).toHaveBeenCalledTimes(1);
+    await provider.onClose();
+    await client.close();
+  });
+
+  it('maps OpenFeature tracking details to Optimizely event tags', async () => {
+    const client = createStaticOptimizelyClient();
+    const userContext = client.createUserContext('openfeature-user');
+    const trackEvent = jest.spyOn(userContext, 'trackEvent');
+    jest.spyOn(client, 'createUserContext').mockReturnValue(userContext);
+    const provider = new OptimizelyProvider(client);
+
+    await provider.initialize();
+    provider.track(
+      'checkout',
+      { targetingKey: 'openfeature-user', plan: 'pro' },
+      { value: 9.5, revenue: 1200, coupon: 'SAVE' },
+    );
+
+    expect(trackEvent).toHaveBeenCalledWith('checkout', {
+      value: 9.5,
+      revenue: 1200,
+      $opt_event_properties: { coupon: 'SAVE' },
+    } satisfies EventTags);
+    await provider.onClose();
+    await client.close();
+  });
+
+  it('rejects decision options that remove variables', () => {
+    const client = createStaticOptimizelyClient();
+
+    expect(
+      () =>
+        new OptimizelyProvider(client, {
+          decideOptions: [OptimizelyDecideOption.EXCLUDE_VARIABLES],
+        }),
+    ).toThrow('EXCLUDE_VARIABLES');
+
+    return client.close();
+  });
+});

--- a/libs/providers/optimizely/src/lib/optimizely-provider.openfeature.spec.ts
+++ b/libs/providers/optimizely/src/lib/optimizely-provider.openfeature.spec.ts
@@ -1,0 +1,98 @@
+import { ErrorCode, OpenFeature, StandardResolutionReasons } from '@openfeature/server-sdk';
+import type { Client as OptimizelyClient } from '@optimizely/optimizely-sdk';
+
+import { OptimizelyProvider } from './optimizely-provider';
+import { createStaticOptimizelyClient, OPTIMIZELY_TEST_FLAG_KEYS } from '../test/optimizely-datafile';
+
+describe('OptimizelyProvider through OpenFeature', () => {
+  let optimizely: OptimizelyClient;
+
+  beforeEach(async () => {
+    optimizely = createStaticOptimizelyClient();
+    await OpenFeature.setProviderAndWait(new OptimizelyProvider(optimizely, { closeClientOnShutdown: true }));
+  });
+
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
+  });
+
+  it('evaluates all supported OpenFeature value types', async () => {
+    const client = OpenFeature.getClient({ targetingKey: 'openfeature-user' });
+
+    await expect(client.getBooleanValue(OPTIMIZELY_TEST_FLAG_KEYS.boolean, false)).resolves.toBe(true);
+    await expect(client.getStringValue(OPTIMIZELY_TEST_FLAG_KEYS.string, '')).resolves.toBe('hello');
+    await expect(client.getNumberValue(OPTIMIZELY_TEST_FLAG_KEYS.number, 0)).resolves.toBe(42.5);
+    await expect(client.getBooleanValue(OPTIMIZELY_TEST_FLAG_KEYS.boolVariable, false)).resolves.toBe(true);
+    await expect(client.getObjectValue(OPTIMIZELY_TEST_FLAG_KEYS.object, {})).resolves.toEqual({
+      color: 'blue',
+      count: 2,
+    });
+    await expect(client.getObjectValue(OPTIMIZELY_TEST_FLAG_KEYS.multiple, {})).resolves.toEqual({
+      first: 'one',
+      second: 7,
+    });
+  });
+
+  it('preserves the Optimizely variation and rule metadata in details', async () => {
+    const client = OpenFeature.getClient({ targetingKey: 'openfeature-user' });
+    const details = await client.getStringDetails(OPTIMIZELY_TEST_FLAG_KEYS.string, 'fallback');
+
+    expect(details.value).toBe('hello');
+    expect(details.variant).toBe('on');
+    expect(details.flagMetadata).toEqual(expect.objectContaining({ ruleKey: 'string-rule' }));
+  });
+
+  it('reports disabled decisions as successful disabled resolutions', async () => {
+    const client = OpenFeature.getClient({ targetingKey: 'openfeature-user' });
+    const details = await client.getBooleanDetails(OPTIMIZELY_TEST_FLAG_KEYS.disabled, true);
+
+    expect(details.value).toBe(false);
+    expect(details.reason).toBe(StandardResolutionReasons.DISABLED);
+    expect(details.errorCode).toBeUndefined();
+  });
+
+  it('returns the caller default and detailed error for missing flags', async () => {
+    const client = OpenFeature.getClient({ targetingKey: 'openfeature-user' });
+    const details = await client.getBooleanDetails('does-not-exist', true);
+
+    expect(details.value).toBe(true);
+    expect(details.reason).toBe(StandardResolutionReasons.ERROR);
+    expect(details.errorCode).toBe(ErrorCode.FLAG_NOT_FOUND);
+  });
+
+  it('returns a type mismatch when the requested OpenFeature type is incompatible', async () => {
+    const client = OpenFeature.getClient({ targetingKey: 'openfeature-user' });
+    const details = await client.getBooleanDetails(OPTIMIZELY_TEST_FLAG_KEYS.string, false);
+
+    expect(details.value).toBe(false);
+    expect(details.reason).toBe(StandardResolutionReasons.ERROR);
+    expect(details.errorCode).toBe(ErrorCode.TYPE_MISMATCH);
+  });
+
+  it('merges client context with per-evaluation context and forwards it to Optimizely', async () => {
+    const createUserContext = jest.spyOn(optimizely, 'createUserContext');
+    const client = OpenFeature.getClient({
+      targetingKey: 'base-user',
+      plan: 'pro',
+    });
+
+    await client.getBooleanValue(OPTIMIZELY_TEST_FLAG_KEYS.boolean, false, {
+      targetingKey: 'request-user',
+      region: 'us-east',
+    });
+
+    expect(createUserContext).toHaveBeenCalledWith('request-user', {
+      plan: 'pro',
+      region: 'us-east',
+    });
+  });
+
+  it('closes a provider-owned Optimizely client when the provider is replaced', async () => {
+    const close = jest.spyOn(optimizely, 'close');
+    await OpenFeature.clearProviders();
+
+    expect(close).toHaveBeenCalledTimes(1);
+    optimizely = createStaticOptimizelyClient();
+    await OpenFeature.setProviderAndWait(new OptimizelyProvider(optimizely, { closeClientOnShutdown: true }));
+  });
+});

--- a/libs/providers/optimizely/src/lib/optimizely-provider.spec.ts
+++ b/libs/providers/optimizely/src/lib/optimizely-provider.spec.ts
@@ -11,7 +11,7 @@ const logger: Logger = {
   debug: jest.fn(),
 };
 
-describe('OptimizelyProvider lifecycle and side effects', () => {
+describe('OptimizelyProvider', () => {
   it('shares concurrent initialization and cleans up when close races readiness', async () => {
     let resolveReady!: () => void;
     const ready = new Promise<void>((resolve) => {

--- a/libs/providers/optimizely/src/lib/optimizely-provider.ts
+++ b/libs/providers/optimizely/src/lib/optimizely-provider.ts
@@ -1,0 +1,203 @@
+import { NOTIFICATION_TYPES, OptimizelyDecideOption, type Client, type EventTags } from '@optimizely/optimizely-sdk';
+import {
+  FlagNotFoundError,
+  GeneralError,
+  OpenFeatureEventEmitter,
+  ProviderEvents,
+  ProviderNotReadyError,
+  type EvaluationContext,
+  type JsonValue,
+  type Logger,
+  type Provider,
+  type ResolutionDetails,
+  type TrackingEventDetails,
+} from '@openfeature/server-sdk';
+import { transformContext } from './context-transformer';
+import { translateDecision, type EvaluationValueType } from './decision-translator';
+
+export interface OptimizelyProviderOptions {
+  /** Close the supplied Optimizely client when the provider is closed. Defaults to false. */
+  closeClientOnShutdown?: boolean;
+  /** Options applied to every Optimizely flag decision. */
+  decideOptions?: OptimizelyDecideOption[];
+}
+
+const NOOP_LOGGER: Logger = {
+  error: () => undefined,
+  warn: () => undefined,
+  info: () => undefined,
+  debug: () => undefined,
+};
+
+export class OptimizelyProvider implements Provider {
+  readonly metadata = {
+    name: OptimizelyProvider.name,
+  };
+
+  readonly runsOn = 'server';
+  readonly hooks = [];
+  readonly events = new OpenFeatureEventEmitter();
+
+  private readonly closeClientOnShutdown: boolean;
+  private readonly decideOptions: OptimizelyDecideOption[];
+  private configUpdateListenerId?: number;
+  private initialized = false;
+  private initializationPromise?: Promise<void>;
+  private closePromise?: Promise<void>;
+
+  constructor(
+    private readonly client: Client,
+    options: OptimizelyProviderOptions = {},
+  ) {
+    if (options.decideOptions?.includes(OptimizelyDecideOption.EXCLUDE_VARIABLES)) {
+      throw new TypeError('EXCLUDE_VARIABLES is incompatible with OpenFeature value resolution.');
+    }
+
+    this.closeClientOnShutdown = options.closeClientOnShutdown ?? false;
+    this.decideOptions = [...(options.decideOptions ?? [])];
+  }
+
+  initialize(): Promise<void> {
+    if (this.closePromise) {
+      return Promise.reject(new ProviderNotReadyError('The Optimizely provider is closing or has been closed.'));
+    }
+    if (this.initialized) {
+      return Promise.resolve();
+    }
+
+    this.initializationPromise ??= this.initializeClient().catch((error) => {
+      this.initializationPromise = undefined;
+      throw error;
+    });
+    return this.initializationPromise;
+  }
+
+  private async initializeClient(): Promise<void> {
+    try {
+      await this.client.onReady();
+    } catch (error) {
+      throw new GeneralError(`Optimizely client initialization failed: ${errorMessage(error)}`);
+    }
+
+    const listenerId = this.client.notificationCenter.addNotificationListener(
+      NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+      () => this.events.emit(ProviderEvents.ConfigurationChanged),
+    );
+    if (listenerId < 1) {
+      throw new GeneralError('Unable to register the Optimizely configuration update listener.');
+    }
+
+    this.configUpdateListenerId = listenerId;
+    this.initialized = true;
+  }
+
+  onClose(): Promise<void> {
+    this.closePromise ??= this.close();
+    return this.closePromise;
+  }
+
+  resolveBooleanEvaluation(
+    flagKey: string,
+    _defaultValue: boolean,
+    context: EvaluationContext,
+    logger: Logger,
+  ): Promise<ResolutionDetails<boolean>> {
+    return this.evaluate(flagKey, context, logger, 'boolean');
+  }
+
+  resolveStringEvaluation(
+    flagKey: string,
+    _defaultValue: string,
+    context: EvaluationContext,
+    logger: Logger,
+  ): Promise<ResolutionDetails<string>> {
+    return this.evaluate(flagKey, context, logger, 'string');
+  }
+
+  resolveNumberEvaluation(
+    flagKey: string,
+    _defaultValue: number,
+    context: EvaluationContext,
+    logger: Logger,
+  ): Promise<ResolutionDetails<number>> {
+    return this.evaluate(flagKey, context, logger, 'number');
+  }
+
+  resolveObjectEvaluation<T extends JsonValue>(
+    flagKey: string,
+    _defaultValue: T,
+    context: EvaluationContext,
+    logger: Logger,
+  ): Promise<ResolutionDetails<T>> {
+    return this.evaluate(flagKey, context, logger, 'object');
+  }
+
+  track(trackingEventName: string, context: EvaluationContext, details: TrackingEventDetails): void {
+    this.assertReady();
+    const { userId, attributes } = transformContext(context, NOOP_LOGGER);
+    const revenue = details['revenue'];
+    const hasOptimizelyRevenue = typeof revenue === 'number' && Number.isInteger(revenue);
+    const eventProperties = Object.fromEntries(
+      Object.entries(details).filter(([key]) => key !== 'value' && !(key === 'revenue' && hasOptimizelyRevenue)),
+    );
+    const eventTags: EventTags = {
+      ...(typeof details.value === 'number' ? { value: details.value } : {}),
+      ...(hasOptimizelyRevenue ? { revenue } : {}),
+      ...(Object.keys(eventProperties).length > 0 ? { $opt_event_properties: eventProperties } : {}),
+    };
+
+    this.client
+      .createUserContext(userId, attributes)
+      .trackEvent(trackingEventName, Object.keys(eventTags).length > 0 ? eventTags : undefined);
+  }
+
+  private async evaluate<T extends JsonValue>(
+    flagKey: string,
+    context: EvaluationContext,
+    logger: Logger,
+    valueType: EvaluationValueType,
+  ): Promise<ResolutionDetails<T>> {
+    this.assertReady();
+    const config = this.client.getOptimizelyConfig();
+    if (config === null) {
+      throw new ProviderNotReadyError('The Optimizely configuration is not available.');
+    }
+    if (!Object.hasOwn(config.featuresMap, flagKey)) {
+      throw new FlagNotFoundError(`Optimizely flag '${flagKey}' was not found.`);
+    }
+
+    const { userId, attributes } = transformContext(context, logger);
+    const decision = await this.client
+      .createUserContext(userId, attributes)
+      .decideAsync(flagKey, [...this.decideOptions]);
+    return translateDecision<T>(decision, valueType);
+  }
+
+  private assertReady(): void {
+    if (!this.initialized || this.closePromise) {
+      throw new ProviderNotReadyError('The Optimizely provider has not been initialized.');
+    }
+  }
+
+  private async close(): Promise<void> {
+    try {
+      await this.initializationPromise;
+    } catch {
+      // Initialization errors are surfaced to the caller that initiated setup.
+    }
+
+    if (this.configUpdateListenerId !== undefined) {
+      this.client.notificationCenter.removeNotificationListener(this.configUpdateListenerId);
+      this.configUpdateListenerId = undefined;
+    }
+    this.initialized = false;
+
+    if (this.closeClientOnShutdown) {
+      await this.client.close();
+    }
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/libs/providers/optimizely/src/test/optimizely-datafile.ts
+++ b/libs/providers/optimizely/src/test/optimizely-datafile.ts
@@ -1,0 +1,111 @@
+import {
+  type Client,
+  type EventDispatcher,
+  createForwardingEventProcessor,
+  createInstance,
+  createStaticProjectConfigManager,
+} from '@optimizely/optimizely-sdk';
+
+export const OPTIMIZELY_TEST_FLAG_KEYS = {
+  boolean: 'boolean-flag',
+  string: 'string-flag',
+  number: 'number-flag',
+  boolVariable: 'bool-variable-flag',
+  object: 'object-flag',
+  multiple: 'multiple-flag',
+  disabled: 'disabled-flag',
+} as const;
+
+const flag = (id: string, key: string, rolloutId: string, variables: unknown[] = []) => ({
+  id,
+  key,
+  rolloutId,
+  experimentIds: [],
+  variables,
+});
+
+const rollout = (
+  id: string,
+  experimentKey: string,
+  variationKey: string,
+  featureEnabled: boolean,
+  variables: unknown[] = [],
+) => ({
+  id,
+  experiments: [
+    {
+      id: `${id}-experiment`,
+      key: experimentKey,
+      applicationId: 'openfeature-test-application',
+      status: 'Running',
+      layerId: 'openfeature-test-layer',
+      audienceIds: [],
+      audienceConditions: [],
+      variations: [{ id: `${id}-variation`, key: variationKey, featureEnabled, variables }],
+      trafficAllocation: [{ entityId: `${id}-variation`, endOfRange: 100000 }],
+    },
+  ],
+});
+
+export const OPTIMIZELY_TEST_DATAFILE = JSON.stringify({
+  version: '4',
+  projectId: 'openfeature-test-project',
+  projectName: 'OpenFeature Optimizely provider tests',
+  revision: '1',
+  sdkKey: 'openfeature-test-sdk-key',
+  environmentKey: 'openfeature-test-environment',
+  accountId: 'openfeature-test-account',
+  events: [],
+  audiences: [],
+  typedAudiences: [],
+  groups: [],
+  attributes: [],
+  experiments: [],
+  experimentFeatureMap: {},
+  holdouts: [],
+  cmabExperiments: [],
+  integrations: [],
+  odpIntegrationConfig: { integrated: false },
+  featureFlags: [
+    flag('1', OPTIMIZELY_TEST_FLAG_KEYS.boolean, 'rollout-boolean'),
+    flag('2', OPTIMIZELY_TEST_FLAG_KEYS.string, 'rollout-string', [
+      { id: 'v20', key: 'string-value', type: 'string', defaultValue: 'default' },
+    ]),
+    flag('3', OPTIMIZELY_TEST_FLAG_KEYS.number, 'rollout-number', [
+      { id: 'v30', key: 'number-value', type: 'double', defaultValue: '0' },
+    ]),
+    flag('4', OPTIMIZELY_TEST_FLAG_KEYS.boolVariable, 'rollout-bool-variable', [
+      { id: 'v40', key: 'bool-value', type: 'boolean', defaultValue: 'false' },
+    ]),
+    flag('5', OPTIMIZELY_TEST_FLAG_KEYS.object, 'rollout-object', [
+      { id: 'v50', key: 'object-value', type: 'json', defaultValue: '{}' },
+    ]),
+    flag('6', OPTIMIZELY_TEST_FLAG_KEYS.multiple, 'rollout-multiple', [
+      { id: 'v60', key: 'first', type: 'string', defaultValue: 'a' },
+      { id: 'v61', key: 'second', type: 'integer', defaultValue: '1' },
+    ]),
+    flag('7', OPTIMIZELY_TEST_FLAG_KEYS.disabled, 'rollout-disabled'),
+  ],
+  rollouts: [
+    rollout('rollout-boolean', 'boolean-rule', 'on', true),
+    rollout('rollout-string', 'string-rule', 'on', true, [{ id: 'v20', value: 'hello' }]),
+    rollout('rollout-number', 'number-rule', 'on', true, [{ id: 'v30', value: '42.5' }]),
+    rollout('rollout-bool-variable', 'bool-variable-rule', 'on', true, [{ id: 'v40', value: 'true' }]),
+    rollout('rollout-object', 'object-rule', 'on', true, [{ id: 'v50', value: '{"color":"blue","count":2}' }]),
+    rollout('rollout-multiple', 'multiple-rule', 'on', true, [
+      { id: 'v60', value: 'one' },
+      { id: 'v61', value: '7' },
+    ]),
+    rollout('rollout-disabled', 'disabled-rule', 'off', false),
+  ],
+});
+
+const NOOP_EVENT_DISPATCHER: EventDispatcher = {
+  dispatchEvent: async () => ({ statusCode: 200 }),
+};
+
+export const createStaticOptimizelyClient = (eventDispatcher: EventDispatcher = NOOP_EVENT_DISPATCHER): Client =>
+  createInstance({
+    projectConfigManager: createStaticProjectConfigManager({ datafile: OPTIMIZELY_TEST_DATAFILE }),
+    eventProcessor: createForwardingEventProcessor(eventDispatcher),
+  });

--- a/libs/providers/optimizely/tsconfig.json
+++ b/libs/providers/optimizely/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ES6",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/providers/optimizely/tsconfig.lib.json
+++ b/libs/providers/optimizely/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "jest.config.cts", "src/**/*.spec.ts", "src/**/*.test.ts", "src/test/**"]
+}

--- a/libs/providers/optimizely/tsconfig.spec.json
+++ b/libs/providers/optimizely/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "jest.config.cts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.205.0",
         "@opentelemetry/semantic-conventions": "^1.37.0",
+        "@optimizely/optimizely-sdk": "^6.6.0",
         "@protobuf-ts/grpc-transport": "^2.9.0",
         "@protobuf-ts/runtime-rpc": "^2.9.0",
         "@swc/helpers": "0.5.21",
@@ -7552,6 +7553,72 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@optimizely/optimizely-sdk": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@optimizely/optimizely-sdk/-/optimizely-sdk-6.6.0.tgz",
+      "integrity": "sha512-efPzH5PD4lKz7KyDiNjBKWUOC0lq0GKqoEammtpyvkTz0zoiwceURjXdpEgr/mW0S530D+Ts4Q0DeE6qV5LIlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "decompress-response": "^7.0.0",
+        "json-schema": "^0.4.0",
+        "murmurhash": "^2.0.1",
+        "uuid": "^13.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": ">=1.0.0 <3.0.0",
+        "@react-native-community/netinfo": ">=5.0.0 <12.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "react-native-get-random-values": "^1.11.0",
+        "ua-parser-js": "^1.0.38"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        },
+        "@react-native-community/netinfo": {
+          "optional": true
+        },
+        "fast-text-encoding": {
+          "optional": true
+        },
+        "react-native-get-random-values": {
+          "optional": true
+        },
+        "ua-parser-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@optimizely/optimizely-sdk/node_modules/decompress-response": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-7.0.0.tgz",
+      "integrity": "sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@optimizely/optimizely-sdk/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@oxc-resolver/binding-android-arm-eabi": {
@@ -21133,7 +21200,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
@@ -22231,6 +22297,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/murmurhash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-2.0.1.tgz",
+      "integrity": "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew==",
+      "license": "MIT"
     },
     "node_modules/mute-stream": {
       "version": "2.0.0",
@@ -26011,6 +26083,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -31730,6 +31815,32 @@
       "version": "1.37.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
       "integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA=="
+    },
+    "@optimizely/optimizely-sdk": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@optimizely/optimizely-sdk/-/optimizely-sdk-6.6.0.tgz",
+      "integrity": "sha512-efPzH5PD4lKz7KyDiNjBKWUOC0lq0GKqoEammtpyvkTz0zoiwceURjXdpEgr/mW0S530D+Ts4Q0DeE6qV5LIlQ==",
+      "requires": {
+        "decompress-response": "^7.0.0",
+        "json-schema": "^0.4.0",
+        "murmurhash": "^2.0.1",
+        "uuid": "^13.0.2"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-7.0.0.tgz",
+          "integrity": "sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==",
+          "requires": {
+            "mimic-response": "^3.1.0"
+          }
+        },
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
     },
     "@oxc-resolver/binding-android-arm-eabi": {
       "version": "11.19.1",
@@ -40650,8 +40761,7 @@
     "json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "1.0.0"
@@ -41354,6 +41464,11 @@
           "dev": true
         }
       }
+    },
+    "murmurhash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-2.0.1.tgz",
+      "integrity": "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew=="
     },
     "mute-stream": {
       "version": "2.0.0",
@@ -43842,6 +43957,11 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
+    },
+    "uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.205.0",
     "@opentelemetry/semantic-conventions": "^1.37.0",
+    "@optimizely/optimizely-sdk": "^6.6.0",
     "@protobuf-ts/grpc-transport": "^2.9.0",
     "@protobuf-ts/runtime-rpc": "^2.9.0",
     "@swc/helpers": "0.5.21",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -192,6 +192,13 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "versioning": "default"
+    },
+    "libs/providers/optimizely": {
+      "release-type": "node",
+      "prerelease": false,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "versioning": "default"
     }
   },
   "changelog-sections": [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -42,7 +42,8 @@
       "@openfeature/ofrep-provider": ["libs/providers/ofrep/src/index.ts"],
       "@openfeature/ofrep-web-provider": ["libs/providers/ofrep-web/src/index.ts"],
       "@openfeature/unleash-web-provider": ["libs/providers/unleash-web/src/index.ts"],
-      "@openfeature/azure-app-configuration-provider": ["libs/providers/azure-app-configuration/src/index.ts"]
+      "@openfeature/azure-app-configuration-provider": ["libs/providers/azure-app-configuration/src/index.ts"],
+      "@openfeature/optimizely-provider": ["libs/providers/optimizely/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## What this adds

This PR adds `@openfeature/optimizely-provider` for Node.js server applications. It uses Optimizely's asynchronous decision API and the OpenFeature server contract; browser and Edge runtimes have different contracts and live in separate PRs.

The provider:

- maps OpenFeature context and typed evaluations to Optimizely decisions
- preserves variation and rule metadata and forwards tracking and configuration-change events
- lets the application keep ownership of the Optimizely client or transfer shutdown responsibility to the provider
- includes deterministic tests built around a committed static datafile

The package is also registered in the repository's TypeScript paths, component ownership, and release configuration.

## Validation

```text
npx nx test optimizely --no-watchman  # 48 tests
npx nx lint optimizely
npx nx package optimizely
```

Contributors do not need an Optimizely account, credentials, environment variables, or network access to run these checks.

## How the split works

This is the server portion of #1618. The other runtime providers are independently reviewable and have no runtime dependency on this package:

- Web/React: #1620
- Universal/Edge: #1621

All three PRs currently include the same root Optimizely development dependency. Once one merges, I will rebase the other two and remove that duplicate diff.

## Before this is ready

- [ ] Add the provider to the openfeature.dev catalog
