### PR TITLE
feat(optimizely-web): add browser provider

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -34,6 +34,8 @@ components:
     - markphelps
   libs/providers/flipt-web:
     - markphelps
+  libs/providers/optimizely-web:
+    - dflynn15
   libs/providers/unleash-web:
     - jarebudev
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -25,5 +25,6 @@
   "libs/providers/flagsmith": "0.1.2",
   "libs/hooks/debounce": "0.1.1",
   "libs/providers/localstorage": "0.1.2",
-  "libs/providers/azure-app-configuration": "0.1.1"
+  "libs/providers/azure-app-configuration": "0.1.1",
+  "libs/providers/optimizely-web": "0.1.0"
 }

--- a/libs/providers/optimizely-web/.eslintrc.json
+++ b/libs/providers/optimizely-web/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../../.eslintrc.json",
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": ["{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/libs/providers/optimizely-web/README.md
+++ b/libs/providers/optimizely-web/README.md
@@ -1,0 +1,114 @@
+# Optimizely Web Provider
+
+This package is the browser/client counterpart to the server-only
+[`@openfeature/optimizely-provider`](../optimizely/README.md). It is intended for
+browser applications that use the Optimizely Feature Experimentation JavaScript
+SDK and OpenFeature's web SDK. It adapts synchronous Optimizely decisions to
+OpenFeature's browser evaluation API.
+
+## Installation
+
+```sh
+npm install @openfeature/optimizely-web-provider @openfeature/web-sdk @optimizely/optimizely-sdk
+```
+
+For React, install the React bindings separately:
+
+```sh
+npm install @openfeature/react-sdk
+```
+
+The provider package, OpenFeature web SDK, React bindings, and Optimizely SDK
+are separate dependencies. The React SDK is a UI integration layer; it does not
+turn the server provider into a browser provider.
+
+## Intended browser setup
+
+Use the explicit browser entry point when constructing the Optimizely client so
+the bundler does not select the Node.js SDK entry point:
+
+```ts
+import { OpenFeature } from '@openfeature/web-sdk';
+import { createInstance } from '@optimizely/optimizely-sdk/browser';
+import { OptimizelyWebProvider } from '@openfeature/optimizely-web-provider';
+
+const optimizely = createInstance({ sdkKey: import.meta.env.VITE_OPTIMIZELY_SDK_KEY });
+const provider = new OptimizelyWebProvider(optimizely);
+
+await OpenFeature.setProviderAndWait(provider);
+```
+
+Register the provider before rendering flag-dependent React UI. The React SDK
+then consumes the web client normally:
+
+```tsx
+'use client';
+
+import { OpenFeatureProvider } from '@openfeature/react-sdk';
+import { OpenFeature } from '@openfeature/web-sdk';
+import type { ReactNode } from 'react';
+
+export function FeatureProvider({ children }: { children: ReactNode }) {
+  return <OpenFeatureProvider client={OpenFeature.getClient()}>{children}</OpenFeatureProvider>;
+}
+```
+
+The exact client options and datafile behavior come from Optimizely's
+[JavaScript SDK documentation](https://docs.developers.optimizely.com/feature-experimentation/docs/javascript-sdk-v6).
+Do not expose server-only credentials in a browser bundle. An SDK key is not a
+secret, but datafile access tokens and REST/API tokens must remain server-side.
+
+The browser provider must use the Optimizely synchronous `decide` API because
+the OpenFeature web SDK resolves flags synchronously. Optimizely features that
+require asynchronous decisions, including ODP-dependent or other async decision
+cases, are unsupported by this provider. Use the server provider from a Node.js
+boundary for those cases.
+
+## Framework compatibility
+
+| Application surface                                     | Package and runtime                                                                  | Status                                                 |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------ |
+| React client components                                 | `@openfeature/react-sdk` + `@openfeature/web-sdk` + this package in a browser bundle | Supported by the provider contract                     |
+| Next.js client components                               | Same browser packages in the client bundle                                           | Supported; initialize behind a `'use client'` boundary |
+| Next.js Server Components and route handlers on Node.js | `@openfeature/server-sdk` + `@openfeature/optimizely-provider`                       | Use the server package instead                         |
+| Hono on Node.js                                         | `@openfeature/server-sdk` + `@openfeature/optimizely-provider`                       | Use the server package instead                         |
+| Next.js Edge runtime or Cloudflare Workers              | `@openfeature/web-sdk` + `@openfeature/optimizely-edge-provider`                     | Use the separate Universal/Edge provider               |
+
+The provider is not a Next.js or React plugin. React applications should use
+the [OpenFeature React SDK](https://openfeature.dev/docs/reference/technologies/client/react)
+and the web SDK provider registration pattern; Hono and server-side Next.js
+code should use the server package. Next.js Edge routes and Hono applications
+on Cloudflare Workers should use `@openfeature/optimizely-edge-provider`.
+
+## Lifecycle, context, and tracking
+
+The web provider initializes the browser Optimizely client before flag reads
+and closes only a client explicitly owned by the provider. An
+OpenFeature `targetingKey` maps to the Optimizely user ID; primitive context
+attributes map to Optimizely user attributes. The Optimizely variation key maps
+to OpenFeature's `variant`, and the rule key maps to flag metadata. Tracking is
+forwarded to the Optimizely user-context `trackEvent` API.
+
+Variable mapping matches the server provider: a flag with no variables resolves
+as a boolean, one variable resolves through its matching typed getter, and
+multiple variables resolve as an object.
+
+## Building and testing
+
+```sh
+npx nx package optimizely-web
+npx nx test optimizely-web --no-watchman
+npx nx lint optimizely-web
+```
+
+The deterministic suite uses a static Optimizely datafile and covers the web
+provider contract, typed decisions, lifecycle, context, tracking, and client
+ownership without credentials or network access. No framework-specific Next.js,
+React, Hono, Edge, or Cloudflare integration test is included.
+
+## Related documentation
+
+- [OpenFeature web SDK](https://openfeature.dev/docs/reference/technologies/client/web)
+- [OpenFeature React SDK](https://openfeature.dev/docs/reference/technologies/client/react)
+- [Optimizely JavaScript SDK](https://docs.developers.optimizely.com/feature-experimentation/docs/javascript-sdk-v6)
+- [Optimizely browser SDK initialization](https://docs.developers.optimizely.com/feature-experimentation/docs/initialize-the-javascript-sdk)

--- a/libs/providers/optimizely-web/README.md
+++ b/libs/providers/optimizely-web/README.md
@@ -72,12 +72,6 @@ boundary for those cases.
 | Hono on Node.js                                         | `@openfeature/server-sdk` + `@openfeature/optimizely-provider`                       | Use the server package instead                         |
 | Next.js Edge runtime or Cloudflare Workers              | `@openfeature/web-sdk` + `@openfeature/optimizely-edge-provider`                     | Use the separate Universal/Edge provider               |
 
-The provider is not a Next.js or React plugin. React applications should use
-the [OpenFeature React SDK](https://openfeature.dev/docs/reference/technologies/client/react)
-and the web SDK provider registration pattern; Hono and server-side Next.js
-code should use the server package. Next.js Edge routes and Hono applications
-on Cloudflare Workers should use `@openfeature/optimizely-edge-provider`.
-
 ## Lifecycle, context, and tracking
 
 The web provider initializes the browser Optimizely client before flag reads

--- a/libs/providers/optimizely-web/README.md
+++ b/libs/providers/optimizely-web/README.md
@@ -1,10 +1,8 @@
 # Optimizely Web Provider
 
-This package is the browser/client counterpart to the server-only
-[`@openfeature/optimizely-provider`](../optimizely/README.md). It is intended for
-browser applications that use the Optimizely Feature Experimentation JavaScript
-SDK and OpenFeature's web SDK. It adapts synchronous Optimizely decisions to
-OpenFeature's browser evaluation API.
+Use this provider to evaluate Optimizely Feature Experimentation flags through
+OpenFeature in browser applications. It connects the Optimizely browser client
+to the synchronous OpenFeature web SDK contract.
 
 ## Installation
 
@@ -22,7 +20,7 @@ The provider package, OpenFeature web SDK, React bindings, and Optimizely SDK
 are separate dependencies. The React SDK is a UI integration layer; it does not
 turn the server provider into a browser provider.
 
-## Intended browser setup
+## Browser setup
 
 Use the explicit browser entry point when constructing the Optimizely client so
 the bundler does not select the Node.js SDK entry point:

--- a/libs/providers/optimizely-web/babel.config.json
+++ b/libs/providers/optimizely-web/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": [["minify", { "builtIns": false }]]
+}

--- a/libs/providers/optimizely-web/jest.config.cts
+++ b/libs/providers/optimizely-web/jest.config.cts
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'optimizely-web',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/src/test/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@optimizely/optimizely-sdk$':
+      '<rootDir>/../../../node_modules/@optimizely/optimizely-sdk/dist/index.browser.min.js',
+  },
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/providers/optimizely-web',
+};

--- a/libs/providers/optimizely-web/package.json
+++ b/libs/providers/optimizely-web/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@openfeature/optimizely-web-provider",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-feature/js-sdk-contrib.git",
+    "directory": "libs/providers/optimizely-web"
+  },
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi",
+    "current-version": "echo $npm_package_version"
+  },
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "@openfeature/web-sdk": "^1.6.0",
+    "@optimizely/optimizely-sdk": "^6.6.0"
+  }
+}

--- a/libs/providers/optimizely-web/project.json
+++ b/libs/providers/optimizely-web/project.json
@@ -1,0 +1,76 @@
+{
+  "name": "optimizely-web",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/providers/optimizely-web/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": ["dist/{projectRoot}"],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "{projectRoot}/jest.config.cts"
+      }
+    },
+    "package": {
+      "executor": "@nx/rollup:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "project": "libs/providers/optimizely-web/package.json",
+        "outputPath": "dist/libs/providers/optimizely-web",
+        "entryFile": "libs/providers/optimizely-web/src/index.ts",
+        "tsConfig": "libs/providers/optimizely-web/tsconfig.lib.json",
+        "compiler": "tsc",
+        "generateExportsField": true,
+        "umdName": "optimizely-web",
+        "external": "all",
+        "format": ["cjs", "esm"],
+        "assets": [
+          {
+            "glob": "package.json",
+            "input": "./assets",
+            "output": "./src/"
+          },
+          {
+            "glob": "LICENSE",
+            "input": "./",
+            "output": "./"
+          },
+          {
+            "glob": "README.md",
+            "input": "./libs/providers/optimizely-web",
+            "output": "./"
+          }
+        ]
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run publish-if-not-exists",
+        "cwd": "dist/libs/providers/optimizely-web"
+      },
+      "dependsOn": [
+        {
+          "projects": "self",
+          "target": "package"
+        }
+      ]
+    }
+  }
+}

--- a/libs/providers/optimizely-web/src/index.ts
+++ b/libs/providers/optimizely-web/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/optimizely-web-provider';

--- a/libs/providers/optimizely-web/src/lib/optimizely-web-provider.contract.spec.ts
+++ b/libs/providers/optimizely-web/src/lib/optimizely-web-provider.contract.spec.ts
@@ -1,0 +1,236 @@
+import { ProviderEvents, type EvaluationContext, type Logger } from '@openfeature/web-sdk';
+import {
+  NOTIFICATION_TYPES,
+  OptimizelyDecideOption,
+  type Client,
+  type OptimizelyUserContext,
+} from '@optimizely/optimizely-sdk';
+import { OptimizelyWebProvider } from './optimizely-web-provider';
+import { createStaticOptimizelyClient, OPTIMIZELY_TEST_FLAG_KEYS } from '../test/optimizely-web-test-utils';
+
+const logger: Logger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+const context: EvaluationContext = {
+  targetingKey: 'web-user-1',
+  plan: 'pro',
+  region: 'us-east-1',
+};
+
+describe('OptimizelyWebProvider', () => {
+  let client: Client;
+  let provider: OptimizelyWebProvider;
+
+  beforeEach(async () => {
+    client = createStaticOptimizelyClient();
+    provider = new OptimizelyWebProvider(client);
+    await provider.initialize();
+  });
+
+  afterEach(async () => {
+    await provider.onClose();
+    await client.close();
+  });
+
+  it('maps all supported OpenFeature value types from a synchronous Optimizely decision', () => {
+    expect(provider.resolveBooleanEvaluation(OPTIMIZELY_TEST_FLAG_KEYS.boolean, false, context, logger)).toMatchObject({
+      value: true,
+      variant: 'on',
+      flagMetadata: { ruleKey: 'boolean-rule' },
+    });
+    expect(provider.resolveStringEvaluation(OPTIMIZELY_TEST_FLAG_KEYS.string, '', context, logger)).toMatchObject({
+      value: 'hello',
+      variant: 'on',
+      flagMetadata: { ruleKey: 'string-rule' },
+    });
+    expect(provider.resolveNumberEvaluation(OPTIMIZELY_TEST_FLAG_KEYS.number, 0, context, logger)).toMatchObject({
+      value: 42.5,
+      variant: 'on',
+      flagMetadata: { ruleKey: 'number-rule' },
+    });
+    expect(
+      provider.resolveBooleanEvaluation(OPTIMIZELY_TEST_FLAG_KEYS.boolVariable, false, context, logger),
+    ).toMatchObject({
+      value: true,
+      variant: 'on',
+    });
+    expect(provider.resolveObjectEvaluation(OPTIMIZELY_TEST_FLAG_KEYS.object, {}, context, logger)).toMatchObject({
+      value: { color: 'blue', count: 2 },
+      variant: 'on',
+    });
+    expect(provider.resolveObjectEvaluation(OPTIMIZELY_TEST_FLAG_KEYS.multiple, {}, context, logger)).toMatchObject({
+      value: { first: 'one', second: 7 },
+      variant: 'on',
+    });
+  });
+
+  it('reports a disabled flag without treating it as an evaluation error', () => {
+    expect(provider.resolveBooleanEvaluation(OPTIMIZELY_TEST_FLAG_KEYS.disabled, true, context, logger)).toMatchObject({
+      value: false,
+      variant: 'off',
+      reason: 'DISABLED',
+    });
+  });
+
+  it('reports type mismatch and flag-not-found errors', () => {
+    expect(() => provider.resolveNumberEvaluation(OPTIMIZELY_TEST_FLAG_KEYS.string, 7, context, logger)).toThrow(
+      'OpenFeature number',
+    );
+    expect(() => provider.resolveBooleanEvaluation('missing-flag', false, context, logger)).toThrow('missing-flag');
+  });
+
+  it('requires a non-empty string targeting key', () => {
+    expect(() => provider.resolveBooleanEvaluation(OPTIMIZELY_TEST_FLAG_KEYS.boolean, false, {}, logger)).toThrow(
+      'targetingKey',
+    );
+    expect(() =>
+      provider.resolveBooleanEvaluation(OPTIMIZELY_TEST_FLAG_KEYS.boolean, false, { targetingKey: '' }, logger),
+    ).toThrow('targetingKey');
+    expect(() =>
+      provider.resolveBooleanEvaluation(
+        OPTIMIZELY_TEST_FLAG_KEYS.boolean,
+        false,
+        { targetingKey: 123 } as unknown as EvaluationContext,
+        logger,
+      ),
+    ).toThrow('targetingKey');
+  });
+
+  it('passes targeting key and custom attributes to the same user context', () => {
+    const createUserContext = jest.spyOn(client, 'createUserContext');
+
+    provider.resolveBooleanEvaluation(OPTIMIZELY_TEST_FLAG_KEYS.boolean, false, context, logger);
+
+    expect(createUserContext).toHaveBeenCalledWith('web-user-1', {
+      plan: 'pro',
+      region: 'us-east-1',
+    });
+  });
+
+  it('uses exactly one synchronous decide call per resolution', () => {
+    const userContext = client.createUserContext('spy-user');
+    const decide = jest.spyOn(userContext, 'decide');
+    jest.spyOn(client, 'createUserContext').mockReturnValue(userContext);
+    const decideAsync = jest.spyOn(userContext, 'decideAsync');
+
+    provider.resolveBooleanEvaluation(OPTIMIZELY_TEST_FLAG_KEYS.boolean, false, context, logger);
+
+    expect(decide).toHaveBeenCalledTimes(1);
+    expect(decideAsync).not.toHaveBeenCalled();
+  });
+
+  it('routes tracking events and preserves value, revenue, and custom properties', () => {
+    const trackEvent = jest.fn();
+    const userContext = { trackEvent } as unknown as OptimizelyUserContext;
+    jest.spyOn(client, 'createUserContext').mockReturnValue(userContext);
+
+    provider.track('checkout', context, {
+      value: 12.5,
+      revenue: 1200,
+      cartSize: 3,
+      source: 'web',
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith('checkout', {
+      value: 12.5,
+      revenue: 1200,
+      $opt_event_properties: { cartSize: 3, source: 'web' },
+    });
+  });
+
+  it('rejects EXCLUDE_VARIABLES because it breaks typed variable resolution', () => {
+    expect(
+      () =>
+        new OptimizelyWebProvider(client, {
+          decideOptions: [OptimizelyDecideOption.EXCLUDE_VARIABLES],
+        }),
+    ).toThrow('EXCLUDE_VARIABLES');
+  });
+});
+
+describe('OptimizelyWebProvider lifecycle', () => {
+  const makeClient = (close?: jest.Mock): Client => {
+    let configListener: (() => void) | undefined;
+    const fakeClient = {
+      getOptimizelyConfig: () => ({ featuresMap: { flag: {} } }),
+      onReady: jest.fn().mockResolvedValue({ success: true }),
+      close: close ?? jest.fn().mockResolvedValue(undefined),
+      createUserContext: jest.fn(),
+      notificationCenter: {
+        addNotificationListener: jest.fn((_type: string, listener: () => void) => {
+          configListener = listener;
+          return 42;
+        }),
+        removeNotificationListener: jest.fn(),
+      },
+      getConfigListener: () => configListener,
+    } as unknown as Client & { getConfigListener: () => (() => void) | undefined };
+    return fakeClient;
+  };
+
+  it('waits for readiness, emits configuration changes, and removes only its listener', async () => {
+    const client = makeClient();
+    const provider = new OptimizelyWebProvider(client);
+    const changed = jest.fn();
+    provider.events.addHandler(ProviderEvents.ConfigurationChanged, changed);
+
+    await provider.initialize();
+    expect(client.onReady).toHaveBeenCalledTimes(1);
+    expect(client.notificationCenter.addNotificationListener).toHaveBeenCalledWith(
+      NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+      expect.any(Function),
+    );
+
+    (client as Client & { getConfigListener: () => (() => void) | undefined }).getConfigListener()?.();
+    expect(changed).toHaveBeenCalledTimes(1);
+
+    await provider.onClose();
+    expect(client.notificationCenter.removeNotificationListener).toHaveBeenCalledWith(42);
+  });
+
+  it('shares concurrent initialization and cleans up when close races readiness', async () => {
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    const client = makeClient();
+    jest.mocked(client.onReady).mockReturnValue(ready);
+    const provider = new OptimizelyWebProvider(client);
+
+    const firstInitialization = provider.initialize();
+    const secondInitialization = provider.initialize();
+    const close = provider.onClose();
+    resolveReady();
+    await Promise.all([firstInitialization, secondInitialization, close]);
+
+    expect(client.onReady).toHaveBeenCalledTimes(1);
+    expect(client.notificationCenter.addNotificationListener).toHaveBeenCalledTimes(1);
+    expect(client.notificationCenter.removeNotificationListener).toHaveBeenCalledTimes(1);
+    expect(client.notificationCenter.removeNotificationListener).toHaveBeenCalledWith(42);
+  });
+
+  it('does not close a borrowed client by default, but closes an owned client when opted in', async () => {
+    const borrowedClose = jest.fn().mockResolvedValue(undefined);
+    const borrowed = makeClient(borrowedClose);
+    const borrowedProvider = new OptimizelyWebProvider(borrowed);
+    await borrowedProvider.initialize();
+    await borrowedProvider.onClose();
+    expect(borrowedClose).not.toHaveBeenCalled();
+
+    const ownedClose = jest.fn().mockResolvedValue(undefined);
+    const owned = makeClient(ownedClose);
+    const ownedProvider = new OptimizelyWebProvider(owned, { closeClientOnShutdown: true });
+    await ownedProvider.initialize();
+    await ownedProvider.onClose();
+    expect(ownedClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not evaluate until initialized', () => {
+    const provider = new OptimizelyWebProvider(makeClient());
+    expect(() => provider.resolveBooleanEvaluation('flag', false, context, logger)).toThrow('initialized');
+  });
+});

--- a/libs/providers/optimizely-web/src/lib/optimizely-web-provider.openfeature.spec.ts
+++ b/libs/providers/optimizely-web/src/lib/optimizely-web-provider.openfeature.spec.ts
@@ -1,0 +1,60 @@
+import { ErrorCode, OpenFeature, StandardResolutionReasons } from '@openfeature/web-sdk';
+import { __platforms, type Client as OptimizelyClient } from '@optimizely/optimizely-sdk';
+
+import { createStaticOptimizelyClient, OPTIMIZELY_TEST_FLAG_KEYS } from '../test/optimizely-web-test-utils';
+import { OptimizelyWebProvider } from './optimizely-web-provider';
+
+describe('OptimizelyWebProvider through OpenFeature', () => {
+  let optimizely: OptimizelyClient;
+
+  beforeEach(async () => {
+    optimizely = createStaticOptimizelyClient();
+    await OpenFeature.setProviderAndWait(new OptimizelyWebProvider(optimizely, { closeClientOnShutdown: true }), {
+      targetingKey: 'browser-user',
+      plan: 'pro',
+    });
+  });
+
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
+  });
+
+  it('loads the Optimizely browser SDK export in the jsdom test runtime', () => {
+    expect(__platforms).toContain('browser');
+  });
+
+  it('evaluates typed flags synchronously through the web SDK', () => {
+    const client = OpenFeature.getClient();
+
+    expect(client.getBooleanValue(OPTIMIZELY_TEST_FLAG_KEYS.boolean, false)).toBe(true);
+    expect(client.getStringValue(OPTIMIZELY_TEST_FLAG_KEYS.string, '')).toBe('hello');
+    expect(client.getNumberValue(OPTIMIZELY_TEST_FLAG_KEYS.number, 0)).toBe(42.5);
+    expect(client.getObjectValue(OPTIMIZELY_TEST_FLAG_KEYS.object, {})).toEqual({
+      color: 'blue',
+      count: 2,
+    });
+  });
+
+  it('preserves decision details and converts provider errors to defaults', () => {
+    const client = OpenFeature.getClient();
+    const success = client.getStringDetails(OPTIMIZELY_TEST_FLAG_KEYS.string, 'fallback');
+    const missing = client.getBooleanDetails('missing-flag', true);
+    const mismatch = client.getBooleanDetails(OPTIMIZELY_TEST_FLAG_KEYS.string, false);
+
+    expect(success).toMatchObject({
+      value: 'hello',
+      variant: 'on',
+      flagMetadata: { ruleKey: 'string-rule' },
+    });
+    expect(missing).toMatchObject({
+      value: true,
+      reason: StandardResolutionReasons.ERROR,
+      errorCode: ErrorCode.FLAG_NOT_FOUND,
+    });
+    expect(mismatch).toMatchObject({
+      value: false,
+      reason: StandardResolutionReasons.ERROR,
+      errorCode: ErrorCode.TYPE_MISMATCH,
+    });
+  });
+});

--- a/libs/providers/optimizely-web/src/lib/optimizely-web-provider.ts
+++ b/libs/providers/optimizely-web/src/lib/optimizely-web-provider.ts
@@ -1,0 +1,335 @@
+import {
+  NOTIFICATION_TYPES,
+  OptimizelyDecideOption,
+  type Client,
+  type EventTags,
+  type OptimizelyDecision,
+  type UserAttributes,
+} from '@optimizely/optimizely-sdk';
+import {
+  FlagNotFoundError,
+  GeneralError,
+  OpenFeatureEventEmitter,
+  ProviderEvents,
+  ProviderNotReadyError,
+  StandardResolutionReasons,
+  TargetingKeyMissingError,
+  TypeMismatchError,
+  type EvaluationContext,
+  type JsonValue,
+  type Logger,
+  type Provider,
+  type ResolutionDetails,
+  type TrackingEventDetails,
+} from '@openfeature/web-sdk';
+
+export interface OptimizelyWebProviderOptions {
+  /** Close the supplied Optimizely client when the provider is closed. Defaults to false. */
+  closeClientOnShutdown?: boolean;
+  /** Options applied to every Optimizely flag decision. */
+  decideOptions?: OptimizelyDecideOption[];
+}
+
+type EvaluationValueType = 'boolean' | 'string' | 'number' | 'object';
+
+const NOOP_LOGGER: Logger = {
+  error: () => undefined,
+  warn: () => undefined,
+  info: () => undefined,
+  debug: () => undefined,
+};
+
+export class OptimizelyWebProvider implements Provider {
+  readonly metadata = {
+    name: OptimizelyWebProvider.name,
+  };
+
+  readonly runsOn = 'client';
+  readonly hooks = [];
+  readonly events = new OpenFeatureEventEmitter();
+
+  private readonly closeClientOnShutdown: boolean;
+  private readonly decideOptions: OptimizelyDecideOption[];
+  private configUpdateListenerId?: number;
+  private initialized = false;
+  private initializationPromise?: Promise<void>;
+  private closePromise?: Promise<void>;
+
+  constructor(
+    private readonly client: Client,
+    options: OptimizelyWebProviderOptions = {},
+  ) {
+    if (options.decideOptions?.includes(OptimizelyDecideOption.EXCLUDE_VARIABLES)) {
+      throw new TypeError('EXCLUDE_VARIABLES is incompatible with OpenFeature value resolution.');
+    }
+
+    this.closeClientOnShutdown = options.closeClientOnShutdown ?? false;
+    this.decideOptions = [...(options.decideOptions ?? [])];
+  }
+
+  initialize(): Promise<void> {
+    if (this.closePromise) {
+      return Promise.reject(new ProviderNotReadyError('The Optimizely provider is closing or has been closed.'));
+    }
+    if (this.initialized) {
+      return Promise.resolve();
+    }
+
+    this.initializationPromise ??= this.initializeClient().catch((error) => {
+      this.initializationPromise = undefined;
+      throw error;
+    });
+    return this.initializationPromise;
+  }
+
+  private async initializeClient(): Promise<void> {
+    try {
+      await this.client.onReady();
+    } catch (error) {
+      throw new GeneralError(`Optimizely client initialization failed: ${errorMessage(error)}`);
+    }
+
+    const listenerId = this.client.notificationCenter.addNotificationListener(
+      NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+      () => this.events.emit(ProviderEvents.ConfigurationChanged),
+    );
+    if (listenerId < 1) {
+      throw new GeneralError('Unable to register the Optimizely configuration update listener.');
+    }
+
+    this.configUpdateListenerId = listenerId;
+    this.initialized = true;
+  }
+
+  onClose(): Promise<void> {
+    this.closePromise ??= this.close();
+    return this.closePromise;
+  }
+
+  resolveBooleanEvaluation(
+    flagKey: string,
+    _defaultValue: boolean,
+    context: EvaluationContext,
+    logger: Logger,
+  ): ResolutionDetails<boolean> {
+    return this.evaluate(flagKey, context, logger, 'boolean');
+  }
+
+  resolveStringEvaluation(
+    flagKey: string,
+    _defaultValue: string,
+    context: EvaluationContext,
+    logger: Logger,
+  ): ResolutionDetails<string> {
+    return this.evaluate(flagKey, context, logger, 'string');
+  }
+
+  resolveNumberEvaluation(
+    flagKey: string,
+    _defaultValue: number,
+    context: EvaluationContext,
+    logger: Logger,
+  ): ResolutionDetails<number> {
+    return this.evaluate(flagKey, context, logger, 'number');
+  }
+
+  resolveObjectEvaluation<T extends JsonValue>(
+    flagKey: string,
+    _defaultValue: T,
+    context: EvaluationContext,
+    logger: Logger,
+  ): ResolutionDetails<T> {
+    return this.evaluate<T>(flagKey, context, logger, 'object');
+  }
+
+  track(trackingEventName: string, context: EvaluationContext, details: TrackingEventDetails): void {
+    this.assertReady();
+    const { userId, attributes } = transformContext(context, NOOP_LOGGER);
+    const revenue = details['revenue'];
+    const hasOptimizelyRevenue = typeof revenue === 'number' && Number.isInteger(revenue);
+    const eventProperties = Object.fromEntries(
+      Object.entries(details).filter(([key]) => key !== 'value' && !(key === 'revenue' && hasOptimizelyRevenue)),
+    );
+    const eventTags: EventTags = {
+      ...(typeof details.value === 'number' ? { value: details.value } : {}),
+      ...(hasOptimizelyRevenue ? { revenue } : {}),
+      ...(Object.keys(eventProperties).length > 0 ? { $opt_event_properties: eventProperties } : {}),
+    };
+
+    this.client
+      .createUserContext(userId, attributes)
+      .trackEvent(trackingEventName, Object.keys(eventTags).length > 0 ? eventTags : undefined);
+  }
+
+  private evaluate<T extends JsonValue>(
+    flagKey: string,
+    context: EvaluationContext,
+    logger: Logger,
+    valueType: EvaluationValueType,
+  ): ResolutionDetails<T> {
+    this.assertReady();
+    const config = this.client.getOptimizelyConfig();
+    if (config === null) {
+      throw new ProviderNotReadyError('The Optimizely configuration is not available.');
+    }
+    if (!Object.hasOwn(config.featuresMap, flagKey)) {
+      throw new FlagNotFoundError(`Optimizely flag '${flagKey}' was not found.`);
+    }
+
+    const { userId, attributes } = transformContext(context, logger);
+    const decision = this.client.createUserContext(userId, attributes).decide(flagKey, [...this.decideOptions]);
+    return translateDecision<T>(decision, valueType);
+  }
+
+  private assertReady(): void {
+    if (!this.initialized || this.closePromise) {
+      throw new ProviderNotReadyError('The Optimizely provider has not been initialized.');
+    }
+  }
+
+  private async close(): Promise<void> {
+    try {
+      await this.initializationPromise;
+    } catch {
+      // Initialization errors are surfaced to the caller that initiated setup.
+    }
+
+    if (this.configUpdateListenerId !== undefined) {
+      this.client.notificationCenter.removeNotificationListener(this.configUpdateListenerId);
+      this.configUpdateListenerId = undefined;
+    }
+    this.initialized = false;
+
+    if (this.closeClientOnShutdown) {
+      await this.client.close();
+    }
+  }
+}
+
+function transformContext(context: EvaluationContext, logger: Logger): { userId: string; attributes: UserAttributes } {
+  const targetingKey = context['targetingKey'];
+  if (typeof targetingKey !== 'string' || targetingKey.trim().length === 0) {
+    throw new TargetingKeyMissingError('Optimizely evaluations require a non-empty string targetingKey.');
+  }
+
+  const attributes: UserAttributes = {};
+  for (const [key, value] of Object.entries(context as Record<string, unknown>)) {
+    if (key === 'targetingKey') {
+      continue;
+    }
+
+    if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      attributes[key] = value;
+      continue;
+    }
+
+    if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      attributes[key] = value.toISOString();
+      continue;
+    }
+
+    logger.warn(`Ignoring unsupported Optimizely attribute '${key}'.`);
+  }
+
+  return { userId: targetingKey, attributes };
+}
+
+function translateDecision<T extends JsonValue>(
+  decision: OptimizelyDecision,
+  valueType: EvaluationValueType,
+): ResolutionDetails<T> {
+  if (decision.variationKey === null) {
+    throw new GeneralError(decision.reasons.join('; ') || 'Optimizely could not make a decision.');
+  }
+
+  const variables = Object.values(decision.variables);
+  const value = getDecisionValue(variables, decision.variables, decision.enabled, valueType);
+
+  return {
+    value: value as T,
+    variant: decision.variationKey,
+    ...(decision.ruleKey === null ? {} : { flagMetadata: { ruleKey: decision.ruleKey } }),
+    reason: decision.enabled ? StandardResolutionReasons.UNKNOWN : StandardResolutionReasons.DISABLED,
+  };
+}
+
+function getDecisionValue(
+  variables: unknown[],
+  variablesMap: Record<string, unknown>,
+  enabled: boolean,
+  valueType: EvaluationValueType,
+): JsonValue {
+  if (variables.length === 0) {
+    if (valueType === 'boolean') {
+      return enabled;
+    }
+    throwTypeMismatch(valueType, 'a flag with no variables');
+  }
+
+  if (variables.length > 1) {
+    if (valueType === 'object' && isJsonValue(variablesMap)) {
+      return variablesMap;
+    }
+    throwTypeMismatch(valueType, 'a flag with multiple variables');
+  }
+
+  const [variable] = variables;
+  if (isExpectedType(variable, valueType)) {
+    return variable;
+  }
+  throwTypeMismatch(valueType, `a ${describeValue(variable)} variable`);
+}
+
+function isExpectedType(value: unknown, valueType: EvaluationValueType): value is JsonValue {
+  switch (valueType) {
+    case 'boolean':
+    case 'string':
+    case 'number':
+      return typeof value === valueType;
+    case 'object':
+      return (value === null || typeof value === 'object') && isJsonValue(value);
+  }
+}
+
+function isJsonValue(value: unknown, visited = new Set<object>()): value is JsonValue {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') {
+    return true;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value);
+  }
+  if (typeof value !== 'object' || visited.has(value)) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    visited.add(value);
+    const isValid = value.every((item) => isJsonValue(item, visited));
+    visited.delete(value);
+    return isValid;
+  }
+  if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) {
+    return false;
+  }
+  visited.add(value);
+  const isValid = Object.values(value).every((item) => isJsonValue(item, visited));
+  visited.delete(value);
+  return isValid;
+}
+
+function throwTypeMismatch(valueType: EvaluationValueType, actual: string): never {
+  throw new TypeMismatchError(`Cannot resolve ${actual} as an OpenFeature ${valueType} value.`);
+}
+
+function describeValue(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  return typeof value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/libs/providers/optimizely-web/src/test/jest.setup.ts
+++ b/libs/providers/optimizely-web/src/test/jest.setup.ts
@@ -1,0 +1,6 @@
+import { TextDecoder, TextEncoder } from 'node:util';
+
+Object.defineProperties(globalThis, {
+  TextDecoder: { value: TextDecoder },
+  TextEncoder: { value: TextEncoder },
+});

--- a/libs/providers/optimizely-web/src/test/optimizely-web-test-utils.ts
+++ b/libs/providers/optimizely-web/src/test/optimizely-web-test-utils.ts
@@ -1,0 +1,111 @@
+import {
+  type Client,
+  type EventDispatcher,
+  createForwardingEventProcessor,
+  createInstance,
+  createStaticProjectConfigManager,
+} from '@optimizely/optimizely-sdk';
+
+export const OPTIMIZELY_TEST_FLAG_KEYS = {
+  boolean: 'boolean-flag',
+  string: 'string-flag',
+  number: 'number-flag',
+  boolVariable: 'bool-variable-flag',
+  object: 'object-flag',
+  multiple: 'multiple-flag',
+  disabled: 'disabled-flag',
+} as const;
+
+const flag = (id: string, key: string, rolloutId: string, variables: unknown[] = []) => ({
+  id,
+  key,
+  rolloutId,
+  experimentIds: [],
+  variables,
+});
+
+const rollout = (
+  id: string,
+  experimentKey: string,
+  variationKey: string,
+  featureEnabled: boolean,
+  variables: unknown[] = [],
+) => ({
+  id,
+  experiments: [
+    {
+      id: `${id}-experiment`,
+      key: experimentKey,
+      applicationId: 'openfeature-test-application',
+      status: 'Running',
+      layerId: 'openfeature-test-layer',
+      audienceIds: [],
+      audienceConditions: [],
+      variations: [{ id: `${id}-variation`, key: variationKey, featureEnabled, variables }],
+      trafficAllocation: [{ entityId: `${id}-variation`, endOfRange: 100000 }],
+    },
+  ],
+});
+
+export const OPTIMIZELY_TEST_DATAFILE = JSON.stringify({
+  version: '4',
+  projectId: 'openfeature-test-project',
+  projectName: 'OpenFeature Optimizely provider tests',
+  revision: '1',
+  sdkKey: 'openfeature-test-sdk-key',
+  environmentKey: 'openfeature-test-environment',
+  accountId: 'openfeature-test-account',
+  events: [],
+  audiences: [],
+  typedAudiences: [],
+  groups: [],
+  attributes: [],
+  experiments: [],
+  experimentFeatureMap: {},
+  holdouts: [],
+  cmabExperiments: [],
+  integrations: [],
+  odpIntegrationConfig: { integrated: false },
+  featureFlags: [
+    flag('1', OPTIMIZELY_TEST_FLAG_KEYS.boolean, 'rollout-boolean'),
+    flag('2', OPTIMIZELY_TEST_FLAG_KEYS.string, 'rollout-string', [
+      { id: 'v20', key: 'string-value', type: 'string', defaultValue: 'default' },
+    ]),
+    flag('3', OPTIMIZELY_TEST_FLAG_KEYS.number, 'rollout-number', [
+      { id: 'v30', key: 'number-value', type: 'double', defaultValue: '0' },
+    ]),
+    flag('4', OPTIMIZELY_TEST_FLAG_KEYS.boolVariable, 'rollout-bool-variable', [
+      { id: 'v40', key: 'bool-value', type: 'boolean', defaultValue: 'false' },
+    ]),
+    flag('5', OPTIMIZELY_TEST_FLAG_KEYS.object, 'rollout-object', [
+      { id: 'v50', key: 'object-value', type: 'json', defaultValue: '{}' },
+    ]),
+    flag('6', OPTIMIZELY_TEST_FLAG_KEYS.multiple, 'rollout-multiple', [
+      { id: 'v60', key: 'first', type: 'string', defaultValue: 'a' },
+      { id: 'v61', key: 'second', type: 'integer', defaultValue: '1' },
+    ]),
+    flag('7', OPTIMIZELY_TEST_FLAG_KEYS.disabled, 'rollout-disabled'),
+  ],
+  rollouts: [
+    rollout('rollout-boolean', 'boolean-rule', 'on', true),
+    rollout('rollout-string', 'string-rule', 'on', true, [{ id: 'v20', value: 'hello' }]),
+    rollout('rollout-number', 'number-rule', 'on', true, [{ id: 'v30', value: '42.5' }]),
+    rollout('rollout-bool-variable', 'bool-variable-rule', 'on', true, [{ id: 'v40', value: 'true' }]),
+    rollout('rollout-object', 'object-rule', 'on', true, [{ id: 'v50', value: '{"color":"blue","count":2}' }]),
+    rollout('rollout-multiple', 'multiple-rule', 'on', true, [
+      { id: 'v60', value: 'one' },
+      { id: 'v61', value: '7' },
+    ]),
+    rollout('rollout-disabled', 'disabled-rule', 'off', false),
+  ],
+});
+
+const NOOP_EVENT_DISPATCHER: EventDispatcher = {
+  dispatchEvent: async () => ({ statusCode: 200 }),
+};
+
+export const createStaticOptimizelyClient = (eventDispatcher: EventDispatcher = NOOP_EVENT_DISPATCHER): Client =>
+  createInstance({
+    projectConfigManager: createStaticProjectConfigManager({ datafile: OPTIMIZELY_TEST_DATAFILE }),
+    eventProcessor: createForwardingEventProcessor(eventDispatcher),
+  });

--- a/libs/providers/optimizely-web/tsconfig.json
+++ b/libs/providers/optimizely-web/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ES6",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/providers/optimizely-web/tsconfig.lib.json
+++ b/libs/providers/optimizely-web/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "jest.config.cts", "src/**/*.spec.ts", "src/**/*.test.ts", "src/test/**"]
+}

--- a/libs/providers/optimizely-web/tsconfig.spec.json
+++ b/libs/providers/optimizely-web/tsconfig.spec.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "jest.config.cts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts",
+    "src/test/jest.setup.ts"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.205.0",
         "@opentelemetry/semantic-conventions": "^1.37.0",
+        "@optimizely/optimizely-sdk": "^6.6.0",
         "@protobuf-ts/grpc-transport": "^2.9.0",
         "@protobuf-ts/runtime-rpc": "^2.9.0",
         "@swc/helpers": "0.5.21",
@@ -7552,6 +7553,72 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@optimizely/optimizely-sdk": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@optimizely/optimizely-sdk/-/optimizely-sdk-6.6.0.tgz",
+      "integrity": "sha512-efPzH5PD4lKz7KyDiNjBKWUOC0lq0GKqoEammtpyvkTz0zoiwceURjXdpEgr/mW0S530D+Ts4Q0DeE6qV5LIlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "decompress-response": "^7.0.0",
+        "json-schema": "^0.4.0",
+        "murmurhash": "^2.0.1",
+        "uuid": "^13.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": ">=1.0.0 <3.0.0",
+        "@react-native-community/netinfo": ">=5.0.0 <12.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "react-native-get-random-values": "^1.11.0",
+        "ua-parser-js": "^1.0.38"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        },
+        "@react-native-community/netinfo": {
+          "optional": true
+        },
+        "fast-text-encoding": {
+          "optional": true
+        },
+        "react-native-get-random-values": {
+          "optional": true
+        },
+        "ua-parser-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@optimizely/optimizely-sdk/node_modules/decompress-response": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-7.0.0.tgz",
+      "integrity": "sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@optimizely/optimizely-sdk/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@oxc-resolver/binding-android-arm-eabi": {
@@ -21133,7 +21200,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
@@ -22231,6 +22297,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/murmurhash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-2.0.1.tgz",
+      "integrity": "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew==",
+      "license": "MIT"
     },
     "node_modules/mute-stream": {
       "version": "2.0.0",
@@ -26011,6 +26083,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -31730,6 +31815,32 @@
       "version": "1.37.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
       "integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA=="
+    },
+    "@optimizely/optimizely-sdk": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@optimizely/optimizely-sdk/-/optimizely-sdk-6.6.0.tgz",
+      "integrity": "sha512-efPzH5PD4lKz7KyDiNjBKWUOC0lq0GKqoEammtpyvkTz0zoiwceURjXdpEgr/mW0S530D+Ts4Q0DeE6qV5LIlQ==",
+      "requires": {
+        "decompress-response": "^7.0.0",
+        "json-schema": "^0.4.0",
+        "murmurhash": "^2.0.1",
+        "uuid": "^13.0.2"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-7.0.0.tgz",
+          "integrity": "sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==",
+          "requires": {
+            "mimic-response": "^3.1.0"
+          }
+        },
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
     },
     "@oxc-resolver/binding-android-arm-eabi": {
       "version": "11.19.1",
@@ -40650,8 +40761,7 @@
     "json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "1.0.0"
@@ -41354,6 +41464,11 @@
           "dev": true
         }
       }
+    },
+    "murmurhash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-2.0.1.tgz",
+      "integrity": "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew=="
     },
     "mute-stream": {
       "version": "2.0.0",
@@ -43842,6 +43957,11 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
+    },
+    "uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.205.0",
     "@opentelemetry/semantic-conventions": "^1.37.0",
+    "@optimizely/optimizely-sdk": "^6.6.0",
     "@protobuf-ts/grpc-transport": "^2.9.0",
     "@protobuf-ts/runtime-rpc": "^2.9.0",
     "@swc/helpers": "0.5.21",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -192,6 +192,13 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "versioning": "default"
+    },
+    "libs/providers/optimizely-web": {
+      "release-type": "node",
+      "prerelease": false,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "versioning": "default"
     }
   },
   "changelog-sections": [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -42,7 +42,8 @@
       "@openfeature/ofrep-provider": ["libs/providers/ofrep/src/index.ts"],
       "@openfeature/ofrep-web-provider": ["libs/providers/ofrep-web/src/index.ts"],
       "@openfeature/unleash-web-provider": ["libs/providers/unleash-web/src/index.ts"],
-      "@openfeature/azure-app-configuration-provider": ["libs/providers/azure-app-configuration/src/index.ts"]
+      "@openfeature/azure-app-configuration-provider": ["libs/providers/azure-app-configuration/src/index.ts"],
+      "@openfeature/optimizely-web-provider": ["libs/providers/optimizely-web/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## What this adds

This PR adds `@openfeature/optimizely-web-provider` for browser applications. This is also the React path: `@openfeature/react-sdk` consumes the client registered with the OpenFeature web SDK, so there is no separate Optimizely React adapter.

The provider maps targeting context, typed values, variants, rule metadata, tracking, lifecycle events, and optional client ownership to Optimizely's synchronous browser API. The synchronous boundary is intentional. Optimizely features that require asynchronous decisions are not supported here and remain a server concern.

The package includes deterministic contract and OpenFeature integration coverage and is registered in the repository's TypeScript paths, component ownership, and release configuration.

## Validation

```text
npx nx test optimizely-web --no-watchman  # 15 tests
npx nx lint optimizely-web
npx nx package optimizely-web
```

Contributors do not need an Optimizely account, credentials, environment variables, or network access to run these checks.

## How the split works

This is the browser/React portion of #1618. It has no runtime dependency on the server or Edge providers:

- Node.js/server: #1619
- Universal/Edge: #1621

All three PRs currently include the same root Optimizely development dependency. Once one merges, I will rebase the remaining PRs and remove that duplicate diff.

## Before this is ready

- [ ] Smoke-test the provider in a representative React or Next.js client application
- [ ] Add the provider to the openfeature.dev catalog
