### PR TITLE
feat(optimizely-edge): add Universal edge provider

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -34,6 +34,8 @@ components:
     - markphelps
   libs/providers/flipt-web:
     - markphelps
+  libs/providers/optimizely-edge:
+    - dflynn15
   libs/providers/unleash-web:
     - jarebudev
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -25,5 +25,6 @@
   "libs/providers/flagsmith": "0.1.2",
   "libs/hooks/debounce": "0.1.1",
   "libs/providers/localstorage": "0.1.2",
-  "libs/providers/azure-app-configuration": "0.1.1"
+  "libs/providers/azure-app-configuration": "0.1.1",
+  "libs/providers/optimizely-edge": "0.1.0"
 }

--- a/libs/providers/optimizely-edge/.eslintrc.json
+++ b/libs/providers/optimizely-edge/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../../.eslintrc.json",
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": ["{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/libs/providers/optimizely-edge/README.md
+++ b/libs/providers/optimizely-edge/README.md
@@ -1,0 +1,190 @@
+# Optimizely Edge Provider
+
+This package adapts the Optimizely Feature Experimentation JavaScript SDK's
+Universal entry point to OpenFeature in Web API-based server runtimes such as
+Next.js Edge and Cloudflare Workers (including Hono applications deployed to
+Workers).
+
+It is separate from the Node.js and browser providers so an edge bundle never
+resolves Optimizely's Node or `XMLHttpRequest` implementation by accident.
+
+## Installation
+
+```sh
+npm install @openfeature/optimizely-edge-provider @openfeature/web-sdk @optimizely/optimizely-sdk
+```
+
+The OpenFeature JavaScript server SDK is Node.js-specific. Edge applications
+therefore use the synchronous, Web API-compatible OpenFeature web SDK with this
+provider. React client components should continue to use
+`@openfeature/optimizely-web-provider`; Node.js
+server code should use [`@openfeature/optimizely-provider`](../optimizely/README.md).
+
+## Universal client setup
+
+Optimizely's Universal SDK requires an application-supplied project config
+manager and request handler. Load and cache the datafile with the APIs provided
+by your deployment platform, then construct the client from the explicit
+`/universal` entry point:
+
+```ts
+import { OpenFeature } from '@openfeature/web-sdk';
+import {
+  OptimizelyDecideOption,
+  createInstance,
+  createStaticProjectConfigManager,
+} from '@optimizely/optimizely-sdk/universal';
+import { OptimizelyEdgeProvider, createFetchRequestHandler } from '@openfeature/optimizely-edge-provider';
+
+export async function initializeOptimizelyEdge(datafile: string) {
+  const requestHandler = createFetchRequestHandler();
+  const optimizely = createInstance({
+    projectConfigManager: createStaticProjectConfigManager({ datafile }),
+    requestHandler,
+    disposable: true,
+    // The portable setup below performs decisions only. See Event delivery.
+    defaultDecideOptions: [OptimizelyDecideOption.DISABLE_DECISION_EVENT],
+  });
+
+  const provider = new OptimizelyEdgeProvider(optimizely, {
+    closeClientOnShutdown: true,
+  });
+  await OpenFeature.setProviderAndWait(provider);
+
+  return { client: OpenFeature.getClient(), provider };
+}
+```
+
+Call this lazily from an incoming request, or use a datafile bundled at build
+time. Cloudflare Workers do not allow `fetch()` at module scope. Cache the
+resulting initialization promise per isolate instead of replacing the global
+OpenFeature provider for every request.
+
+The OpenFeature web SDK has static global/domain context rather than the server
+SDK's per-invocation context argument. Mutating that static context for each
+request would let concurrent requests overwrite one another. Use the provider's
+synchronous context scope instead:
+
+```ts
+const { client, provider } = await initializeOnce();
+
+const enabled = provider.withEvaluationContext({ targetingKey: user.id, country: user.country }, () =>
+  client.getBooleanValue('checkout-redesign', false),
+);
+```
+
+`withEvaluationContext` restores the previous context before returning, so
+separate synchronous evaluation scopes cannot leak identity. Its callback must
+remain synchronous; perform request I/O before entering the scope.
+
+## Next.js Edge and Hono
+
+The provider has no framework dependency. A Next.js Edge route can evaluate
+after awaiting the application's cached initialization promise:
+
+```ts
+export const runtime = 'edge';
+
+export async function GET(request: Request) {
+  const { client, provider } = await getInitializedFeatureClient();
+  const enabled = provider.withEvaluationContext(
+    { targetingKey: request.headers.get('x-user-id') ?? crypto.randomUUID() },
+    () => client.getBooleanValue('checkout-redesign', false),
+  );
+
+  return Response.json({ enabled });
+}
+```
+
+The same initialized client works inside a Hono handler deployed to Cloudflare
+Workers:
+
+```ts
+app.get('/flags/:key', async (c) => {
+  const { client, provider } = await getInitializedFeatureClient(c.env);
+  const value = provider.withEvaluationContext({ targetingKey: c.req.header('x-user-id') ?? crypto.randomUUID() }, () =>
+    client.getBooleanValue(c.req.param('key'), false),
+  );
+
+  return c.json({ value });
+});
+```
+
+The application-specific `getInitializedFeatureClient` function should load
+the datafile from a build asset, KV, or a platform cache and reuse the initialized
+client while that datafile is current. The provider deliberately does not hide
+Next.js cache options or Cloudflare's Cache API behind a lowest-common-denominator
+abstraction.
+
+## Event delivery
+
+Decision impressions and tracking require an Optimizely event processor. Edge
+runtimes may cancel un-awaited network work after returning a response, so event
+delivery is platform-specific. On Cloudflare Workers, connect the request
+handler to the current execution context:
+
+```ts
+import { waitUntil } from 'cloudflare:workers';
+import {
+  createEventDispatcher,
+  createForwardingEventProcessor,
+  createInstance,
+  createStaticProjectConfigManager,
+} from '@optimizely/optimizely-sdk/universal';
+
+const requestHandler = createFetchRequestHandler({
+  schedule: waitUntil,
+});
+const optimizely = createInstance({
+  projectConfigManager: createStaticProjectConfigManager({ datafile }),
+  eventProcessor: createForwardingEventProcessor(createEventDispatcher(requestHandler)),
+  requestHandler,
+  disposable: true,
+});
+```
+
+Cloudflare's imported `waitUntil` binds to the current invocation, so a shared
+client does not retain an expired request context. Do not close over a Hono
+`c.executionCtx` or Worker `ctx` in a client that is cached across requests.
+Where the platform has no background-lifetime primitive, event delivery is best
+effort unless the application keeps the request alive until the event request
+settles.
+
+## Runtime and decision limitations
+
+- Only the explicit `@optimizely/optimizely-sdk/universal` entry point is
+  supported. Do not import the package root in an edge bundle.
+- Datafile loading, caching, and revalidation belong to the application. The
+  provider does not start Node.js polling, access a filesystem, or fetch at
+  module scope.
+- Evaluation is synchronous because the edge-safe OpenFeature SDK exposes
+  synchronous provider resolvers. Optimizely features that require asynchronous
+  decisions, including CMAB or asynchronous user-profile/ODP flows, are not
+  supported. Use the Node.js provider for those cases.
+- Request-specific targeting must use `withEvaluationContext` around synchronous
+  OpenFeature reads. Do not call the web SDK's global `setContext` per request,
+  and do not cross an `await` inside the scoped callback.
+- `targetingKey` is required and maps to the Optimizely user ID. Other primitive
+  invocation-context fields map to Optimizely user attributes.
+- Variable, error, variant, metadata, tracking, and lifecycle behavior otherwise
+  match the web provider.
+
+## Building and testing
+
+```sh
+npx nx test optimizely-edge --no-watchman
+npx nx lint optimizely-edge
+npx nx package optimizely-edge
+```
+
+The edge suite runs under a restricted Web Worker environment, constructs the
+Optimizely Universal client from a static datafile, and verifies typed
+OpenFeature evaluations without credentials or network access.
+
+## Related documentation
+
+- [Optimizely JavaScript SDK](https://github.com/optimizely/javascript-sdk)
+- [Optimizely Edge SDKs](https://docs.developers.optimizely.com/feature-experimentation/docs/get-started-edge-functions)
+- [Next.js Edge Runtime](https://nextjs.org/docs/pages/api-reference/edge)
+- [Cloudflare Workers runtime APIs](https://developers.cloudflare.com/workers/runtime-apis/)
+- [OpenFeature web SDK](https://openfeature.dev/docs/reference/technologies/client/web)

--- a/libs/providers/optimizely-edge/README.md
+++ b/libs/providers/optimizely-edge/README.md
@@ -1,9 +1,8 @@
 # Optimizely Edge Provider
 
-This package adapts the Optimizely Feature Experimentation JavaScript SDK's
-Universal entry point to OpenFeature in Web API-based server runtimes such as
-Next.js Edge and Cloudflare Workers (including Hono applications deployed to
-Workers).
+Use this provider to evaluate Optimizely Feature Experimentation flags through
+OpenFeature in Web API-based server runtimes such as Next.js Edge and
+Cloudflare Workers, including Hono applications deployed to Workers.
 
 It is separate from the Node.js and browser providers so an edge bundle never
 resolves Optimizely's Node or `XMLHttpRequest` implementation by accident.
@@ -17,8 +16,8 @@ npm install @openfeature/optimizely-edge-provider @openfeature/web-sdk @optimize
 The OpenFeature JavaScript server SDK is Node.js-specific. Edge applications
 therefore use the synchronous, Web API-compatible OpenFeature web SDK with this
 provider. React client components should continue to use
-`@openfeature/optimizely-web-provider`; Node.js
-server code should use [`@openfeature/optimizely-provider`](../optimizely/README.md).
+`@openfeature/optimizely-web-provider`; Node.js server code should use
+`@openfeature/optimizely-provider`.
 
 ## Universal client setup
 

--- a/libs/providers/optimizely-edge/babel.config.json
+++ b/libs/providers/optimizely-edge/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": [["minify", { "builtIns": false }]]
+}

--- a/libs/providers/optimizely-edge/jest.config.cts
+++ b/libs/providers/optimizely-edge/jest.config.cts
@@ -1,0 +1,11 @@
+module.exports = {
+  displayName: 'optimizely-edge',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['\\.edge\\.spec\\.ts$'],
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/providers/optimizely-edge',
+};

--- a/libs/providers/optimizely-edge/jest.edge.config.cts
+++ b/libs/providers/optimizely-edge/jest.edge.config.cts
@@ -1,0 +1,11 @@
+module.exports = {
+  displayName: 'optimizely-edge (edge runtime)',
+  preset: '../../../jest.preset.js',
+  testEnvironment: '<rootDir>/src/test/jest-environment-web-worker.js',
+  testMatch: ['<rootDir>/src/**/*.edge.spec.ts'],
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/providers/optimizely-edge',
+};

--- a/libs/providers/optimizely-edge/package.json
+++ b/libs/providers/optimizely-edge/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@openfeature/optimizely-edge-provider",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-feature/js-sdk-contrib.git",
+    "directory": "libs/providers/optimizely-edge"
+  },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi",
+    "current-version": "echo $npm_package_version"
+  },
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "@openfeature/web-sdk": "^1.6.0",
+    "@optimizely/optimizely-sdk": "^6.6.0"
+  }
+}

--- a/libs/providers/optimizely-edge/project.json
+++ b/libs/providers/optimizely-edge/project.json
@@ -1,0 +1,93 @@
+{
+  "name": "optimizely-edge",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/providers/optimizely-edge/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": ["dist/{projectRoot}"],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "{projectRoot}/jest.config.cts"
+      },
+      "dependsOn": [
+        {
+          "target": "package"
+        },
+        {
+          "target": "test-edge",
+          "params": "forward"
+        }
+      ]
+    },
+    "test-edge": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "{projectRoot}/jest.edge.config.cts",
+        "coverageProvider": "v8"
+      }
+    },
+    "package": {
+      "executor": "@nx/rollup:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "project": "libs/providers/optimizely-edge/package.json",
+        "outputPath": "dist/libs/providers/optimizely-edge",
+        "entryFile": "libs/providers/optimizely-edge/src/index.ts",
+        "tsConfig": "libs/providers/optimizely-edge/tsconfig.lib.json",
+        "compiler": "tsc",
+        "generateExportsField": true,
+        "umdName": "optimizely-edge",
+        "external": "all",
+        "format": ["esm"],
+        "assets": [
+          {
+            "glob": "package.json",
+            "input": "./assets",
+            "output": "./src/"
+          },
+          {
+            "glob": "LICENSE",
+            "input": "./",
+            "output": "./"
+          },
+          {
+            "glob": "README.md",
+            "input": "./libs/providers/optimizely-edge",
+            "output": "./"
+          }
+        ]
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run publish-if-not-exists",
+        "cwd": "dist/libs/providers/optimizely-edge"
+      },
+      "dependsOn": [
+        {
+          "projects": "self",
+          "target": "package"
+        }
+      ]
+    }
+  }
+}

--- a/libs/providers/optimizely-edge/src/index.ts
+++ b/libs/providers/optimizely-edge/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/fetch-request-handler';
+export * from './lib/optimizely-edge-provider';

--- a/libs/providers/optimizely-edge/src/lib/fetch-request-handler.edge.spec.ts
+++ b/libs/providers/optimizely-edge/src/lib/fetch-request-handler.edge.spec.ts
@@ -1,0 +1,69 @@
+import { createFetchRequestHandler } from './fetch-request-handler';
+
+describe('createFetchRequestHandler in an edge runtime', () => {
+  it('translates Fetch responses to the Universal SDK response shape', async () => {
+    const fetch = jest.fn().mockResolvedValue(
+      new Response('{"ok":true}', {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ) as jest.MockedFunction<typeof globalThis.fetch>;
+    const handler = createFetchRequestHandler({ fetch });
+
+    const request = handler.makeRequest('https://example.test/datafile', { authorization: 'Bearer test' }, 'GET');
+    await expect(request.responsePromise).resolves.toEqual({
+      statusCode: 201,
+      body: '{"ok":true}',
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(fetch).toHaveBeenCalledWith('https://example.test/datafile', {
+      method: 'GET',
+      headers: { authorization: 'Bearer test' },
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it('aborts an in-flight Fetch request', async () => {
+    let signal: AbortSignal | undefined;
+    const fetch = jest.fn().mockImplementation((_url: RequestInfo | URL, init?: RequestInit) => {
+      signal = init?.signal ?? undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+      });
+    }) as jest.MockedFunction<typeof globalThis.fetch>;
+    const handler = createFetchRequestHandler({ fetch });
+    const request = handler.makeRequest('https://example.test/datafile', {}, 'GET');
+
+    request.abort();
+
+    expect(signal?.aborted).toBe(true);
+    await expect(request.responsePromise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('hands background work to an edge scheduler', async () => {
+    const scheduled: Promise<unknown>[] = [];
+    const fetch = jest.fn().mockResolvedValue(new Response('ok')) as jest.MockedFunction<typeof globalThis.fetch>;
+    const handler = createFetchRequestHandler({ fetch, schedule: (task) => scheduled.push(task) });
+
+    const request = handler.makeRequest('https://example.test/event', {}, 'POST', '{"event":"test"}');
+    await request.responsePromise;
+
+    expect(scheduled).toHaveLength(1);
+    await expect(scheduled[0]).resolves.toMatchObject({
+      statusCode: 200,
+      body: 'ok',
+    });
+  });
+
+  it('preserves request failures without rejecting scheduled background work', async () => {
+    const failure = new TypeError('network unavailable');
+    const scheduled: Promise<unknown>[] = [];
+    const fetch = jest.fn().mockRejectedValue(failure) as jest.MockedFunction<typeof globalThis.fetch>;
+    const handler = createFetchRequestHandler({ fetch, schedule: (task) => scheduled.push(task) });
+
+    const request = handler.makeRequest('https://example.test/event', {}, 'POST');
+
+    await expect(request.responsePromise).rejects.toBe(failure);
+    await expect(scheduled[0]).resolves.toBeUndefined();
+  });
+});

--- a/libs/providers/optimizely-edge/src/lib/fetch-request-handler.ts
+++ b/libs/providers/optimizely-edge/src/lib/fetch-request-handler.ts
@@ -1,0 +1,57 @@
+import type { RequestHandler } from '@optimizely/optimizely-sdk/universal';
+
+export interface FetchRequestHandlerOptions {
+  /** Fetch implementation supplied by the edge runtime. Defaults to globalThis.fetch. */
+  fetch?: typeof globalThis.fetch;
+  /**
+   * Registers background requests with the edge runtime.
+   * For Cloudflare Workers, pass `(task) => ctx.waitUntil(task)`.
+   */
+  schedule?: (task: Promise<unknown>) => void;
+}
+
+export function createFetchRequestHandler(options: FetchRequestHandlerOptions = {}): RequestHandler {
+  const fetchImplementation = options.fetch ?? globalThis.fetch;
+
+  if (typeof fetchImplementation !== 'function') {
+    throw new TypeError('A Fetch API implementation is required.');
+  }
+
+  return {
+    makeRequest(url, headers, method, data) {
+      const controller = new AbortController();
+      const request = fetchImplementation(url, {
+        method,
+        headers: Object.fromEntries(
+          Object.entries(headers).filter((entry): entry is [string, string] => entry[1] !== undefined),
+        ),
+        ...(data === undefined ? {} : { body: data }),
+        signal: controller.signal,
+      }).then(async (response) => {
+        const responseHeaders: Record<string, string> = {};
+        response.headers.forEach((value, key) => {
+          responseHeaders[key] = value;
+        });
+
+        return {
+          statusCode: response.status,
+          body: await response.text(),
+          headers: responseHeaders,
+        };
+      });
+
+      if (options.schedule) {
+        try {
+          options.schedule(request.catch(() => undefined));
+        } catch {
+          // Scheduling is an edge-runtime concern and must not change request semantics.
+        }
+      }
+
+      return {
+        abort: () => controller.abort(),
+        responsePromise: request,
+      };
+    },
+  };
+}

--- a/libs/providers/optimizely-edge/src/lib/optimizely-edge-package.spec.ts
+++ b/libs/providers/optimizely-edge/src/lib/optimizely-edge-package.spec.ts
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { EdgeVM } from '@edge-runtime/vm';
+import commonjs from '@rollup/plugin-commonjs';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import { rollup } from 'rollup';
+
+describe('Optimizely edge package output', () => {
+  const packageRoot = resolve(__dirname, '../../../../../dist/libs/providers/optimizely-edge');
+
+  it('publishes an ESM entry point without Node-only imports', () => {
+    const packageJsonPath = resolve(packageRoot, 'package.json');
+    const entryPath = resolve(packageRoot, 'index.esm.js');
+
+    expect(existsSync(packageJsonPath)).toBe(true);
+
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      exports: { '.': { import: string; types: string } };
+    };
+    const entry = readFileSync(entryPath, 'utf8');
+
+    expect(packageJson.exports['.'].import).toBe('./index.esm.js');
+    expect(packageJson.exports['.'].types).toBe('./index.d.ts');
+    expect(existsSync(resolve(packageRoot, packageJson.exports['.'].import))).toBe(true);
+    expect(existsSync(resolve(packageRoot, packageJson.exports['.'].types))).toBe(true);
+    expect(entry).toContain("from '@optimizely/optimizely-sdk/universal'");
+    expect(entry).not.toMatch(/\brequire\s*\(/);
+    expect(entry).not.toMatch(/\bnode:/);
+  });
+
+  it('bundles the published dependency graph and executes it in an edge VM', async () => {
+    const entryPath = resolve(packageRoot, 'index.esm.js');
+    const bundle = await rollup({
+      input: entryPath,
+      plugins: [nodeResolve({ browser: true, exportConditions: ['edge', 'browser', 'import'] }), commonjs()],
+      onwarn(warning) {
+        if (warning.code === 'UNRESOLVED_IMPORT') {
+          throw new Error(warning.message);
+        }
+      },
+    });
+
+    try {
+      const { output } = await bundle.generate({ format: 'iife', name: 'OptimizelyEdge' });
+      const code = output.map((chunk) => ('code' in chunk ? chunk.code : '')).join('\n');
+
+      expect(code).not.toMatch(/\bnode:/);
+      expect(code).not.toMatch(/\brequire\s*\(/);
+      expect(
+        () =>
+          new EdgeVM({
+            initialCode: `${code}; if (typeof OptimizelyEdge.OptimizelyEdgeProvider !== 'function') {
+              throw new Error('Provider export missing from edge bundle');
+            }`,
+          }),
+      ).not.toThrow();
+    } finally {
+      await bundle.close();
+    }
+  }, 30_000);
+});

--- a/libs/providers/optimizely-edge/src/lib/optimizely-edge-provider.edge.spec.ts
+++ b/libs/providers/optimizely-edge/src/lib/optimizely-edge-provider.edge.spec.ts
@@ -1,0 +1,142 @@
+import { ErrorCode, OpenFeature, StandardResolutionReasons, type Logger } from '@openfeature/web-sdk';
+
+import { OptimizelyEdgeProvider } from './optimizely-edge-provider';
+import { createStaticUniversalClient, EDGE_TEST_FLAG_KEYS } from '../test/universal-client';
+
+const logger: Logger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+};
+
+describe('OptimizelyEdgeProvider in an edge runtime', () => {
+  let optimizely: ReturnType<typeof createStaticUniversalClient>;
+  let provider: OptimizelyEdgeProvider;
+
+  beforeEach(async () => {
+    optimizely = createStaticUniversalClient();
+    provider = new OptimizelyEdgeProvider(optimizely, { closeClientOnShutdown: true });
+    await provider.initialize();
+  });
+
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
+    await OpenFeature.clearContext();
+    await provider.onClose();
+  });
+
+  it('evaluates boolean, string, number, and object flags synchronously', () => {
+    const context = { targetingKey: 'edge-user' };
+
+    expect(provider.resolveBooleanEvaluation(EDGE_TEST_FLAG_KEYS.boolean, false, context, logger)).toMatchObject({
+      value: true,
+      variant: 'on',
+    });
+    expect(provider.resolveStringEvaluation(EDGE_TEST_FLAG_KEYS.string, '', context, logger)).toMatchObject({
+      value: 'hello-edge',
+      variant: 'on',
+    });
+    expect(provider.resolveNumberEvaluation(EDGE_TEST_FLAG_KEYS.number, 0, context, logger)).toMatchObject({
+      value: 42.5,
+      variant: 'on',
+    });
+    expect(provider.resolveObjectEvaluation(EDGE_TEST_FLAG_KEYS.object, {}, context, logger)).toMatchObject({
+      value: { color: 'blue', count: 2 },
+      variant: 'on',
+    });
+  });
+
+  it('uses each invocation context without leaking identity between requests', () => {
+    const createUserContext = jest.spyOn(optimizely, 'createUserContext');
+
+    provider.resolveBooleanEvaluation(EDGE_TEST_FLAG_KEYS.boolean, false, { targetingKey: 'first-user' }, logger);
+    provider.resolveBooleanEvaluation(EDGE_TEST_FLAG_KEYS.boolean, false, { targetingKey: 'second-user' }, logger);
+
+    expect(createUserContext.mock.calls.map(([userId]) => userId)).toEqual(['first-user', 'second-user']);
+    expect(createUserContext.mock.calls[0]?.[1]).toEqual({});
+    expect(createUserContext.mock.calls[1]?.[1]).toEqual({});
+  });
+
+  it('evaluates typed values through OpenFeature with context isolated per invocation', async () => {
+    const createUserContext = jest.spyOn(optimizely, 'createUserContext');
+    await OpenFeature.setProviderAndWait(provider, { targetingKey: 'global-fallback' });
+    const client = OpenFeature.getClient();
+
+    expect(
+      provider.withEvaluationContext({ targetingKey: 'first-request' }, () =>
+        client.getBooleanValue(EDGE_TEST_FLAG_KEYS.boolean, false),
+      ),
+    ).toBe(true);
+    expect(
+      provider.withEvaluationContext({ targetingKey: 'second-request' }, () =>
+        client.getStringValue(EDGE_TEST_FLAG_KEYS.string, ''),
+      ),
+    ).toBe('hello-edge');
+    expect(
+      provider.withEvaluationContext({ targetingKey: 'third-request' }, () =>
+        client.getNumberValue(EDGE_TEST_FLAG_KEYS.number, 0),
+      ),
+    ).toBe(42.5);
+    expect(
+      provider.withEvaluationContext({ targetingKey: 'fourth-request' }, () =>
+        client.getObjectValue(EDGE_TEST_FLAG_KEYS.object, {}),
+      ),
+    ).toEqual({
+      color: 'blue',
+      count: 2,
+    });
+
+    expect(client.getBooleanValue(EDGE_TEST_FLAG_KEYS.boolean, false)).toBe(true);
+
+    expect(createUserContext.mock.calls.map(([userId]) => userId)).toEqual([
+      'first-request',
+      'second-request',
+      'third-request',
+      'fourth-request',
+      'global-fallback',
+    ]);
+  });
+
+  it('rejects asynchronous scoped-context callbacks without leaking context', async () => {
+    const createUserContext = jest.spyOn(optimizely, 'createUserContext');
+    await OpenFeature.setProviderAndWait(provider, { targetingKey: 'global-fallback' });
+    const client = OpenFeature.getClient();
+
+    expect(() =>
+      provider.withEvaluationContext({ targetingKey: 'request-user' }, async () =>
+        client.getBooleanValue(EDGE_TEST_FLAG_KEYS.boolean, false),
+      ),
+    ).toThrow('withEvaluationContext callbacks must be synchronous.');
+
+    expect(client.getBooleanValue(EDGE_TEST_FLAG_KEYS.boolean, false)).toBe(true);
+    expect(createUserContext.mock.calls.map(([userId]) => userId)).toEqual(['request-user', 'global-fallback']);
+  });
+
+  it('retains OpenFeature details and reports provider errors', () => {
+    const success = provider.resolveStringEvaluation(
+      EDGE_TEST_FLAG_KEYS.string,
+      'fallback',
+      {
+        targetingKey: 'edge-user',
+      },
+      logger,
+    );
+    const missing = (() => {
+      try {
+        return provider.resolveBooleanEvaluation('missing-flag', true, { targetingKey: 'edge-user' }, logger);
+      } catch (error) {
+        return error;
+      }
+    })();
+
+    expect(success).toMatchObject({
+      value: 'hello-edge',
+      variant: 'on',
+      flagMetadata: { ruleKey: 'edge-string-rule' },
+    });
+    expect(missing).toBeInstanceOf(Error);
+    expect((missing as { code?: string }).code).toBe(ErrorCode.FLAG_NOT_FOUND);
+    expect(success.reason).not.toBe(StandardResolutionReasons.ERROR);
+  });
+});

--- a/libs/providers/optimizely-edge/src/lib/optimizely-edge-provider.ts
+++ b/libs/providers/optimizely-edge/src/lib/optimizely-edge-provider.ts
@@ -1,0 +1,366 @@
+import {
+  NOTIFICATION_TYPES,
+  OptimizelyDecideOption,
+  type Client,
+  type EventTags,
+  type OptimizelyDecision,
+  type UserAttributes,
+} from '@optimizely/optimizely-sdk/universal';
+import {
+  FlagNotFoundError,
+  GeneralError,
+  OpenFeatureEventEmitter,
+  ProviderEvents,
+  ProviderNotReadyError,
+  StandardResolutionReasons,
+  TargetingKeyMissingError,
+  TypeMismatchError,
+  type EvaluationContext,
+  type JsonValue,
+  type Logger,
+  type Provider,
+  type ResolutionDetails,
+  type TrackingEventDetails,
+} from '@openfeature/web-sdk';
+
+export interface OptimizelyEdgeProviderOptions {
+  /** Close the supplied Optimizely client when the provider is closed. Defaults to false. */
+  closeClientOnShutdown?: boolean;
+  /** Options applied to every Optimizely flag decision. */
+  decideOptions?: OptimizelyDecideOption[];
+}
+
+type EvaluationValueType = 'boolean' | 'string' | 'number' | 'object';
+
+const NOOP_LOGGER: Logger = {
+  error: () => undefined,
+  warn: () => undefined,
+  info: () => undefined,
+  debug: () => undefined,
+};
+
+export class OptimizelyEdgeProvider implements Provider {
+  readonly metadata = {
+    name: OptimizelyEdgeProvider.name,
+  };
+
+  readonly runsOn = 'client';
+  readonly hooks = [];
+  readonly events = new OpenFeatureEventEmitter();
+
+  private readonly closeClientOnShutdown: boolean;
+  private readonly decideOptions: OptimizelyDecideOption[];
+  private configUpdateListenerId?: number;
+  private initialized = false;
+  private initializationPromise?: Promise<void>;
+  private closePromise?: Promise<void>;
+  private evaluationContextOverride?: EvaluationContext;
+
+  constructor(
+    private readonly client: Client,
+    options: OptimizelyEdgeProviderOptions = {},
+  ) {
+    if (options.decideOptions?.includes(OptimizelyDecideOption.EXCLUDE_VARIABLES)) {
+      throw new TypeError('EXCLUDE_VARIABLES is incompatible with OpenFeature value resolution.');
+    }
+
+    this.closeClientOnShutdown = options.closeClientOnShutdown ?? false;
+    this.decideOptions = [...(options.decideOptions ?? [])];
+  }
+
+  initialize(): Promise<void> {
+    if (this.closePromise) {
+      return Promise.reject(new ProviderNotReadyError('The Optimizely provider is closing or has been closed.'));
+    }
+    if (this.initialized) {
+      return Promise.resolve();
+    }
+
+    this.initializationPromise ??= this.initializeClient().catch((error) => {
+      this.initializationPromise = undefined;
+      throw error;
+    });
+    return this.initializationPromise;
+  }
+
+  private async initializeClient(): Promise<void> {
+    try {
+      await this.client.onReady();
+    } catch (error) {
+      throw new GeneralError(`Optimizely client initialization failed: ${errorMessage(error)}`);
+    }
+
+    const listenerId = this.client.notificationCenter.addNotificationListener(
+      NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+      () => this.events.emit(ProviderEvents.ConfigurationChanged),
+    );
+    if (listenerId < 1) {
+      throw new GeneralError('Unable to register the Optimizely configuration update listener.');
+    }
+
+    this.configUpdateListenerId = listenerId;
+    this.initialized = true;
+  }
+
+  onClose(): Promise<void> {
+    this.closePromise ??= this.close();
+    return this.closePromise;
+  }
+
+  /**
+   * Applies request-specific context to synchronous OpenFeature web SDK evaluations.
+   * The callback must not return a Promise or cross an asynchronous boundary.
+   */
+  withEvaluationContext<T>(context: EvaluationContext, callback: () => T): T {
+    const previousContext = this.evaluationContextOverride;
+    this.evaluationContextOverride = { ...previousContext, ...context };
+
+    try {
+      const result = callback();
+      if (isPromiseLike(result)) {
+        throw new TypeError('withEvaluationContext callbacks must be synchronous.');
+      }
+      return result;
+    } finally {
+      this.evaluationContextOverride = previousContext;
+    }
+  }
+
+  resolveBooleanEvaluation(
+    flagKey: string,
+    _defaultValue: boolean,
+    context: EvaluationContext,
+    logger: Logger,
+  ): ResolutionDetails<boolean> {
+    return this.evaluate(flagKey, context, logger, 'boolean');
+  }
+
+  resolveStringEvaluation(
+    flagKey: string,
+    _defaultValue: string,
+    context: EvaluationContext,
+    logger: Logger,
+  ): ResolutionDetails<string> {
+    return this.evaluate(flagKey, context, logger, 'string');
+  }
+
+  resolveNumberEvaluation(
+    flagKey: string,
+    _defaultValue: number,
+    context: EvaluationContext,
+    logger: Logger,
+  ): ResolutionDetails<number> {
+    return this.evaluate(flagKey, context, logger, 'number');
+  }
+
+  resolveObjectEvaluation<T extends JsonValue>(
+    flagKey: string,
+    _defaultValue: T,
+    context: EvaluationContext,
+    logger: Logger,
+  ): ResolutionDetails<T> {
+    return this.evaluate<T>(flagKey, context, logger, 'object');
+  }
+
+  track(trackingEventName: string, context: EvaluationContext, details: TrackingEventDetails): void {
+    this.assertReady();
+    const { userId, attributes } = transformContext(this.mergeEvaluationContext(context), NOOP_LOGGER);
+    const revenue = details['revenue'];
+    const hasOptimizelyRevenue = typeof revenue === 'number' && Number.isInteger(revenue);
+    const eventProperties = Object.fromEntries(
+      Object.entries(details).filter(([key]) => key !== 'value' && !(key === 'revenue' && hasOptimizelyRevenue)),
+    );
+    const eventTags: EventTags = {
+      ...(typeof details.value === 'number' ? { value: details.value } : {}),
+      ...(hasOptimizelyRevenue ? { revenue } : {}),
+      ...(Object.keys(eventProperties).length > 0 ? { $opt_event_properties: eventProperties } : {}),
+    };
+
+    this.client
+      .createUserContext(userId, attributes)
+      .trackEvent(trackingEventName, Object.keys(eventTags).length > 0 ? eventTags : undefined);
+  }
+
+  private evaluate<T extends JsonValue>(
+    flagKey: string,
+    context: EvaluationContext,
+    logger: Logger,
+    valueType: EvaluationValueType,
+  ): ResolutionDetails<T> {
+    this.assertReady();
+    const config = this.client.getOptimizelyConfig();
+    if (config === null) {
+      throw new ProviderNotReadyError('The Optimizely configuration is not available.');
+    }
+    if (!Object.hasOwn(config.featuresMap, flagKey)) {
+      throw new FlagNotFoundError(`Optimizely flag '${flagKey}' was not found.`);
+    }
+
+    const { userId, attributes } = transformContext(this.mergeEvaluationContext(context), logger);
+    const decision = this.client.createUserContext(userId, attributes).decide(flagKey, [...this.decideOptions]);
+    return translateDecision<T>(decision, valueType);
+  }
+
+  private assertReady(): void {
+    if (!this.initialized || this.closePromise) {
+      throw new ProviderNotReadyError('The Optimizely provider has not been initialized.');
+    }
+  }
+
+  private mergeEvaluationContext(context: EvaluationContext): EvaluationContext {
+    return { ...context, ...this.evaluationContextOverride };
+  }
+
+  private async close(): Promise<void> {
+    try {
+      await this.initializationPromise;
+    } catch {
+      // Initialization errors are surfaced to the caller that initiated setup.
+    }
+
+    if (this.configUpdateListenerId !== undefined) {
+      this.client.notificationCenter.removeNotificationListener(this.configUpdateListenerId);
+      this.configUpdateListenerId = undefined;
+    }
+    this.initialized = false;
+
+    if (this.closeClientOnShutdown) {
+      await this.client.close();
+    }
+  }
+}
+
+function transformContext(context: EvaluationContext, logger: Logger): { userId: string; attributes: UserAttributes } {
+  const targetingKey = context['targetingKey'];
+  if (typeof targetingKey !== 'string' || targetingKey.trim().length === 0) {
+    throw new TargetingKeyMissingError('Optimizely evaluations require a non-empty string targetingKey.');
+  }
+
+  const attributes: UserAttributes = {};
+  for (const [key, value] of Object.entries(context as Record<string, unknown>)) {
+    if (key === 'targetingKey') {
+      continue;
+    }
+
+    if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      attributes[key] = value;
+      continue;
+    }
+
+    if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      attributes[key] = value.toISOString();
+      continue;
+    }
+
+    logger.warn(`Ignoring unsupported Optimizely attribute '${key}'.`);
+  }
+
+  return { userId: targetingKey, attributes };
+}
+
+function translateDecision<T extends JsonValue>(
+  decision: OptimizelyDecision,
+  valueType: EvaluationValueType,
+): ResolutionDetails<T> {
+  if (decision.variationKey === null) {
+    throw new GeneralError(decision.reasons.join('; ') || 'Optimizely could not make a decision.');
+  }
+
+  const variables = Object.values(decision.variables);
+  const value = getDecisionValue(variables, decision.variables, decision.enabled, valueType);
+
+  return {
+    value: value as T,
+    variant: decision.variationKey,
+    ...(decision.ruleKey === null ? {} : { flagMetadata: { ruleKey: decision.ruleKey } }),
+    reason: decision.enabled ? StandardResolutionReasons.UNKNOWN : StandardResolutionReasons.DISABLED,
+  };
+}
+
+function getDecisionValue(
+  variables: unknown[],
+  variablesMap: Record<string, unknown>,
+  enabled: boolean,
+  valueType: EvaluationValueType,
+): JsonValue {
+  if (variables.length === 0) {
+    if (valueType === 'boolean') {
+      return enabled;
+    }
+    throwTypeMismatch(valueType, 'a flag with no variables');
+  }
+
+  if (variables.length > 1) {
+    if (valueType === 'object' && isJsonValue(variablesMap)) {
+      return variablesMap;
+    }
+    throwTypeMismatch(valueType, 'a flag with multiple variables');
+  }
+
+  const [variable] = variables;
+  if (isExpectedType(variable, valueType)) {
+    return variable;
+  }
+  throwTypeMismatch(valueType, `a ${describeValue(variable)} variable`);
+}
+
+function isExpectedType(value: unknown, valueType: EvaluationValueType): value is JsonValue {
+  switch (valueType) {
+    case 'boolean':
+    case 'string':
+    case 'number':
+      return typeof value === valueType;
+    case 'object':
+      return (value === null || typeof value === 'object') && isJsonValue(value);
+  }
+}
+
+function isJsonValue(value: unknown, visited = new Set<object>()): value is JsonValue {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') {
+    return true;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value);
+  }
+  if (typeof value !== 'object' || visited.has(value)) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    visited.add(value);
+    const isValid = value.every((item) => isJsonValue(item, visited));
+    visited.delete(value);
+    return isValid;
+  }
+  if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) {
+    return false;
+  }
+  visited.add(value);
+  const isValid = Object.values(value).every((item) => isJsonValue(item, visited));
+  visited.delete(value);
+  return isValid;
+}
+
+function throwTypeMismatch(valueType: EvaluationValueType, actual: string): never {
+  throw new TypeMismatchError(`Cannot resolve ${actual} as an OpenFeature ${valueType} value.`);
+}
+
+function describeValue(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  return typeof value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === 'object' && value !== null && 'then' in value && typeof value.then === 'function') ||
+    (typeof value === 'function' && 'then' in value && typeof value.then === 'function')
+  );
+}

--- a/libs/providers/optimizely-edge/src/test/jest-environment-web-worker.js
+++ b/libs/providers/optimizely-edge/src/test/jest-environment-web-worker.js
@@ -1,0 +1,8 @@
+'use strict';
+
+// Cloudflare Workers, Vercel Edge, and similar isolates reject dynamic code
+// generation. The edge-runtime environment also supplies the Web APIs used by
+// the Universal Optimizely SDK (fetch, Request, Response, URL, and crypto).
+const { default: WorkerEnvironment } = require('@edge-runtime/jest-environment');
+
+module.exports = WorkerEnvironment;

--- a/libs/providers/optimizely-edge/src/test/universal-client.ts
+++ b/libs/providers/optimizely-edge/src/test/universal-client.ts
@@ -1,0 +1,98 @@
+import {
+  createInstance,
+  createStaticProjectConfigManager,
+  type Client,
+  type RequestHandler,
+} from '@optimizely/optimizely-sdk/universal';
+
+export const EDGE_TEST_FLAG_KEYS = {
+  boolean: 'edge-boolean-flag',
+  string: 'edge-string-flag',
+  number: 'edge-number-flag',
+  object: 'edge-object-flag',
+} as const;
+
+const flag = (id: string, key: string, rolloutId: string, variables: unknown[] = []) => ({
+  id,
+  key,
+  rolloutId,
+  experimentIds: [],
+  variables,
+});
+
+const rollout = (
+  id: string,
+  experimentKey: string,
+  variationKey: string,
+  variables: unknown[] = [],
+  featureEnabled = true,
+) => ({
+  id,
+  experiments: [
+    {
+      id: `${id}-experiment`,
+      key: experimentKey,
+      applicationId: 'openfeature-edge-test-application',
+      status: 'Running',
+      layerId: 'openfeature-edge-test-layer',
+      audienceIds: [],
+      audienceConditions: [],
+      variations: [{ id: `${id}-variation`, key: variationKey, featureEnabled, variables }],
+      trafficAllocation: [{ entityId: `${id}-variation`, endOfRange: 100000 }],
+    },
+  ],
+});
+
+export const OPTIMIZELY_EDGE_TEST_DATAFILE = JSON.stringify({
+  version: '4',
+  projectId: 'openfeature-edge-test-project',
+  projectName: 'OpenFeature Optimizely edge provider tests',
+  revision: '1',
+  sdkKey: 'openfeature-edge-test-sdk-key',
+  environmentKey: 'openfeature-edge-test-environment',
+  accountId: 'openfeature-edge-test-account',
+  events: [],
+  audiences: [],
+  typedAudiences: [],
+  groups: [],
+  attributes: [],
+  experiments: [],
+  experimentFeatureMap: {},
+  holdouts: [],
+  cmabExperiments: [],
+  integrations: [],
+  odpIntegrationConfig: { integrated: false },
+  featureFlags: [
+    flag('1', EDGE_TEST_FLAG_KEYS.boolean, 'edge-rollout-boolean'),
+    flag('2', EDGE_TEST_FLAG_KEYS.string, 'edge-rollout-string', [
+      { id: 'v2', key: 'string-value', type: 'string', defaultValue: 'default' },
+    ]),
+    flag('3', EDGE_TEST_FLAG_KEYS.number, 'edge-rollout-number', [
+      { id: 'v3', key: 'number-value', type: 'double', defaultValue: '0' },
+    ]),
+    flag('4', EDGE_TEST_FLAG_KEYS.object, 'edge-rollout-object', [
+      { id: 'v4', key: 'object-value', type: 'json', defaultValue: '{}' },
+    ]),
+  ],
+  rollouts: [
+    rollout('edge-rollout-boolean', 'edge-boolean-rule', 'on'),
+    rollout('edge-rollout-string', 'edge-string-rule', 'on', [{ id: 'v2', value: 'hello-edge' }]),
+    rollout('edge-rollout-number', 'edge-number-rule', 'on', [{ id: 'v3', value: '42.5' }]),
+    rollout('edge-rollout-object', 'edge-object-rule', 'on', [{ id: 'v4', value: '{"color":"blue","count":2}' }]),
+  ],
+});
+
+const staticRequestHandler: RequestHandler = {
+  makeRequest: () => ({
+    abort: () => undefined,
+    responsePromise: Promise.resolve({ statusCode: 200, body: '', headers: {} }),
+  }),
+};
+
+export function createStaticUniversalClient(): Client {
+  return createInstance({
+    projectConfigManager: createStaticProjectConfigManager({ datafile: OPTIMIZELY_EDGE_TEST_DATAFILE }),
+    requestHandler: staticRequestHandler,
+    disposable: true,
+  });
+}

--- a/libs/providers/optimizely-edge/tsconfig.json
+++ b/libs/providers/optimizely-edge/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ES6",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/providers/optimizely-edge/tsconfig.lib.json
+++ b/libs/providers/optimizely-edge/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "declaration": true,
+    "moduleResolution": "bundler",
+    "types": []
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "jest.config.cts", "src/**/*.spec.ts", "src/**/*.test.ts", "src/test/**"]
+}

--- a/libs/providers/optimizely-edge/tsconfig.spec.json
+++ b/libs/providers/optimizely-edge/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "isolatedModules": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "jest.config.cts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.205.0",
         "@opentelemetry/semantic-conventions": "^1.37.0",
+        "@optimizely/optimizely-sdk": "^6.6.0",
         "@protobuf-ts/grpc-transport": "^2.9.0",
         "@protobuf-ts/runtime-rpc": "^2.9.0",
         "@swc/helpers": "0.5.21",
@@ -7552,6 +7553,72 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@optimizely/optimizely-sdk": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@optimizely/optimizely-sdk/-/optimizely-sdk-6.6.0.tgz",
+      "integrity": "sha512-efPzH5PD4lKz7KyDiNjBKWUOC0lq0GKqoEammtpyvkTz0zoiwceURjXdpEgr/mW0S530D+Ts4Q0DeE6qV5LIlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "decompress-response": "^7.0.0",
+        "json-schema": "^0.4.0",
+        "murmurhash": "^2.0.1",
+        "uuid": "^13.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": ">=1.0.0 <3.0.0",
+        "@react-native-community/netinfo": ">=5.0.0 <12.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "react-native-get-random-values": "^1.11.0",
+        "ua-parser-js": "^1.0.38"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        },
+        "@react-native-community/netinfo": {
+          "optional": true
+        },
+        "fast-text-encoding": {
+          "optional": true
+        },
+        "react-native-get-random-values": {
+          "optional": true
+        },
+        "ua-parser-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@optimizely/optimizely-sdk/node_modules/decompress-response": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-7.0.0.tgz",
+      "integrity": "sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@optimizely/optimizely-sdk/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@oxc-resolver/binding-android-arm-eabi": {
@@ -21133,7 +21200,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
@@ -22231,6 +22297,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/murmurhash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-2.0.1.tgz",
+      "integrity": "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew==",
+      "license": "MIT"
     },
     "node_modules/mute-stream": {
       "version": "2.0.0",
@@ -26011,6 +26083,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -31730,6 +31815,32 @@
       "version": "1.37.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
       "integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA=="
+    },
+    "@optimizely/optimizely-sdk": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@optimizely/optimizely-sdk/-/optimizely-sdk-6.6.0.tgz",
+      "integrity": "sha512-efPzH5PD4lKz7KyDiNjBKWUOC0lq0GKqoEammtpyvkTz0zoiwceURjXdpEgr/mW0S530D+Ts4Q0DeE6qV5LIlQ==",
+      "requires": {
+        "decompress-response": "^7.0.0",
+        "json-schema": "^0.4.0",
+        "murmurhash": "^2.0.1",
+        "uuid": "^13.0.2"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-7.0.0.tgz",
+          "integrity": "sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==",
+          "requires": {
+            "mimic-response": "^3.1.0"
+          }
+        },
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
     },
     "@oxc-resolver/binding-android-arm-eabi": {
       "version": "11.19.1",
@@ -40650,8 +40761,7 @@
     "json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "1.0.0"
@@ -41354,6 +41464,11 @@
           "dev": true
         }
       }
+    },
+    "murmurhash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-2.0.1.tgz",
+      "integrity": "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew=="
     },
     "mute-stream": {
       "version": "2.0.0",
@@ -43842,6 +43957,11 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
+    },
+    "uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.205.0",
     "@opentelemetry/semantic-conventions": "^1.37.0",
+    "@optimizely/optimizely-sdk": "^6.6.0",
     "@protobuf-ts/grpc-transport": "^2.9.0",
     "@protobuf-ts/runtime-rpc": "^2.9.0",
     "@swc/helpers": "0.5.21",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -192,6 +192,13 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "versioning": "default"
+    },
+    "libs/providers/optimizely-edge": {
+      "release-type": "node",
+      "prerelease": false,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "versioning": "default"
     }
   },
   "changelog-sections": [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -42,7 +42,8 @@
       "@openfeature/ofrep-provider": ["libs/providers/ofrep/src/index.ts"],
       "@openfeature/ofrep-web-provider": ["libs/providers/ofrep-web/src/index.ts"],
       "@openfeature/unleash-web-provider": ["libs/providers/unleash-web/src/index.ts"],
-      "@openfeature/azure-app-configuration-provider": ["libs/providers/azure-app-configuration/src/index.ts"]
+      "@openfeature/azure-app-configuration-provider": ["libs/providers/azure-app-configuration/src/index.ts"],
+      "@openfeature/optimizely-edge-provider": ["libs/providers/optimizely-edge/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## What this adds

This PR adds `@openfeature/optimizely-edge-provider` for Next.js Edge, Cloudflare Workers, and Hono applications running on Workers. It imports Optimizely's explicit Universal entry point so an Edge bundle does not resolve the Node.js or `XMLHttpRequest` implementation.

The runtime boundary drives the design:

- the application owns datafile loading, caching, and revalidation
- `withEvaluationContext` scopes identity to one synchronous evaluation instead of mutating the web SDK's static context per request
- the Fetch request handler can connect event delivery to a platform lifetime primitive such as `waitUntil`
- restricted-runtime and packed-artifact tests verify the bundle does not introduce Node.js dependencies

The package is also registered in the repository's TypeScript paths, component ownership, and release configuration.

## Validation

```text
npx nx test optimizely-edge --no-watchman  # 9 runtime tests + 2 package-output tests
npx nx lint optimizely-edge
npx nx package optimizely-edge
```

Contributors do not need an Optimizely account, credentials, environment variables, or network access to run these checks.

## How the split works

This is the Edge portion of #1618. It has no runtime dependency on the Node.js or browser providers:

- Node.js/server: #1619
- Web/React: #1620

All three PRs currently include the same root Optimizely development dependency. Once one merges, I will rebase the remaining PRs and remove that duplicate diff.

## Before this is ready

- [ ] Smoke-test the provider in representative Next.js Edge and Hono/Cloudflare Workers applications
- [ ] Add the provider to the openfeature.dev catalog
